### PR TITLE
Added warning to (unsupported) collision priority

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -619,11 +619,13 @@ void JoltPhysicsServer3D::_body_set_collision_priority(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_priority
 ) {
-	ERR_FAIL_NOT_IMPL();
+	if (p_priority != 1.0) {
+		WARN_PRINT_ONCE("Collision priorities are not supported.");
+	}
 }
 
 double JoltPhysicsServer3D::_body_get_collision_priority([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_V_NOT_IMPL({});
+	return 1.0;
 }
 
 void JoltPhysicsServer3D::_body_set_user_flags(


### PR DESCRIPTION
Collision priorities (see godotengine/godot#64343) are not supported in Jolt, as far as I can tell, so we simply emit a warning when anyone tries to use anything but the default value (`1.0`).