### PR TITLE
Added `enc_temp_folder` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 
 # Visual Studio
 /**/.vs
+/**/enc_temp_folder
 
 # CLion
 /**/.idea


### PR DESCRIPTION
Supposedly produced by Visual Studio's [AutoRecover](https://learn.microsoft.com/en-us/visualstudio/ide/reference/autorecover-environment-options-dialog-box) feature.