### PR TITLE
Fixed broken `CFLAGS` variable passed to mimalloc

### DIFF
--- a/cmake/GodotJoltExternalMimalloc.cmake
+++ b/cmake/GodotJoltExternalMimalloc.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if(DEFINED ENV{CFLAGS})
-	set(c_flags $ENV{CFLAGS} ${c_flags})
+	set(c_flags "$ENV{CFLAGS} ${c_flags}")
 endif()
 
 GodotJoltExternalLibrary_Add(mimalloc "${configurations}"


### PR DESCRIPTION
Originated from #33.