### PR TITLE
Indented and added braces to switch cases

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,7 +37,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 IndentAccessModifiers: false
 IndentCaseBlocks: false
-IndentCaseLabels: false
+IndentCaseLabels: true
 IndentExternBlock: NoIndent
 IndentGotoLabels: false
 IndentPPDirectives: None

--- a/src/jolt_physics_area_3d.cpp
+++ b/src/jolt_physics_area_3d.cpp
@@ -4,35 +4,41 @@
 
 Variant JoltPhysicsArea3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
 	switch (p_param) {
-	case PhysicsServer3D::AREA_PARAM_GRAVITY:
-		return gravity;
-	case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR:
-		return gravity_vector;
-	case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP:
-		return linear_damp;
-	case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP:
-		return angular_damp;
-	default:
-		ERR_FAIL_D_NOT_IMPL();
+		case PhysicsServer3D::AREA_PARAM_GRAVITY: {
+			return gravity;
+		}
+		case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR: {
+			return gravity_vector;
+		}
+		case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP: {
+			return linear_damp;
+		}
+		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP: {
+			return angular_damp;
+		}
+		default: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
 	}
 }
 
 void JoltPhysicsArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
 	switch (p_param) {
-	case PhysicsServer3D::AREA_PARAM_GRAVITY:
-		gravity = p_value;
-		break;
-	case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR:
-		gravity_vector = p_value;
-		break;
-	case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP:
-		linear_damp = p_value;
-		break;
-	case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP:
-		angular_damp = p_value;
-		break;
-	default:
-		ERR_FAIL_NOT_IMPL();
+		case PhysicsServer3D::AREA_PARAM_GRAVITY: {
+			gravity = p_value;
+		} break;
+		case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR: {
+			gravity_vector = p_value;
+		} break;
+		case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP: {
+			linear_damp = p_value;
+		} break;
+		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP: {
+			angular_damp = p_value;
+		} break;
+		default: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
 	}
 }
 

--- a/src/jolt_physics_body_3d.cpp
+++ b/src/jolt_physics_body_3d.cpp
@@ -16,99 +16,117 @@ JoltPhysicsBody3D::~JoltPhysicsBody3D() {
 
 Variant JoltPhysicsBody3D::get_state(PhysicsServer3D::BodyState p_state) {
 	switch (p_state) {
-	case PhysicsServer3D::BODY_STATE_TRANSFORM:
-		return get_transform();
-	case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY:
-		return get_linear_velocity();
-	case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY:
-		return get_angular_velocity();
-	case PhysicsServer3D::BODY_STATE_SLEEPING:
-		return get_sleep_state();
-	case PhysicsServer3D::BODY_STATE_CAN_SLEEP:
-		return can_sleep();
-	default:
-		ERR_FAIL_D_MSG(vformat("Unhandled body state: '{}'", p_state));
+		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
+			return get_transform();
+		}
+		case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY: {
+			return get_linear_velocity();
+		}
+		case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY: {
+			return get_angular_velocity();
+		}
+		case PhysicsServer3D::BODY_STATE_SLEEPING: {
+			return get_sleep_state();
+		}
+		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
+			return can_sleep();
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled body state: '{}'", p_state));
+		}
 	}
 }
 
 void JoltPhysicsBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value) {
 	switch (p_state) {
-	case PhysicsServer3D::BODY_STATE_TRANSFORM:
-		set_transform(p_value);
-		break;
-	case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY:
-		set_linear_velocity(p_value);
-		break;
-	case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY:
-		set_angular_velocity(p_value);
-		break;
-	case PhysicsServer3D::BODY_STATE_SLEEPING:
-		set_sleep_state(p_value);
-		break;
-	case PhysicsServer3D::BODY_STATE_CAN_SLEEP:
-		set_can_sleep(p_value);
-		break;
-	default:
-		ERR_FAIL_MSG(vformat("Unhandled body state: '{}'", p_state));
+		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
+			set_transform(p_value);
+		} break;
+		case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY: {
+			set_linear_velocity(p_value);
+		} break;
+		case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY: {
+			set_angular_velocity(p_value);
+		} break;
+		case PhysicsServer3D::BODY_STATE_SLEEPING: {
+			set_sleep_state(p_value);
+		} break;
+		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
+			set_can_sleep(p_value);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled body state: '{}'", p_state));
+		} break;
 	}
 }
 
 Variant JoltPhysicsBody3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
 	switch (p_param) {
-	case PhysicsServer3D::BODY_PARAM_BOUNCE:
-		return get_bounce();
-	case PhysicsServer3D::BODY_PARAM_FRICTION:
-		return get_friction();
-	case PhysicsServer3D::BODY_PARAM_MASS:
-		return get_mass();
-	case PhysicsServer3D::BODY_PARAM_INERTIA:
-		return get_inertia();
-	case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE:
-		return get_gravity_scale();
-	case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE:
-		ERR_FAIL_D_NOT_IMPL();
-	case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE:
-		ERR_FAIL_D_NOT_IMPL();
-	case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP:
-		return get_linear_damp();
-	case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP:
-		return get_angular_damp();
-	default:
-		ERR_FAIL_D_MSG(vformat("Unhandled body parameter: '{}'", p_param));
+		case PhysicsServer3D::BODY_PARAM_BOUNCE: {
+			return get_bounce();
+		}
+		case PhysicsServer3D::BODY_PARAM_FRICTION: {
+			return get_friction();
+		}
+		case PhysicsServer3D::BODY_PARAM_MASS: {
+			return get_mass();
+		}
+		case PhysicsServer3D::BODY_PARAM_INERTIA: {
+			return get_inertia();
+		}
+		case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE: {
+			return get_gravity_scale();
+		}
+		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
+		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
+		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP: {
+			return get_linear_damp();
+		}
+		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP: {
+			return get_angular_damp();
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled body parameter: '{}'", p_param));
+		}
 	}
 }
 
 void JoltPhysicsBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value) {
 	switch (p_param) {
-	case PhysicsServer3D::BODY_PARAM_BOUNCE:
-		set_bounce(p_value);
-		break;
-	case PhysicsServer3D::BODY_PARAM_FRICTION:
-		set_friction(p_value);
-		break;
-	case PhysicsServer3D::BODY_PARAM_MASS:
-		set_mass(p_value);
-		break;
-	case PhysicsServer3D::BODY_PARAM_INERTIA:
-		set_inertia(p_value);
-		break;
-	case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE:
-		set_gravity_scale(p_value);
-		break;
-	case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE:
-		ERR_FAIL_NOT_IMPL();
-		break;
-	case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE:
-		ERR_FAIL_NOT_IMPL();
-		break;
-	case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP:
-		set_linear_damp(p_value);
-		break;
-	case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP:
-		set_angular_damp(p_value);
-		break;
-	default:
-		ERR_FAIL_MSG(vformat("Unhandled body parameter: '{}'", p_param));
+		case PhysicsServer3D::BODY_PARAM_BOUNCE: {
+			set_bounce(p_value);
+		} break;
+		case PhysicsServer3D::BODY_PARAM_FRICTION: {
+			set_friction(p_value);
+		} break;
+		case PhysicsServer3D::BODY_PARAM_MASS: {
+			set_mass(p_value);
+		} break;
+		case PhysicsServer3D::BODY_PARAM_INERTIA: {
+			set_inertia(p_value);
+		} break;
+		case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE: {
+			set_gravity_scale(p_value);
+		} break;
+		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
+		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
+		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP: {
+			set_linear_damp(p_value);
+		} break;
+		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP: {
+			set_angular_damp(p_value);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled body parameter: '{}'", p_param));
+		} break;
 	}
 }
 
