### PR TITLE
Added cancellation of ongoing CI runs on pull request commits

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,6 +1,10 @@
 name: 🔍 Analyze
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     name: Formatting

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,10 @@
 name: 🐧 Build (Linux)
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,6 +1,10 @@
 name: 🍎 Build (macOS)
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-12

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,6 +1,10 @@
 name: 🪟 Build (Windows)
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     runs-on: windows-2022


### PR DESCRIPTION
This assigns a [concurrency group](https://docs.github.com/en/actions/using-jobs/using-concurrency) to each workflow run. Only one run is allowed per group and any ongoing runs are cancelled.

When committing to a pull request, the group ID will effectively be `<workflow>-<source_branch>`, meaning as you commit to a pull request branch it will end up cancelling any ongoing runs.

When triggering a run in any other way (e.g. `push` or `workflow_dispatch`) the group ID will instead be `<workflow>-<run_id>` which effectively gives it a unique group, meaning it'll behave as if you weren't using `concurrency` at all.