### PR TITLE
Added support for physics materials

### DIFF
--- a/src/jolt_physics_area_3d.hpp
+++ b/src/jolt_physics_area_3d.hpp
@@ -31,6 +31,10 @@ public:
 
 	Vector3 get_inertia() const override { return {0, 0, 0}; }
 
+	float get_bounce() const override { return 0.0f; }
+
+	float get_friction() const override { return 1.0f; }
+
 	bool is_sensor() const override { return true; }
 
 	bool can_sleep() const override { return false; }

--- a/src/jolt_physics_body_3d.hpp
+++ b/src/jolt_physics_body_3d.hpp
@@ -70,6 +70,14 @@ public:
 
 	void set_inertia(const Vector3& p_inertia, bool p_lock = true);
 
+	float get_bounce() const override { return bounce; }
+
+	void set_bounce(float p_bounce, bool p_lock = true);
+
+	float get_friction() const override { return friction; }
+
+	void set_friction(float p_friction, bool p_lock = true);
+
 	bool is_sensor() const override { return false; }
 
 private:
@@ -82,6 +90,10 @@ private:
 	float mass = 1.0f;
 
 	Vector3 inertia;
+
+	float bounce = 0.0f;
+
+	float friction = 1.0f;
 
 	bool allowed_sleep = true;
 

--- a/src/jolt_physics_collision_object_3d.hpp
+++ b/src/jolt_physics_collision_object_3d.hpp
@@ -78,6 +78,10 @@ public:
 
 	virtual Vector3 get_inertia() const = 0;
 
+	virtual float get_bounce() const = 0;
+
+	virtual float get_friction() const = 0;
+
 	virtual bool is_sensor() const = 0;
 
 	virtual bool can_sleep() const = 0;

--- a/src/jolt_physics_space_3d.cpp
+++ b/src/jolt_physics_space_3d.cpp
@@ -246,6 +246,8 @@ void JoltPhysicsSpace3D::create_object(JoltPhysicsCollisionObject3D* p_object) {
 	settings.mAllowDynamicOrKinematic = true;
 	settings.mIsSensor = is_sensor;
 	settings.mAllowSleeping = p_object->can_sleep();
+	settings.mFriction = p_object->get_friction();
+	settings.mRestitution = p_object->get_bounce();
 	settings.mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
 	settings.mMassPropertiesOverride = p_object->calculate_mass_properties(*settings.GetShape());
 

--- a/src/utility_functions.hpp
+++ b/src/utility_functions.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+template<typename TType, typename... TRest>
+constexpr const TType& min(const TType& p_first, const TType& p_second, const TRest&... p_rest) {
+	if constexpr (sizeof...(p_rest) == 0) {
+		return p_first < p_second ? p_first : p_second;
+	} else {
+		return min(min(p_first, p_second), p_rest...);
+	}
+}
+
+template<typename TType, typename... TRest>
+constexpr const TType& max(const TType& p_first, const TType& p_second, const TRest&... p_rest) {
+	if constexpr (sizeof...(p_rest) == 0) {
+		return p_first > p_second ? p_first : p_second;
+	} else {
+		return max(max(p_first, p_second), p_rest...);
+	}
+}
+
+template<typename TType>
+constexpr const TType& clamp(const TType& p_value, const TType& p_min, const TType& p_max) {
+	return min(max(p_value, p_min), p_max);
+}


### PR DESCRIPTION
This adds support for the properties "Bounce" and "Friction" found in physics materials.

The remaining properties, "Rough" and "Absorbent", seem to be handled by Godot somehow and work as expected.