### PR TITLE
Fixed error when modifying some properties of `RigidBody3D`

### DIFF
--- a/src/jolt_physics_area_3d.hpp
+++ b/src/jolt_physics_area_3d.hpp
@@ -27,6 +27,8 @@ public:
 
 	Vector3 get_initial_angular_velocity() const override { return {0, 0, 0}; }
 
+	bool get_initial_sleep_state() const override { return false; }
+
 	PhysicsServer3D::BodyMode get_mode() const override {
 		return PhysicsServer3D::BODY_MODE_KINEMATIC;
 	}

--- a/src/jolt_physics_body_3d.cpp
+++ b/src/jolt_physics_body_3d.cpp
@@ -23,7 +23,7 @@ Variant JoltPhysicsBody3D::get_state(PhysicsServer3D::BodyState p_state) {
 	case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY:
 		return get_angular_velocity();
 	case PhysicsServer3D::BODY_STATE_SLEEPING:
-		return is_sleeping();
+		return get_sleep_state();
 	case PhysicsServer3D::BODY_STATE_CAN_SLEEP:
 		return can_sleep();
 	default:
@@ -116,7 +116,7 @@ void JoltPhysicsBody3D::set_state_sync_callback(const Callable& p_callback) {
 	body_state_callback = p_callback;
 }
 
-bool JoltPhysicsBody3D::is_sleeping(bool p_lock) const {
+bool JoltPhysicsBody3D::get_sleep_state(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	const BodyAccessRead body_access(*space, jid, p_lock);
@@ -126,7 +126,10 @@ bool JoltPhysicsBody3D::is_sleeping(bool p_lock) const {
 }
 
 void JoltPhysicsBody3D::set_sleep_state(bool p_enabled, bool p_lock) {
-	ERR_FAIL_NULL(space);
+	if (!space) {
+		initial_sleep_state = p_enabled;
+		return;
+	}
 
 	if (p_enabled) {
 		space->get_body_iface(p_lock).DeactivateBody(jid);
@@ -250,13 +253,13 @@ void JoltPhysicsBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) 
 	const BodyAccessWrite body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
-	if (!is_sleeping(false) && motion_type == JPH::EMotionType::Static) {
+	if (!get_sleep_state(false) && motion_type == JPH::EMotionType::Static) {
 		set_sleep_state(true, false);
 	}
 
 	body_access.get_body().SetMotionType(motion_type);
 
-	if (is_sleeping(false) && motion_type != JPH::EMotionType::Static) {
+	if (get_sleep_state(false) && motion_type != JPH::EMotionType::Static) {
 		set_sleep_state(false, false);
 	}
 

--- a/src/jolt_physics_body_3d.hpp
+++ b/src/jolt_physics_body_3d.hpp
@@ -19,7 +19,9 @@ public:
 
 	void set_state_sync_callback(const Callable& p_callback);
 
-	bool is_sleeping(bool p_lock = true) const;
+	bool get_initial_sleep_state() const override { return initial_sleep_state; }
+
+	bool get_sleep_state(bool p_lock = true) const;
 
 	void set_sleep_state(bool p_enabled, bool p_lock = true);
 
@@ -116,6 +118,8 @@ private:
 	float linear_damp = 0.0f;
 
 	float angular_damp = 0.0f;
+
+	bool initial_sleep_state = false;
 
 	bool allowed_sleep = true;
 

--- a/src/jolt_physics_collision_object_3d.cpp
+++ b/src/jolt_physics_collision_object_3d.cpp
@@ -83,7 +83,7 @@ void JoltPhysicsCollisionObject3D::set_transform(const Transform3D& p_transform,
 		jid,
 		to_jolt(p_transform.get_origin()),
 		to_jolt(p_transform.get_basis()),
-		JPH::EActivation::Activate
+		JPH::EActivation::DontActivate
 	);
 }
 
@@ -159,7 +159,7 @@ void JoltPhysicsCollisionObject3D::add_shape(
 		->AddShape(to_jolt(p_transform.origin), to_jolt(p_transform.basis), p_shape->get_jref());
 
 	space->get_body_iface(false)
-		.NotifyShapeChanged(jid, previous_com, false, JPH::EActivation::Activate);
+		.NotifyShapeChanged(jid, previous_com, false, JPH::EActivation::DontActivate);
 
 	shapes_changed(false);
 }
@@ -196,7 +196,7 @@ void JoltPhysicsCollisionObject3D::remove_shape(int p_index, bool p_lock) {
 	root_shape->RemoveShape((JPH::uint)p_index);
 
 	space->get_body_iface(false)
-		.NotifyShapeChanged(jid, previous_com, false, JPH::EActivation::Activate);
+		.NotifyShapeChanged(jid, previous_com, false, JPH::EActivation::DontActivate);
 
 	shapes_changed(false);
 }
@@ -237,7 +237,7 @@ void JoltPhysicsCollisionObject3D::set_shape_transform(
 		->ModifyShape((JPH::uint)p_index, to_jolt(p_transform.origin), to_jolt(p_transform.basis));
 
 	space->get_body_iface(false)
-		.NotifyShapeChanged(jid, previous_com, false, JPH::EActivation::Activate);
+		.NotifyShapeChanged(jid, previous_com, false, JPH::EActivation::DontActivate);
 
 	shapes_changed(false);
 }

--- a/src/jolt_physics_collision_object_3d.hpp
+++ b/src/jolt_physics_collision_object_3d.hpp
@@ -78,6 +78,8 @@ public:
 
 	virtual Vector3 get_initial_angular_velocity() const = 0;
 
+	virtual bool get_initial_sleep_state() const = 0;
+
 	virtual PhysicsServer3D::BodyMode get_mode() const = 0;
 
 	virtual float get_mass() const = 0;

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -145,7 +145,7 @@ void JoltPhysicsDirectBodyState3D::_set_constant_torque([[maybe_unused]] const V
 
 bool JoltPhysicsDirectBodyState3D::_is_sleeping() const {
 	ERR_FAIL_NULL_D(body);
-	return body->is_sleeping(false);
+	return body->get_sleep_state(false);
 }
 
 void JoltPhysicsDirectBodyState3D::_set_sleep_state(bool p_enabled) {

--- a/src/jolt_physics_space_3d.cpp
+++ b/src/jolt_physics_space_3d.cpp
@@ -269,7 +269,11 @@ void JoltPhysicsSpace3D::create_object(JoltPhysicsCollisionObject3D* p_object) {
 }
 
 void JoltPhysicsSpace3D::add_object(JoltPhysicsCollisionObject3D* p_object) {
-	physics_system->GetBodyInterface().AddBody(p_object->get_jid(), JPH::EActivation::Activate);
+	physics_system->GetBodyInterface().AddBody(
+		p_object->get_jid(),
+		p_object->get_initial_sleep_state() ? JPH::EActivation::DontActivate
+											: JPH::EActivation::Activate
+	);
 }
 
 void JoltPhysicsSpace3D::remove_object(JoltPhysicsCollisionObject3D* p_object) {


### PR DESCRIPTION
This fixes the `Parameter "space" is null` error that you would sometimes get if you had changed the "Linear Velocity", "Angular Velocity" or "Sleeping" property, on a `RigidBody3D`, to anything but their default values.

With this change we now make an explicit distinction between the initial values and the actual values of properties that are modified by Jolt during simulation, such as velocities, transforms or sleep state. Initial values should only to be get/set **before** space insertion. Actual values should only be get/set **after** space insertion. If you try to access the actual values before space insertion then you'll be met with an error.

I find that this helps when trying to reason about the intermediate state that collision objects are in after they've been created but not yet inserted into a space.

We'll have to wait and see if it holds up over time.