### PR TITLE
Fixed movement of RigidBody3D when in the editor

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -1388,6 +1388,10 @@ void JoltPhysicsServer3D::_sync() {
 }
 
 void JoltPhysicsServer3D::_flush_queries() {
+	if (!active) {
+		return;
+	}
+
 	flushing_queries = true;
 
 	for (JoltPhysicsSpace3D* space : active_spaces) {


### PR DESCRIPTION
This fixes the issue of rigid bodies acting "jerky" when moving them around in the editor, or movements not being applied at all when doing stuff like Undo or similar large movements.

I was under the impression that the physics server had to essentially run a frozen simulation and that it was responsible for moving entities in the editor through the state sync callbacks. That was not correct at all, and all that was needed to fix the janky/broken editor movement was to stop invoking the state sync callbacks when the server isn't active.

As far as I can tell the editor and the running game shares the same main loop, which might answer the follow-up question of "why is the editor even calling `_flush_queries`?".