### PR TITLE
Changed single quotes to double quotes in scripts

### DIFF
--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -4,4 +4,4 @@
 #Requires -Version 7.2
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = "Stop"

--- a/scripts/run_clang_format.ps1
+++ b/scripts/run_clang_format.ps1
@@ -1,17 +1,17 @@
 #!/usr/bin/env pwsh
 
 param (
-	[Parameter(Mandatory = $true, HelpMessage = 'Path to directory with source files')]
+	[Parameter(Mandatory = $true, HelpMessage = "Path to directory with source files")]
 	[ValidateNotNullOrEmpty()]
 	[string]$SourcePath,
 
-	[Parameter(HelpMessage = 'Apply fixes if applicable')]
+	[Parameter(HelpMessage = "Apply fixes if applicable")]
 	[switch]$Fix = $false
 )
 
 . $PSScriptRoot/_common.ps1
 
-$SourceFiles = Get-ChildItem -Recurse -Path $SourcePath -Include ('*.cpp', '*.h')
+$SourceFiles = Get-ChildItem -Recurse -Path $SourcePath -Include ("*.cpp", "*.h")
 
 $Outputs = [Collections.Concurrent.ConcurrentBag[psobject]]::new()
 
@@ -19,12 +19,12 @@ $SourceFiles | ForEach-Object -Parallel {
 	$Outputs = $using:Outputs
 	$Fix = $using:Fix
 	$Output = $null
-	$($Output = clang-format $($Fix ? '-i' : '-n') --Werror $_ *>&1) || $Outputs.Add($Output)
+	$($Output = clang-format $($Fix ? "-i" : "-n") --Werror $_ *>&1) || $Outputs.Add($Output)
 } -ThrottleLimit ([Environment]::ProcessorCount)
 
 $Outputs | Where-Object { $_ -ne $null } | ForEach-Object {
 	Write-Output $_
-	Write-Output ''
+	Write-Output ""
 }
 
 exit $Outputs.IsEmpty ? 0 : 1

--- a/scripts/run_clang_tidy.ps1
+++ b/scripts/run_clang_tidy.ps1
@@ -1,21 +1,21 @@
 #!/usr/bin/env pwsh
 
 param (
-	[Parameter(Mandatory = $true, HelpMessage = 'Path to directory with source files')]
+	[Parameter(Mandatory = $true, HelpMessage = "Path to directory with source files")]
 	[ValidateNotNullOrEmpty()]
 	[string]$SourcePath,
 
-	[Parameter(Mandatory = $true, HelpMessage = 'Path to directory with compile_commands.json')]
+	[Parameter(Mandatory = $true, HelpMessage = "Path to directory with compile_commands.json")]
 	[ValidateNotNullOrEmpty()]
 	[string]$BuildPath,
 
-	[Parameter(HelpMessage = 'Apply fixes if applicable (warning: slow)')]
+	[Parameter(HelpMessage = "Apply fixes if applicable (warning: slow)")]
 	[switch]$Fix = $false
 )
 
 . $PSScriptRoot/_common.ps1
 
-$SourceFiles = Get-ChildItem -Recurse -Path $SourcePath -Include '*.cpp'
+$SourceFiles = Get-ChildItem -Recurse -Path $SourcePath -Include "*.cpp"
 
 if ($Fix) {
 	clang-tidy -p $BuildPath --quiet --fix-notes @SourceFiles
@@ -33,7 +33,7 @@ $SourceFiles | ForEach-Object -Parallel {
 
 $Outputs | Where-Object { $_ -ne $null } | ForEach-Object {
 	Write-Output $_
-	Write-Output ''
+	Write-Output ""
 }
 
 exit $Outputs.IsEmpty ? 0 : 1


### PR DESCRIPTION
I realized while writing the CI setup scripts for #36 that single and double quotes are not interchangable in PowerShell.

As mentioned in [their documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.2), double quotes are expandable, meaning you can use variables inside them. I find myself wanting this behavior more often than I want to prevent it, so double quotes will now be the default.

Sadly there's no linter to enforce this, although it seems there is an official tool called [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) that can enforce single quotes when no variable is referenced in the string. I might add this, along with some custom rule, as a CI check at some point.