### PR TITLE
Updated godot-cpp to 4.0-beta5

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT e33f3e4b0f83612da30e9afae1808313501e4e7d
+	GIT_COMMIT b5ce301e8f860ba774bc75fb4abad15f4b6a1a0f
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES
 		<SOURCE_DIR>/godot-headers


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@e33f3e4b0f83612da30e9afae1808313501e4e7d aka `4.0-beta4` to godot-jolt/godot-cpp@b5ce301e8f860ba774bc75fb4abad15f4b6a1a0f aka `4.0-beta5` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/e33f3e4b0f83612da30e9afae1808313501e4e7d...b5ce301e8f860ba774bc75fb4abad15f4b6a1a0f)).