### PR TITLE
Removed redundant `intelliSenseMode` from CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -130,22 +130,12 @@
     {
       "name": "windows-msvc-x64",
       "displayName": "MSVC, 64-bit",
-      "inherits": ["windows-base", "msvc-base", "x64-base"],
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-msvc-x64"
-        }
-      }
+      "inherits": ["windows-base", "msvc-base", "x64-base"]
     },
     {
       "name": "windows-clangcl-x64",
       "displayName": "Clang, 64-bit",
-      "inherits": ["windows-base", "clangcl-base", "x64-base"],
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-clang-x64"
-        }
-      }
+      "inherits": ["windows-base", "clangcl-base", "x64-base"]
     },
     {
       "name": "linux-clang-x64",


### PR DESCRIPTION
According to Visual Studio's [documentation](https://learn.microsoft.com/en-us/cpp/build/cmake-presets-vs#configure-intellisense-for-a-cross-compiler) on its integration with CMake Presets they infer the IntelliSense mode from the toolset (when not cross-compiling), so this currently adds nothing.