### PR TITLE
Added support for overriding inertia

### DIFF
--- a/src/jolt_physics_area_3d.hpp
+++ b/src/jolt_physics_area_3d.hpp
@@ -29,6 +29,8 @@ public:
 
 	float get_mass() const override { return 1.0f; }
 
+	Vector3 get_inertia() const override { return {0, 0, 0}; }
+
 	bool is_sensor() const override { return true; }
 
 private:

--- a/src/jolt_physics_body_3d.cpp
+++ b/src/jolt_physics_body_3d.cpp
@@ -36,20 +36,23 @@ void JoltPhysicsBody3D::set_state(PhysicsServer3D::BodyState p_state, const Vari
 }
 
 Variant JoltPhysicsBody3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
-	// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 	switch (p_param) {
 	case PhysicsServer3D::BODY_PARAM_MASS:
 		return get_mass();
+	case PhysicsServer3D::BODY_PARAM_INERTIA:
+		return get_inertia();
 	default:
 		ERR_FAIL_V_NOT_IMPL({});
 	}
 }
 
 void JoltPhysicsBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value) {
-	// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 	switch (p_param) {
 	case PhysicsServer3D::BODY_PARAM_MASS:
 		set_mass(p_value);
+		break;
+	case PhysicsServer3D::BODY_PARAM_INERTIA:
+		set_inertia(p_value);
 		break;
 	default:
 		ERR_FAIL_NOT_IMPL();
@@ -161,4 +164,9 @@ void JoltPhysicsBody3D::set_mode(PhysicsServer3D::BodyMode p_mode) {
 void JoltPhysicsBody3D::set_mass(float p_mass) {
 	ERR_FAIL_COND_MSG(space, "Cannot change mass after body has been created.");
 	mass = p_mass;
+}
+
+void JoltPhysicsBody3D::set_inertia(const Vector3& p_inertia) {
+	ERR_FAIL_COND_MSG(space, "Cannot change inertia after body has been created.");
+	inertia = p_inertia;
 }

--- a/src/jolt_physics_body_3d.hpp
+++ b/src/jolt_physics_body_3d.hpp
@@ -60,12 +60,18 @@ public:
 
 	void set_mass(float p_mass);
 
+	Vector3 get_inertia() const override { return inertia; }
+
+	void set_inertia(const Vector3& p_inertia);
+
 	bool is_sensor() const override { return false; }
 
 private:
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
 
 	float mass = 1.0f;
+
+	Vector3 inertia;
 
 	Vector3 constant_force;
 

--- a/src/jolt_physics_collision_object_3d.hpp
+++ b/src/jolt_physics_collision_object_3d.hpp
@@ -67,6 +67,8 @@ public:
 
 	virtual float get_mass() const = 0;
 
+	virtual Vector3 get_inertia() const = 0;
+
 	virtual bool is_sensor() const = 0;
 
 protected:


### PR DESCRIPTION
This adds support for the "Inertia" property found in the Inspector panel on a `RigidBody3D`.

Like with Godot Physics it will automatically calculate inertia when either of the components are less than or equal to zero. However, unlike Godot Physics it will also automatically calculate mass if the provided mass is less than or equal to zero, instead of throwing an error.