### PR TITLE
Replaced CI environment setup with custom actions

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -1,0 +1,16 @@
+name: Setup Linux
+
+inputs:
+  toolchain:
+    required: true
+  version:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      run: >
+        sudo ./scripts/ci_setup_linux.ps1
+        -Toolchain ${{ inputs.toolchain }}
+        -Version ${{ inputs.version }}

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -1,0 +1,13 @@
+name: Setup macOS
+
+inputs:
+  version:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      run: >
+        sudo ./scripts/ci_setup_macos.ps1
+        -Version ${{ inputs.version }}

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -1,0 +1,16 @@
+name: Setup Windows
+
+inputs:
+  version:
+    required: true
+  arch:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      run: >
+        ./scripts/ci_setup_windows.ps1
+        -Version ${{ inputs.version }}
+        -Arch ${{ inputs.arch }}

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up LLVM
-        uses: aminya/setup-cpp@v1
+        uses: ./.github/actions/setup-linux
         with:
-          compiler: llvm-14.0.0
-          architecture: x64
+          toolchain: llvm
+          version: 14
 
       - name: Identify clang-format
         shell: pwsh
@@ -33,10 +33,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up LLVM
-        uses: aminya/setup-cpp@v1
+        uses: ./.github/actions/setup-linux
         with:
-          compiler: llvm-14.0.0
-          architecture: x64
+          toolchain: llvm
+          version: 14
 
       - name: Build 'Debug' configuration
         uses: ./.github/actions/build-with-cmake

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,19 +20,21 @@ jobs:
 
         include:
           - platform: linux-clang
-            compiler: llvm-14.0.0
+            toolchain: llvm
+            version: 14
           - platform: linux-gcc
-            compiler: gcc-11
+            toolchain: gcc
+            version: 11
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up C++ environment
-        uses: aminya/setup-cpp@v1
+      - name: Set up environment
+        uses: ./.github/actions/setup-linux
         with:
-          compiler: ${{ matrix.compiler }}
-          architecture: ${{ matrix.arch }}
+          toolchain: ${{ matrix.toolchain }}
+          version: ${{ matrix.version }}
 
       - name: Configure and build
         uses: ./.github/actions/build-with-cmake

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,15 +15,16 @@ jobs:
         platform: [macos-clang]
         editor: [false, true]
         config: [debug, development, distribution]
-        xcode: [14.1]
+        version: [14.1]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up C++ environment
-        shell: pwsh
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Set up environment
+        uses: ./.github/actions/setup-macos
+        with:
+          version: ${{ matrix.version }}
 
       - name: Configure and build
         uses: ./.github/actions/build-with-cmake

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,16 +17,17 @@ jobs:
         arch: [x64]
         editor: [false, true]
         config: [debug, development, distribution]
+        version: [17]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up C++ environment
-        uses: aminya/setup-cpp@v1
+      - name: Set up environment
+        uses: ./.github/actions/setup-windows
         with:
-          compiler: vs-2022
-          architecture: ${{ matrix.arch }}
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
 
       - name: Configure and build
         uses: ./.github/actions/build-with-cmake

--- a/scripts/ci_setup_linux.ps1
+++ b/scripts/ci_setup_linux.ps1
@@ -1,0 +1,57 @@
+#!/usr/bin/env pwsh
+
+param (
+	[Parameter(Mandatory = $true, HelpMessage = "Toolchain to use")]
+	[ValidateSet("gcc", "llvm")]
+	[string]
+	$Toolchain,
+
+	[Parameter(Mandatory = $true, HelpMessage = "Major version of the toolchain")]
+	[ValidatePattern("^\d+$")]
+	[string]
+	$Version
+)
+
+. $PSScriptRoot/_common.ps1
+
+function Set-DefaultCommand($Name, $Path) {
+	Write-Output "Displaying alternatives to '$Name' pre install..."
+
+	update-alternatives --display $Name
+
+	Write-Output "Installing alternatives to '$Name'..."
+
+	update-alternatives --install /usr/bin/$Name $Name $Path 100
+	update-alternatives --set $Name $Path
+
+	Write-Output "Displaying alternatives to '$Name' post install..."
+
+	update-alternatives --display $Name
+}
+
+Write-Output "Adding the ubuntu-toolchain-r repository..."
+
+add-apt-repository --yes --update ppa:ubuntu-toolchain-r/ppa
+
+if ($Toolchain -eq "gcc") {
+	Write-Output "Installing g++-$Version-multilib..."
+
+	apt install --quiet --yes g++-$Version-multilib
+
+	Write-Output "Setting GCC $Version as the default C/C++ toolchain..."
+
+	Set-DefaultCommand -Name gcc -Path /usr/bin/gcc-$Version
+	Set-DefaultCommand -Name g++ -Path /usr/bin/g++-$Version
+}
+elseif ($Toolchain -eq "llvm") {
+	Write-Output "Installing g++-multilib..."
+
+	apt install --quiet --yes g++-multilib
+
+	Write-Output "Setting LLVM $Version as the default C/C++ toolchain..."
+
+	Set-DefaultCommand -Name clang -Path /usr/bin/clang-$Version
+	Set-DefaultCommand -Name clang++ -Path /usr/bin/clang++-$Version
+	Set-DefaultCommand -Name clang-format -Path /usr/bin/clang-format-$Version
+	Set-DefaultCommand -Name clang-tidy -Path /usr/bin/clang-tidy-$Version
+}

