### PR TITLE
Added `CRASH_NOW` to `jolt_assert`

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -42,12 +42,14 @@ void jolt_trace(const char* p_format, ...) {
 
 bool jolt_assert(const char* p_expr, const char* p_msg, const char* p_file, uint32_t p_line) {
 	ERR_PRINT(vformat(
-		"Jolt assertion failed: {}:{} ({}) {}",
+		"Assertion ({}) failed at '{}:{}' with message '{}'",
+		p_expr,
 		p_file,
 		p_line,
-		p_expr,
 		p_msg != nullptr ? p_msg : ""
 	));
+
+	CRASH_NOW();
 
 	return false;
 }


### PR DESCRIPTION
Note that (at least on Windows) this will just [`__debugbreak`](https://learn.microsoft.com/en-us/cpp/intrinsics/debugbreak) and still let you continue from the debugger if you so choose.

I figured since asserts are only enabled for `*Debug` builds, I might as well trigger a hard break/crash, so I don't miss it in the logs and end up with #45/#48 again.