### PR TITLE
Reverted "Fixed memory leak of group filter"

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -79,7 +79,6 @@ void JoltPhysicsServer3D::init_statics() {
 }
 
 void JoltPhysicsServer3D::finish_statics() {
-	delete group_filter;
 	group_filter = nullptr;
 
 	delete job_system;


### PR DESCRIPTION
Reverts #45.

This wasn't a memory leak at all, because it's a `JPH::Ref`. Not sure what I was thinking.