### PR TITLE
Refactored Jolt usage to make locking more fine-grained

### DIFF
--- a/src/body_access.cpp
+++ b/src/body_access.cpp
@@ -1,0 +1,17 @@
+#include "body_access.hpp"
+
+#include "jolt_physics_space_3d.hpp"
+
+BodyAccessRead::BodyAccessRead(
+	const JoltPhysicsSpace3D& p_space,
+	const JPH::BodyID& p_jid,
+	bool p_lock
+)
+	: lock(p_space.get_body_lock_iface(p_lock), p_jid) { }
+
+BodyAccessWrite::BodyAccessWrite(
+	const JoltPhysicsSpace3D& p_space,
+	const JPH::BodyID& p_jid,
+	bool p_lock
+)
+	: lock(p_space.get_body_lock_iface(p_lock), p_jid) { }

--- a/src/body_access.hpp
+++ b/src/body_access.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+class JoltPhysicsSpace3D;
+
+class BodyAccessRead {
+public:
+	BodyAccessRead(const JoltPhysicsSpace3D& p_space, const JPH::BodyID& p_jid, bool p_lock);
+
+	bool is_valid() const { return lock.Succeeded(); }
+
+	const JPH::Body& get_body() const { return lock.GetBody(); }
+
+private:
+	JPH::BodyLockRead lock;
+};
+
+class BodyAccessWrite {
+public:
+	BodyAccessWrite(const JoltPhysicsSpace3D& p_space, const JPH::BodyID& p_jid, bool p_lock);
+
+	bool is_valid() const { return lock.Succeeded(); }
+
+	JPH::Body& get_body() const { return lock.GetBody(); }
+
+private:
+	JPH::BodyLockWrite lock;
+};

--- a/src/jolt_physics_body_3d.hpp
+++ b/src/jolt_physics_body_3d.hpp
@@ -21,15 +21,17 @@ public:
 
 	bool is_sleeping(bool p_lock = true) const;
 
+	void set_sleep_state(bool p_enabled, bool p_lock = true);
+
 	Basis get_inverse_inertia_tensor(bool p_lock = true) const;
 
 	Vector3 get_linear_velocity(bool p_lock = true) const;
 
-	void set_linear_velocity(const Vector3& p_velocity);
+	void set_linear_velocity(const Vector3& p_velocity, bool p_lock = true);
 
 	Vector3 get_angular_velocity(bool p_lock = true) const;
 
-	void set_angular_velocity(const Vector3& p_velocity);
+	void set_angular_velocity(const Vector3& p_velocity, bool p_lock = true);
 
 	void add_constant_central_force(const Vector3& p_force) { constant_force += p_force; }
 
@@ -54,19 +56,23 @@ public:
 
 	PhysicsServer3D::BodyMode get_mode() const override { return mode; }
 
-	void set_mode(PhysicsServer3D::BodyMode p_mode);
+	void set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock = true);
 
 	float get_mass() const override { return mass; }
 
-	void set_mass(float p_mass);
+	void set_mass(float p_mass, bool p_lock = true);
 
 	Vector3 get_inertia() const override { return inertia; }
 
-	void set_inertia(const Vector3& p_inertia);
+	void set_inertia(const Vector3& p_inertia, bool p_lock = true);
 
 	bool is_sensor() const override { return false; }
 
 private:
+	void shapes_changed(bool p_lock) override;
+
+	void mass_properties_changed(bool p_lock);
+
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
 
 	float mass = 1.0f;

--- a/src/jolt_physics_collision_object_3d.hpp
+++ b/src/jolt_physics_collision_object_3d.hpp
@@ -31,23 +31,32 @@ public:
 
 	uint32_t get_collision_layer() const { return collision_layer; }
 
-	void set_collision_layer(uint32_t p_layer);
+	void set_collision_layer(uint32_t p_layer, bool p_lock = true);
 
 	uint32_t get_collision_mask() const { return collision_mask; }
 
-	void set_collision_mask(uint32_t p_mask);
+	void set_collision_mask(uint32_t p_mask, bool p_lock = true);
 
 	Transform3D get_transform(bool p_lock = true) const;
 
-	void set_transform(const Transform3D& p_transform);
+	void set_transform(const Transform3D& p_transform, bool p_lock = true);
 
-	Vector3 get_center_of_mass() const;
+	Vector3 get_center_of_mass(bool p_lock = true) const;
 
-	void add_shape(JoltPhysicsShape3D* p_shape, const Transform3D& p_transform, bool p_disabled);
+	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_root_shape) const;
 
-	void remove_shape(JoltPhysicsShape3D* p_shape);
+	JPH::MassProperties calculate_mass_properties(bool p_lock = true) const;
 