@@ -236,18 +254,19 @@ void JoltPhysicsBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) 
 	JPH::EMotionType motion_type = {};
 
 	switch (p_mode) {
-	case PhysicsServer3D::BODY_MODE_STATIC:
-		motion_type = JPH::EMotionType::Static;
-		break;
-	case PhysicsServer3D::BODY_MODE_KINEMATIC:
-		motion_type = JPH::EMotionType::Kinematic;
-		break;
-	case PhysicsServer3D::BODY_MODE_RIGID:
-	case PhysicsServer3D::BODY_MODE_RIGID_LINEAR:
-		motion_type = JPH::EMotionType::Dynamic;
-		break;
-	default:
-		ERR_FAIL_MSG(vformat("Unhandled body mode: '{}'", p_mode));
+		case PhysicsServer3D::BODY_MODE_STATIC: {
+			motion_type = JPH::EMotionType::Static;
+		} break;
+		case PhysicsServer3D::BODY_MODE_KINEMATIC: {
+			motion_type = JPH::EMotionType::Kinematic;
+		} break;
+		case PhysicsServer3D::BODY_MODE_RIGID:
+		case PhysicsServer3D::BODY_MODE_RIGID_LINEAR: {
+			motion_type = JPH::EMotionType::Dynamic;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled body mode: '{}'", p_mode));
+		} break;
 	}
 
 	const BodyAccessWrite body_access(*space, jid, p_lock);

--- a/src/jolt_physics_space_3d.cpp
+++ b/src/jolt_physics_space_3d.cpp
@@ -26,23 +26,29 @@ constexpr uint32_t GDJOLT_MAX_CONTACT_CONSTRAINTS = 65536;
 
 bool jolt_can_collide_object(JPH::ObjectLayer p_object1, JPH::ObjectLayer p_object2) {
 	switch (p_object1) {
-	case GDJOLT_OBJECT_LAYER_STATIC:
-		return p_object2 == GDJOLT_OBJECT_LAYER_MOVING;
-	case GDJOLT_OBJECT_LAYER_MOVING:
-		return true;
-	default:
-		ERR_FAIL_D_NOT_IMPL();
+		case GDJOLT_OBJECT_LAYER_STATIC: {
+			return p_object2 == GDJOLT_OBJECT_LAYER_MOVING;
+		}
+		case GDJOLT_OBJECT_LAYER_MOVING: {
+			return true;
+		}
+		default: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
 	}
 }
 
 bool jolt_can_collide_broad_phase(JPH::ObjectLayer p_layer1, JPH::BroadPhaseLayer p_layer2) {
 	switch (p_layer1) {
-	case GDJOLT_OBJECT_LAYER_STATIC:
-		return p_layer2 == JPH::BroadPhaseLayer(GDJOLT_BROAD_PHASE_LAYER_MOVING);
-	case GDJOLT_OBJECT_LAYER_MOVING:
-		return true;
-	default:
-		ERR_FAIL_D_NOT_IMPL();
+		case GDJOLT_OBJECT_LAYER_STATIC: {
+			return p_layer2 == JPH::BroadPhaseLayer(GDJOLT_BROAD_PHASE_LAYER_MOVING);
+		}
+		case GDJOLT_OBJECT_LAYER_MOVING: {
+			return true;
+		}
+		default: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
 	}
 }
 
