### PR TITLE
Added support for the "Gravity Scale" property of `RigidBody3D`

### DIFF
--- a/src/jolt_physics_area_3d.hpp
+++ b/src/jolt_physics_area_3d.hpp
@@ -35,6 +35,8 @@ public:
 
 	float get_friction() const override { return 1.0f; }
 
+	float get_gravity_scale() const override { return 1.0f; }
+
 	bool is_sensor() const override { return true; }
 
 	bool can_sleep() const override { return false; }

--- a/src/jolt_physics_body_3d.cpp
+++ b/src/jolt_physics_body_3d.cpp
@@ -63,8 +63,10 @@ Variant JoltPhysicsBody3D::get_param(PhysicsServer3D::BodyParameter p_param) con
 		return get_mass();
 	case PhysicsServer3D::BODY_PARAM_INERTIA:
 		return get_inertia();
+	case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE:
+		return get_gravity_scale();
 	default:
-		ERR_FAIL_D_NOT_IMPL();
+		ERR_FAIL_D_MSG(vformat("Unhandled body parameter: '{}'", p_param));
 	}
 }
 
@@ -82,8 +84,11 @@ void JoltPhysicsBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const 
 	case PhysicsServer3D::BODY_PARAM_INERTIA:
 		set_inertia(p_value);
 		break;
+	case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE:
+		set_gravity_scale(p_value);
+		break;
 	default:
-		ERR_FAIL_NOT_IMPL();
+		ERR_FAIL_MSG(vformat("Unhandled body parameter: '{}'", p_param));
 	}
 }
 
@@ -298,6 +303,23 @@ void JoltPhysicsBody3D::set_friction(float p_friction, bool p_lock) {
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().SetFriction(friction);
+}
+
+void JoltPhysicsBody3D::set_gravity_scale(float p_scale, bool p_lock) {
+	if (p_scale == gravity_scale) {
+		return;
+	}
+
+	gravity_scale = p_scale;
+
+	if (!space) {
+		return;
+	}
+
+	const BodyAccessWrite body_access(*space, jid, p_lock);
+	ERR_FAIL_COND(!body_access.is_valid());
+
+	body_access.get_body().GetMotionPropertiesUnchecked()->SetGravityFactor(p_scale);
 }
 
 void JoltPhysicsBody3D::shapes_changed(bool p_lock) {

--- a/src/jolt_physics_body_3d.hpp
+++ b/src/jolt_physics_body_3d.hpp
@@ -78,6 +78,10 @@ public:
 
 	void set_friction(float p_friction, bool p_lock = true);
 
+	float get_gravity_scale() const override { return gravity_scale; }
+
+	void set_gravity_scale(float p_scale, bool p_lock = true);
+
 	bool is_sensor() const override { return false; }
 
 private:
@@ -94,6 +98,8 @@ private:
 	float bounce = 0.0f;
 
 	float friction = 1.0f;
+
+	float gravity_scale = 1.0f;
 
 	bool allowed_sleep = true;
 

--- a/src/jolt_physics_collision_object_3d.hpp
+++ b/src/jolt_physics_collision_object_3d.hpp
@@ -82,6 +82,8 @@ public:
 
 	virtual float get_friction() const = 0;
 
+	virtual float get_gravity_scale() const = 0;
+
 	virtual bool is_sensor() const = 0;
 
 	virtual bool can_sleep() const = 0;

--- a/src/jolt_physics_space_3d.cpp
+++ b/src/jolt_physics_space_3d.cpp
@@ -247,6 +247,7 @@ void JoltPhysicsSpace3D::create_object(JoltPhysicsCollisionObject3D* p_object) {
 	settings.mAllowSleeping = p_object->can_sleep();
 	settings.mFriction = p_object->get_friction();
 	settings.mRestitution = p_object->get_bounce();
+	settings.mGravityFactor = p_object->get_gravity_scale();
 	settings.mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
 	settings.mMassPropertiesOverride = p_object->calculate_mass_properties(*settings.GetShape());
 


### PR DESCRIPTION
Also snuck in a better error message for unhandled body parameters in `JoltPhysicsBody3D`'s `get_param`/`set_param`.