### PR TITLE
Fixed incorrect library initialization level

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -4,7 +4,7 @@
 
 namespace {
 
-constexpr ModuleInitializationLevel GDJOLT_INIT_LEVEL = MODULE_INITIALIZATION_LEVEL_SCENE;
+constexpr ModuleInitializationLevel GDJOLT_INIT_LEVEL = MODULE_INITIALIZATION_LEVEL_SERVERS;
 
 JoltPhysicsServerFactory3D* server_factory = nullptr;
 


### PR DESCRIPTION
The initialization level was apparently set to `MODULE_INITIALIZATION_LEVEL_SCENE` at some point, when it was meant to be `MODULE_INITIALIZATION_LEVEL_SERVERS`, which turned out to be the cause for some very strange crashes at shutdown when running the editor in `dev_build` mode.