@@ -64,12 +70,15 @@ public:
 #if defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
 	const char* GetBroadPhaseLayerName(JPH::BroadPhaseLayer p_layer) const override {
 		switch ((JPH::BroadPhaseLayer::Type)p_layer) {
-		case GDJOLT_BROAD_PHASE_LAYER_STATIC:
-			return "STATIC";
-		case GDJOLT_BROAD_PHASE_LAYER_MOVING:
-			return "MOVING";
-		default:
-			return "INVALID";
+			case GDJOLT_BROAD_PHASE_LAYER_STATIC: {
+				return "STATIC";
+			}
+			case GDJOLT_BROAD_PHASE_LAYER_MOVING: {
+				return "MOVING";
+			}
+			default: {
+				return "INVALID";
+			}
 		}
 	}
 #endif // JPH_EXTERNAL_PROFILE || JPH_PROFILE_ENABLED
@@ -171,27 +180,31 @@ PhysicsDirectSpaceState3D* JoltPhysicsSpace3D::get_direct_state() const {
 
 Variant JoltPhysicsSpace3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
 	switch (p_param) {
-	case PhysicsServer3D::AREA_PARAM_GRAVITY:
-		return gravity;
-	case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR:
-		return gravity_vector;
-	default:
-		ERR_FAIL_D_NOT_IMPL();
+		case PhysicsServer3D::AREA_PARAM_GRAVITY: {
+			return gravity;
+		}
+		case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR: {
+			return gravity_vector;
+		}
+		default: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
 	}
 }
 
 void JoltPhysicsSpace3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
 	switch (p_param) {
-	case PhysicsServer3D::AREA_PARAM_GRAVITY:
-		gravity = p_value;
-		update_gravity();
-		break;
-	case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR:
-		gravity_vector = p_value;
-		update_gravity();
-		break;
-	default:
-		ERR_FAIL_NOT_IMPL();
+		case PhysicsServer3D::AREA_PARAM_GRAVITY: {
+			gravity = p_value;
+			update_gravity();
+		} break;
+		case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR: {
+			gravity_vector = p_value;
+			update_gravity();
+		} break;
+		default: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
 	}
 }
 
@@ -214,21 +227,22 @@ void JoltPhysicsSpace3D::create_object(JoltPhysicsCollisionObject3D* p_object) {
 	JPH::ObjectLayer object_layer = {};
 
 	switch (p_object->get_mode()) {
-	case PhysicsServer3D::BODY_MODE_STATIC:
-		motion_type = JPH::EMotionType::Static;
-		object_layer = GDJOLT_OBJECT_LAYER_STATIC;
-		break;
-	case PhysicsServer3D::BODY_MODE_KINEMATIC:
-		motion_type = JPH::EMotionType::Kinematic;
-		object_layer = GDJOLT_OBJECT_LAYER_MOVING;
-		break;
-	case PhysicsServer3D::BODY_MODE_RIGID:
-	case PhysicsServer3D::BODY_MODE_RIGID_LINEAR:
-		motion_type = JPH::EMotionType::Dynamic;
-		object_layer = GDJOLT_OBJECT_LAYER_MOVING;
-		break;
-	default:
-		ERR_FAIL_MSG("Unhandled body mode");
+		case PhysicsServer3D::BODY_MODE_STATIC: {
+			motion_type = JPH::EMotionType::Static;
+			object_layer = GDJOLT_OBJECT_LAYER_STATIC;
+		} break;
+		case PhysicsServer3D::BODY_MODE_KINEMATIC: {
+			motion_type = JPH::EMotionType::Kinematic;
+			object_layer = GDJOLT_OBJECT_LAYER_MOVING;
+		} break;
+		case PhysicsServer3D::BODY_MODE_RIGID:
+		case PhysicsServer3D::BODY_MODE_RIGID_LINEAR: {
+			motion_type = JPH::EMotionType::Dynamic;
+			object_layer = GDJOLT_OBJECT_LAYER_MOVING;
+		} break;
+		default: {
+			ERR_FAIL_MSG("Unhandled body mode");
+		} break;
 	}
 
 	const Transform3D& transform = p_object->get_initial_transform();


### PR DESCRIPTION
It's only a matter of time before I need to declare variables inside a switch case, so I figured it's better to be consistent and use braces everywhere.

I ended up indenting them all as well, since it looked weird to have the last closing case brace on the same level as the closing switch brace.