### PR TITLE
Updated godot-cpp to 4.0-beta7

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 978cba5538b576a016321ec51519425c528f35a9
+	GIT_COMMIT ebfed62e9ce920a8d6e8fd8e6d93906b06784b27
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES
 		<SOURCE_DIR>/godot-headers


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@978cba5538b576a016321ec51519425c528f35a9 aka `4.0-beta6` to godot-jolt/godot-cpp@ebfed62e9ce920a8d6e8fd8e6d93906b06784b27 aka `4.0-beta7` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/978cba5538b576a016321ec51519425c528f35a9...ebfed62e9ce920a8d6e8fd8e6d93906b06784b27)).