-	void remove_shape(int p_index);
+	void add_shape(
+		JoltPhysicsShape3D* p_shape,
+		const Transform3D& p_transform,
+		bool p_disabled,
+		bool p_lock = true
+	);
+
+	void remove_shape(JoltPhysicsShape3D* p_shape, bool p_lock = true);
+
+	void remove_shape(int p_index, bool p_lock = true);
 
 	const Vector<Shape>& get_shapes() const { return shapes; }
 
@@ -55,7 +64,7 @@ public:
 
 	int find_shape_index(JoltPhysicsShape3D* p_shape);
 
-	void set_shape_transform(int64_t p_index, const Transform3D& p_transform);
+	void set_shape_transform(int64_t p_index, const Transform3D& p_transform, bool p_lock = true);
 
 	bool is_ray_pickable() const { return ray_pickable; }
 
@@ -72,7 +81,9 @@ public:
 	virtual bool is_sensor() const = 0;
 
 protected:
-	JPH::MutableCompoundShape* find_root_shape() const;
+	virtual void shapes_changed([[maybe_unused]] bool p_lock) { }
+
+	JPH::MutableCompoundShape* get_root_shape() const;
 
 	RID rid;
 

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -149,7 +149,8 @@ bool JoltPhysicsDirectBodyState3D::_is_sleeping() const {
 }
 
 void JoltPhysicsDirectBodyState3D::_set_sleep_state([[maybe_unused]] bool p_enabled) {
-	ERR_FAIL_NOT_IMPL();
+	ERR_FAIL_NULL(body);
+	body->set_sleep_state(p_enabled);
 }
 
 int64_t JoltPhysicsDirectBodyState3D::_get_contact_count() const {

--- a/src/jolt_physics_space_3d.hpp
+++ b/src/jolt_physics_space_3d.hpp
@@ -24,7 +24,11 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
-	JPH::PhysicsSystem* get_system() const { return physics_system; }
+	JPH::BodyInterface& get_body_iface(bool p_locked = true);
+
+	const JPH::BodyInterface& get_body_iface(bool p_locked = true) const;
+
+	const JPH::BodyLockInterface& get_body_lock_iface(bool p_locked = true) const;
 
 	PhysicsDirectSpaceState3D* get_direct_state() const;
 


### PR DESCRIPTION
This started as a PR to address the issue of not being able to [set mass/inertia](https://github.com/godot-jolt/godot-jolt/blob/c271fd0bf80603ba5855e769706f6b2bc222ad03/src/jolt_physics_body_3d.cpp#L164-L172) after the body has been created. That ended up having a lot of knock-on effects until the PR grew to the size you see here.

Here are the chain of events/conclusions/changes:

- `JPH::BodyInterface`, which up until now I'd been using to interact with bodies, doesn't support modifying mass properties. Instead you need to do that through `JPH::Body`.
- `JPH::BodyInterface` doesn't support retrieving a `JPH::Body` from a `JPH::BodyID`, instead you do that by using `JPH::BodyLockRead`/`JPH::BodyLockWrite` and retrieving the body through the lock.
- I figured that I might as well lean on the locks as much as possible and only use `JPH::BodyInterface` when necessary, like for operations that affect the broad phase.
  - This is implemented through the new `BodyAccessRead` and `BodyAccessWrite`, which are essentially just thin wrappers on top of the above mentioned locks.
  - Most setters/getters (that can't safely rely on cached state) now take a `p_lock` parameter to indicate whether they should lock or not, to avoid double-locking.
  - Besides removing a level of indirection, this had the added benefit of letting us emit Godot errors when the locks fail, and also let us be more explicit about the default values that get returned in such cases, instead of silently failing inside Jolt and returning some unknown default value.
  - One downside is that I ended up duplicating some maybe-prone-to-changing logic from `JPH::BodyInterface`, like the activation/deactivation stuff in `JoltPhysicsBody3D::set_mode`.
- Once that refactoring was done I took on actually implementing the setting of mass/inertia.
  - This needed to replicate `JPH::BodyCreationSettings`'s ability to automatically calculate mass, inertia or both, which Jolt doesn't provide outside of `JPH::BodyCreationSettings`.
  - This can be found in `JoltPhysicsCollisionObject3D::calculate_mass_properties`.
- I took some inspiration from Godot Physics and had the mass properties update/reset when changing quantity/transforms of shapes as well.
  - This can be found in `JoltPhysicsBody3D::mass_properties_changed` and `JoltPhysicsCollisionObject3D::shapes_changed`.
- A somewhat unrelated addition that made its way into this PR were the calls to `JPH::BodyInterface::NotifyShapeChanged`, which apparently must be called after having changed the shapes of a `JPH::MutableCompoundShape`.