--- a/scripts/ci_setup_macos.ps1
+++ b/scripts/ci_setup_macos.ps1
@@ -1,0 +1,14 @@
+#!/usr/bin/env pwsh
+
+param (
+	[Parameter(Mandatory = $true, HelpMessage = "Version of Xcode")]
+	[ValidatePattern("^\d+\.\d+$")]
+	[string]
+	$Version
+)
+
+. $PSScriptRoot/_common.ps1
+
+Write-Output "Setting Xcode $Version as the default..."
+
+xcode-select --switch /Applications/Xcode_$Version.app

--- a/scripts/ci_setup_windows.ps1
+++ b/scripts/ci_setup_windows.ps1
@@ -1,0 +1,91 @@
+#!/usr/bin/env pwsh
+
+param (
+	[Parameter(Mandatory = $true, HelpMessage = "Version of Visual Studio")]
+	[ValidatePattern("^\d+(\.\d+)?$")]
+	[string]
+	$Version,
+
+	[Parameter(Mandatory = $true, HelpMessage = "Target architecture")]
+	[ValidateSet("x64", "x86")]
+	[string]
+	$Arch
+)
+
+. $PSScriptRoot/_common.ps1
+
+filter ConvertTo-Hashtable {
+	begin { $Result = @{} }
+	process { $Result[$_.Key] = $_.Value }
+	end { return $Result }
+}
+
+$VsArch = ($Arch -eq "x64") ? "amd64" : "x86";
+
+Write-Output "Querying for Visual Studio $Version..."
+
+$VsInstalls = @(vswhere -version $Version -sort -format json | ConvertFrom-Json)
+
+if ($VsInstalls.Count -eq 0) {
+	throw "Failed to find Visual Studio $Version"
+}
+
+$VsInstall = $VsInstalls[0]
+
+Write-Output "Found Visual Studio $Version, displaying properties..."
+Write-Output $($VsInstall | Format-List)
+Write-Output "Looking for developer shell..."
+
+$VsRoot = $VsInstall.installationPath
+$VsDevShellPaths = @(Get-ChildItem -Recurse -Path $VsRoot -Filter "Launch-VsDevShell.ps1")
+
+if ($VsDevShellPaths.Count -eq 0) {
+	throw "Failed to find developer shell"
+}
+
+$VsDevShellPath = $VsDevShellPaths[0]
+
+Write-Output "Found developer shell at: $VsDevShellPath"
+
+Write-Output "Looking for clang-cl in PATH..."
+
+$ClangClPath = Get-Command -ErrorAction SilentlyContinue clang-cl
+
+if ($?) {
+	$ClangClDir = $ClangClPath | Split-Path -Parent | Resolve-Path
+
+	Write-Output "Found clang-cl at: $ClangClDir"
+	Write-Output "Removing clang-cl from PATH..."
+
+	$AllPaths = $env:PATH -split ";"
+	$RealPaths = $AllPaths | Where-Object { Test-Path $_ }
+	$NormalizedPaths = $RealPaths | ForEach-Object { Resolve-Path $_ }
+	$FilteredPaths = $NormalizedPaths | Where-Object { $_.Path -ne $ClangClDir }
+	$env:PATH = $FilteredPaths -join ";"
+}
+else {
+	Write-Output "No clang-cl found in PATH, which is good"
+}
+
+Write-Output "Caching environment variables..."
+
+$EnvOld = Get-ChildItem env: | ConvertTo-Hashtable
+
+Write-Output "Launching $VsArch developer shell..."
+
+. $VsDevShellPath -HostArch $VsArch -Arch $VsArch -SkipAutomaticLocation
+
+Write-Output "Caching environment variables..."
+
+$EnvNew = Get-ChildItem env: | ConvertTo-Hashtable
+
+Write-Output "Exporting changed environment variables..."
+
+foreach ($Item in $EnvNew.GetEnumerator()) {
+	$Key = $Item.Key
+	$Value = $Item.Value
+
+	if ($EnvOld[$Key] -ne $EnvNew[$Key]) {
+		"$Key=$Value" >> $env:GITHUB_ENV
+	}
+}


### PR DESCRIPTION
This replaces the [`aminya/setup-cpp`](https://github.com/aminya/setup-cpp) GitHub action with some custom PowerShell scripts, to accommodate for the upcoming 32-bit CI builds (see #35).

The new scripts are a bit more primitive than `setup-cpp`, as they don't do any installation (besides `g++-multilib`) and instead rely on what the GitHub runners have preinstalled on them. Thankfully (and somewhat purposefully) this lines up with the compilers Godot Jolt sets as prerequisites, i.e. Visual Studio 2022, GCC 11 and LLVM/Clang 14.

`ci_setup_linux.ps1` ensures that the desired version of the desired toolchain is what you get if you invoke the respective version-less command. So if you invoke `clang++` you should end up with `clang++-14`, or whatever version you requested. It achieves this using the `update-alternatives` tool that comes bundled with Ubuntu.

`ci_setup_linux.ps1` also installs the appropriate `g++-multilib`, which enables us to do 32-bit builds on 64-bit Linux.

`ci_setup_macos.ps1` uses `xcode-select` to set the desired Xcode version as the default environment.

`ci_setup_windows.ps1` goes through a bit of hassle to find the desired Visual Studio installation (using `vswhere`) to launch its Developer PowerShell with the desired target architecture and then exports the relevant environment variables to `GITHUB_ENV`.

`ci_setup_windows.ps1` also checks if there's any `clang-cl.exe` in the `PATH` environment variable and omits its parent directory from `PATH` if that is the case. This is needed because MSVC-like compilers rely on a specific compiler being invoked for the desired target architecture, and sadly GitHub's runners have 64-bit LLVM installed in `PATH`, which CMake ends up finding instead of the LLVM installation that Developer PowerShell exposes in `PATH`, thus breaking 32-bit builds.