### PR TITLE
Renamed types to better line up with their Godot counterparts

### DIFF
--- a/src/body_access.cpp
+++ b/src/body_access.cpp
@@ -2,15 +2,15 @@
 
 #include "jolt_physics_space_3d.hpp"
 
-BodyAccessRead::BodyAccessRead(
-	const JoltPhysicsSpace3D& p_space,
+JoltBodyAccessRead3D::JoltBodyAccessRead3D(
+	const JoltSpace3D& p_space,
 	const JPH::BodyID& p_jid,
 	bool p_lock
 )
 	: lock(p_space.get_body_lock_iface(p_lock), p_jid) { }
 
-BodyAccessWrite::BodyAccessWrite(
-	const JoltPhysicsSpace3D& p_space,
+JoltBodyAccessWrite3D::JoltBodyAccessWrite3D(
+	const JoltSpace3D& p_space,
 	const JPH::BodyID& p_jid,
 	bool p_lock
 )

--- a/src/body_access.hpp
+++ b/src/body_access.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-class JoltPhysicsSpace3D;
+class JoltSpace3D;
 
-class BodyAccessRead {
+class JoltBodyAccessRead3D {
 public:
-	BodyAccessRead(const JoltPhysicsSpace3D& p_space, const JPH::BodyID& p_jid, bool p_lock);
+	JoltBodyAccessRead3D(const JoltSpace3D& p_space, const JPH::BodyID& p_jid, bool p_lock);
 
 	bool is_valid() const { return lock.Succeeded(); }
 
@@ -14,9 +14,9 @@ private:
 	JPH::BodyLockRead lock;
 };
 
-class BodyAccessWrite {
+class JoltBodyAccessWrite3D {
 public:
-	BodyAccessWrite(const JoltPhysicsSpace3D& p_space, const JPH::BodyID& p_jid, bool p_lock);
+	JoltBodyAccessWrite3D(const JoltSpace3D& p_space, const JPH::BodyID& p_jid, bool p_lock);
 
 	bool is_valid() const { return lock.Succeeded(); }
 

--- a/src/jolt_physics_area_3d.cpp
+++ b/src/jolt_physics_area_3d.cpp
@@ -2,7 +2,7 @@
 
 #include "error_macros.hpp"
 
-Variant JoltPhysicsArea3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
+Variant JoltArea3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::AREA_PARAM_GRAVITY: {
 			return gravity;
@@ -22,7 +22,7 @@ Variant JoltPhysicsArea3D::get_param(PhysicsServer3D::AreaParameter p_param) con
 	}
 }
 
-void JoltPhysicsArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
+void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::AREA_PARAM_GRAVITY: {
 			gravity = p_value;
@@ -42,4 +42,4 @@ void JoltPhysicsArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const 
 	}
 }
 
-void JoltPhysicsArea3D::call_queries() { }
+void JoltArea3D::call_queries() { }

--- a/src/jolt_physics_area_3d.hpp
+++ b/src/jolt_physics_area_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "jolt_physics_collision_object_3d.hpp"
 
-class JoltPhysicsArea3D final : public JoltPhysicsCollisionObject3D {
+class JoltArea3D final : public JoltCollisionObject3D {
 public:
 	bool has_monitor_callback() const { return !monitor_callback.is_null(); }
 

--- a/src/jolt_physics_body_3d.cpp
+++ b/src/jolt_physics_body_3d.cpp
@@ -7,14 +7,14 @@
 #include "jolt_physics_space_3d.hpp"
 #include "utility_functions.hpp"
 
-JoltPhysicsBody3D::~JoltPhysicsBody3D() {
+JoltBody3D::~JoltBody3D() {
 	if (direct_state) {
 		memdelete(direct_state);
 		direct_state = nullptr;
 	}
 }
 
-Variant JoltPhysicsBody3D::get_state(PhysicsServer3D::BodyState p_state) {
+Variant JoltBody3D::get_state(PhysicsServer3D::BodyState p_state) {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
 			return get_transform();
@@ -37,7 +37,7 @@ Variant JoltPhysicsBody3D::get_state(PhysicsServer3D::BodyState p_state) {
 	}
 }
 
-void JoltPhysicsBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value) {
+void JoltBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value) {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
 			set_transform(p_value);
@@ -60,7 +60,7 @@ void JoltPhysicsBody3D::set_state(PhysicsServer3D::BodyState p_state, const Vari
 	}
 }
 
-Variant JoltPhysicsBody3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
+Variant JoltBody3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::BODY_PARAM_BOUNCE: {
 			return get_bounce();
@@ -95,7 +95,7 @@ Variant JoltPhysicsBody3D::get_param(PhysicsServer3D::BodyParameter p_param) con
 	}
 }
 
-void JoltPhysicsBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value) {
+void JoltBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::BODY_PARAM_BOUNCE: {
 			set_bounce(p_value);
@@ -130,20 +130,20 @@ void JoltPhysicsBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const 
 	}
 }
 
-void JoltPhysicsBody3D::set_state_sync_callback(const Callable& p_callback) {
+void JoltBody3D::set_state_sync_callback(const Callable& p_callback) {
 	body_state_callback = p_callback;
 }
 
-bool JoltPhysicsBody3D::get_sleep_state(bool p_lock) const {
+bool JoltBody3D::get_sleep_state(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	const BodyAccessRead body_access(*space, jid, p_lock);
+	const JoltBodyAccessRead3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	return !body_access.get_body().IsActive();
 }
 
-void JoltPhysicsBody3D::set_sleep_state(bool p_enabled, bool p_lock) {
+void JoltBody3D::set_sleep_state(bool p_enabled, bool p_lock) {
 	if (!space) {
 		initial_sleep_state = p_enabled;
 		return;
@@ -156,7 +156,7 @@ void JoltPhysicsBody3D::set_sleep_state(bool p_enabled, bool p_lock) {
 	}
 }
 
-void JoltPhysicsBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
+void JoltBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
 	if (p_enabled == allowed_sleep) {
 		return;
 	}
@@ -167,64 +167,64 @@ void JoltPhysicsBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().SetAllowSleeping(allowed_sleep);
 }
 
-Basis JoltPhysicsBody3D::get_inverse_inertia_tensor(bool p_lock) const {
+Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	const BodyAccessRead body_access(*space, jid, p_lock);
+	const JoltBodyAccessRead3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	return to_godot(body_access.get_body().GetInverseInertia().GetQuaternion());
 }
 
-Vector3 JoltPhysicsBody3D::get_linear_velocity(bool p_lock) const {
+Vector3 JoltBody3D::get_linear_velocity(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	const BodyAccessRead body_access(*space, jid, p_lock);
+	const JoltBodyAccessRead3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	return to_godot(body_access.get_body().GetLinearVelocity());
 }
 
-void JoltPhysicsBody3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
+void JoltBody3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
 	if (!space) {
 		initial_linear_velocity = p_velocity;
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().SetLinearVelocityClamped(to_jolt(p_velocity));
 }
 
-Vector3 JoltPhysicsBody3D::get_angular_velocity(bool p_lock) const {
+Vector3 JoltBody3D::get_angular_velocity(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	const BodyAccessRead body_access(*space, jid, p_lock);
+	const JoltBodyAccessRead3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	return to_godot(body_access.get_body().GetAngularVelocity());
 }
 
-void JoltPhysicsBody3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
+void JoltBody3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
 	if (!space) {
 		initial_angular_velocity = p_velocity;
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().SetAngularVelocityClamped(to_jolt(p_velocity));
 }
 
-void JoltPhysicsBody3D::call_queries() {
+void JoltBody3D::call_queries() {
 	// TODO(mihe): Call force integration callback
 
 	if (body_state_callback.is_valid()) {
@@ -232,7 +232,7 @@ void JoltPhysicsBody3D::call_queries() {
 	}
 }
 
-JoltPhysicsDirectBodyState3D* JoltPhysicsBody3D::get_direct_state() {
+JoltPhysicsDirectBodyState3D* JoltBody3D::get_direct_state() {
 	if (!direct_state) {
 		direct_state = memnew(JoltPhysicsDirectBodyState3D(this));
 	}
@@ -240,7 +240,7 @@ JoltPhysicsDirectBodyState3D* JoltPhysicsBody3D::get_direct_state() {
 	return direct_state;
 }
 
-void JoltPhysicsBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
+void JoltBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
 	if (p_mode == PhysicsServer3D::BODY_MODE_RIGID_LINEAR) {
 		WARN_PRINT(
 			"Locking rotation is not supported by Godot Jolt. "
@@ -277,7 +277,7 @@ void JoltPhysicsBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) 
 		} break;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	if (!get_sleep_state(false) && motion_type == JPH::EMotionType::Static) {
@@ -291,7 +291,7 @@ void JoltPhysicsBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) 
 	}
 }
 
-void JoltPhysicsBody3D::set_ccd_enabled(bool p_enable, bool p_lock) {
+void JoltBody3D::set_ccd_enabled(bool p_enable, bool p_lock) {
 	if (p_enable == ccd_enabled) {
 		return;
 	}
@@ -308,21 +308,21 @@ void JoltPhysicsBody3D::set_ccd_enabled(bool p_enable, bool p_lock) {
 	);
 }
 
-void JoltPhysicsBody3D::set_mass(float p_mass, bool p_lock) {
+void JoltBody3D::set_mass(float p_mass, bool p_lock) {
 	if (p_mass != mass) {
 		mass = p_mass;
 		mass_properties_changed(p_lock);
 	}
 }
 
-void JoltPhysicsBody3D::set_inertia(const Vector3& p_inertia, bool p_lock) {
+void JoltBody3D::set_inertia(const Vector3& p_inertia, bool p_lock) {
 	if (p_inertia != inertia) {
 		inertia = p_inertia;
 		mass_properties_changed(p_lock);
 	}
 }
 
-void JoltPhysicsBody3D::set_bounce(float p_bounce, bool p_lock) {
+void JoltBody3D::set_bounce(float p_bounce, bool p_lock) {
 	if (p_bounce < 0 || p_bounce > 1) {
 		WARN_PRINT(
 			"Bounce values less than 0 or greater than 1 are not supported by Godot Jolt. "
@@ -342,13 +342,13 @@ void JoltPhysicsBody3D::set_bounce(float p_bounce, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().SetRestitution(bounce);
 }
 
-void JoltPhysicsBody3D::set_friction(float p_friction, bool p_lock) {
+void JoltBody3D::set_friction(float p_friction, bool p_lock) {
 	if (p_friction < 0) {
 		WARN_PRINT(
 			"Friction values less than 0 are not supported by Godot Jolt. "
@@ -368,13 +368,13 @@ void JoltPhysicsBody3D::set_friction(float p_friction, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().SetFriction(friction);
 }
 
-void JoltPhysicsBody3D::set_gravity_scale(float p_scale, bool p_lock) {
+void JoltBody3D::set_gravity_scale(float p_scale, bool p_lock) {
 	if (p_scale == gravity_scale) {
 		return;
 	}
@@ -385,13 +385,13 @@ void JoltPhysicsBody3D::set_gravity_scale(float p_scale, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().GetMotionPropertiesUnchecked()->SetGravityFactor(p_scale);
 }
 
-void JoltPhysicsBody3D::set_linear_damp(float p_damp, bool p_lock) {
+void JoltBody3D::set_linear_damp(float p_damp, bool p_lock) {
 	if (p_damp < 0) {
 		WARN_PRINT(
 			"Linear damp values less than 0 are not supported by Godot Jolt. "
@@ -411,13 +411,13 @@ void JoltPhysicsBody3D::set_linear_damp(float p_damp, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().GetMotionPropertiesUnchecked()->SetLinearDamping(linear_damp);
 }
 
-void JoltPhysicsBody3D::set_angular_damp(float p_damp, bool p_lock) {
+void JoltBody3D::set_angular_damp(float p_damp, bool p_lock) {
 	if (p_damp < 0) {
 		WARN_PRINT(
 			"Angular damp values less than 0 are not supported by Godot Jolt. "
@@ -437,22 +437,22 @@ void JoltPhysicsBody3D::set_angular_damp(float p_damp, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	body_access.get_body().GetMotionPropertiesUnchecked()->SetAngularDamping(angular_damp);
 }
 
-void JoltPhysicsBody3D::shapes_changed(bool p_lock) {
+void JoltBody3D::shapes_changed(bool p_lock) {
 	mass_properties_changed(p_lock);
 }
 
-void JoltPhysicsBody3D::mass_properties_changed(bool p_lock) {
+void JoltBody3D::mass_properties_changed(bool p_lock) {
 	if (!space) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	const JPH::MassProperties mass_properties = calculate_mass_properties(false);

--- a/src/jolt_physics_body_3d.hpp
+++ b/src/jolt_physics_body_3d.hpp
@@ -3,9 +3,9 @@
 #include "jolt_physics_collision_object_3d.hpp"
 #include "jolt_physics_direct_body_state_3d.hpp"
 
-class JoltPhysicsBody3D final : public JoltPhysicsCollisionObject3D {
+class JoltBody3D final : public JoltCollisionObject3D {
 public:
-	~JoltPhysicsBody3D() override;
+	~JoltBody3D() override;
 
 	Variant get_state(PhysicsServer3D::BodyState p_state);
 

--- a/src/jolt_physics_broad_phase_layer_3d.hpp
+++ b/src/jolt_physics_broad_phase_layer_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-enum JoltPhysicsBroadPhaseLayer3D {
+enum JoltBroadPhaseLayer {
 	GDJOLT_BROAD_PHASE_LAYER_STATIC,
 	GDJOLT_BROAD_PHASE_LAYER_MOVING,
 	GDJOLT_BROAD_PHASE_LAYER_COUNT

--- a/src/jolt_physics_collision_object_3d.cpp
+++ b/src/jolt_physics_collision_object_3d.cpp
@@ -6,9 +6,9 @@
 #include "jolt_physics_shape_3d.hpp"
 #include "jolt_physics_space_3d.hpp"
 
-JoltPhysicsCollisionObject3D::~JoltPhysicsCollisionObject3D() = default;
+JoltCollisionObject3D::~JoltCollisionObject3D() = default;
 
-void JoltPhysicsCollisionObject3D::set_space(JoltPhysicsSpace3D* p_space) {
+void JoltCollisionObject3D::set_space(JoltSpace3D* p_space) {
 	if (space == p_space) {
 		return;
 	}
@@ -27,7 +27,7 @@ void JoltPhysicsCollisionObject3D::set_space(JoltPhysicsSpace3D* p_space) {
 	space = p_space;
 }
 
-void JoltPhysicsCollisionObject3D::set_collision_layer(uint32_t p_layer, bool p_lock) {
+void JoltCollisionObject3D::set_collision_layer(uint32_t p_layer, bool p_lock) {
 	if (p_layer == collision_layer) {
 		return;
 	}
@@ -38,12 +38,12 @@ void JoltPhysicsCollisionObject3D::set_collision_layer(uint32_t p_layer, bool p_
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 	body_access.get_body().GetCollisionGroup().SetGroupID(p_layer);
 }
 
-void JoltPhysicsCollisionObject3D::set_collision_mask(uint32_t p_mask, bool p_lock) {
+void JoltCollisionObject3D::set_collision_mask(uint32_t p_mask, bool p_lock) {
 	if (p_mask == collision_mask) {
 		return;
 	}
@@ -54,15 +54,15 @@ void JoltPhysicsCollisionObject3D::set_collision_mask(uint32_t p_mask, bool p_lo
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 	body_access.get_body().GetCollisionGroup().SetSubGroupID(p_mask);
 }
 
-Transform3D JoltPhysicsCollisionObject3D::get_transform(bool p_lock) const {
+Transform3D JoltCollisionObject3D::get_transform(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	const BodyAccessRead body_access(*space, jid, p_lock);
+	const JoltBodyAccessRead3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	const JPH::Body& body = body_access.get_body();
@@ -70,7 +70,7 @@ Transform3D JoltPhysicsCollisionObject3D::get_transform(bool p_lock) const {
 	return {to_godot(body.GetRotation()), to_godot(body.GetPosition())};
 }
 
-void JoltPhysicsCollisionObject3D::set_transform(const Transform3D& p_transform, bool p_lock) {
+void JoltCollisionObject3D::set_transform(const Transform3D& p_transform, bool p_lock) {
 	if (!space) {
 		initial_transform = p_transform;
 		return;
@@ -87,17 +87,16 @@ void JoltPhysicsCollisionObject3D::set_transform(const Transform3D& p_transform,
 	);
 }
 
-Vector3 JoltPhysicsCollisionObject3D::get_center_of_mass(bool p_lock) const {
+Vector3 JoltCollisionObject3D::get_center_of_mass(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	const BodyAccessRead body_access(*space, jid, p_lock);
+	const JoltBodyAccessRead3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	return to_godot(body_access.get_body().GetCenterOfMassPosition());
 }
 
-JPH::MassProperties JoltPhysicsCollisionObject3D::calculate_mass_properties(
-	const JPH::Shape& p_root_shape
+JPH::MassProperties JoltCollisionObject3D::calculate_mass_properties(const JPH::Shape& p_root_shape
 ) const {
 	const float mass = get_mass();
 	const Vector3 inertia = get_inertia();
@@ -120,16 +119,16 @@ JPH::MassProperties JoltPhysicsCollisionObject3D::calculate_mass_properties(
 	return mass_properties;
 }
 
-JPH::MassProperties JoltPhysicsCollisionObject3D::calculate_mass_properties(bool p_lock) const {
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+JPH::MassProperties JoltCollisionObject3D::calculate_mass_properties(bool p_lock) const {
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	const JPH::Body& body = body_access.get_body();
 	return calculate_mass_properties(*body.GetShape());
 }
 
-void JoltPhysicsCollisionObject3D::add_shape(
-	JoltPhysicsShape3D* p_shape,
+void JoltCollisionObject3D::add_shape(
+	JoltShape3D* p_shape,
 	const Transform3D& p_transform,
 	bool p_disabled,
 	bool p_lock
@@ -147,7 +146,7 @@ void JoltPhysicsCollisionObject3D::add_shape(
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	JPH::MutableCompoundShape* root_shape = get_root_shape();
@@ -164,7 +163,7 @@ void JoltPhysicsCollisionObject3D::add_shape(
 	shapes_changed(false);
 }
 
-void JoltPhysicsCollisionObject3D::remove_shape(JoltPhysicsShape3D* p_shape, bool p_lock) {
+void JoltCollisionObject3D::remove_shape(JoltShape3D* p_shape, bool p_lock) {
 	const int index = find_shape_index(p_shape);
 	if (index == -1) {
 		return;
@@ -173,7 +172,7 @@ void JoltPhysicsCollisionObject3D::remove_shape(JoltPhysicsShape3D* p_shape, boo
 	remove_shape(index, p_lock);
 }
 
-void JoltPhysicsCollisionObject3D::remove_shape(int p_index, bool p_lock) {
+void JoltCollisionObject3D::remove_shape(int p_index, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
 	const Shape& shape = shapes[p_index];
@@ -185,7 +184,7 @@ void JoltPhysicsCollisionObject3D::remove_shape(int p_index, bool p_lock) {
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	JPH::MutableCompoundShape* root_shape = get_root_shape();
@@ -202,7 +201,7 @@ void JoltPhysicsCollisionObject3D::remove_shape(int p_index, bool p_lock) {
 	shapes_changed(false);
 }
 
-int JoltPhysicsCollisionObject3D::find_shape_index(JoltPhysicsShape3D* p_shape) {
+int JoltCollisionObject3D::find_shape_index(JoltShape3D* p_shape) {
 	for (int i = 0; i < shapes.size(); ++i) {
 		if (shapes[i].ref == p_shape) {
 			return i;
@@ -212,7 +211,7 @@ int JoltPhysicsCollisionObject3D::find_shape_index(JoltPhysicsShape3D* p_shape) 
 	return -1;
 }
 
-void JoltPhysicsCollisionObject3D::set_shape_transform(
+void JoltCollisionObject3D::set_shape_transform(
 	int64_t p_index,
 	const Transform3D& p_transform,
 	bool p_lock
@@ -226,7 +225,7 @@ void JoltPhysicsCollisionObject3D::set_shape_transform(
 		return;
 	}
 
-	const BodyAccessWrite body_access(*space, jid, p_lock);
+	const JoltBodyAccessWrite3D body_access(*space, jid, p_lock);
 	ERR_FAIL_COND(!body_access.is_valid());
 
 	JPH::MutableCompoundShape* root_shape = get_root_shape();
@@ -244,12 +243,12 @@ void JoltPhysicsCollisionObject3D::set_shape_transform(
 	shapes_changed(false);
 }
 
-JPH::MutableCompoundShape* JoltPhysicsCollisionObject3D::get_root_shape() const {
+JPH::MutableCompoundShape* JoltCollisionObject3D::get_root_shape() const {
 	ERR_FAIL_NULL_D(space);
 
 	// We assume that we're already locked, since anything returned from this function after the
 	// lock is released could disappear from underneath us anyway
-	const BodyAccessRead body_access(*space, jid, false);
+	const JoltBodyAccessRead3D body_access(*space, jid, false);
 	ERR_FAIL_COND_D(!body_access.is_valid());
 
 	// HACK(mihe): const_cast is not ideal, but that's what the official tests for

--- a/src/jolt_physics_collision_object_3d.hpp
+++ b/src/jolt_physics_collision_object_3d.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-class JoltPhysicsSpace3D;
-class JoltPhysicsShape3D;
+class JoltSpace3D;
+class JoltShape3D;
 
-class JoltPhysicsCollisionObject3D {
+class JoltCollisionObject3D {
 public:
 	struct Shape {
-		JoltPhysicsShape3D* ref = nullptr;
+		JoltShape3D* ref = nullptr;
 		bool disabled = false;
 		Transform3D transform;
 	};
 
-	virtual ~JoltPhysicsCollisionObject3D() = 0;
+	virtual ~JoltCollisionObject3D() = 0;
 
 	RID get_rid() const { return rid; }
 
@@ -25,9 +25,9 @@ public:
 
 	void set_jid(JPH::BodyID p_jid) { jid = p_jid; }
 
-	JoltPhysicsSpace3D* get_space() const { return space; }
+	JoltSpace3D* get_space() const { return space; }
 
-	void set_space(JoltPhysicsSpace3D* p_space);
+	void set_space(JoltSpace3D* p_space);
 
 	uint32_t get_collision_layer() const { return collision_layer; }
 
@@ -50,13 +50,13 @@ public:
 	JPH::MassProperties calculate_mass_properties(bool p_lock = true) const;
 
 	void add_shape(
-		JoltPhysicsShape3D* p_shape,
+		JoltShape3D* p_shape,
 		const Transform3D& p_transform,
 		bool p_disabled,
 		bool p_lock = true
 	);
 
-	void remove_shape(JoltPhysicsShape3D* p_shape, bool p_lock = true);
+	void remove_shape(JoltShape3D* p_shape, bool p_lock = true);
 
 	void remove_shape(int p_index, bool p_lock = true);
 
@@ -64,7 +64,7 @@ public:
 
 	int get_shape_count() const { return shapes.size(); }
 
-	int find_shape_index(JoltPhysicsShape3D* p_shape);
+	int find_shape_index(JoltShape3D* p_shape);
 
 	void set_shape_transform(int64_t p_index, const Transform3D& p_transform, bool p_lock = true);
 
@@ -113,7 +113,7 @@ protected:
 
 	JPH::BodyID jid;
 
-	JoltPhysicsSpace3D* space = nullptr;
+	JoltSpace3D* space = nullptr;
 
 	uint32_t collision_layer = 1;
 

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -3,7 +3,7 @@
 #include "error_macros.hpp"
 #include "jolt_physics_body_3d.hpp"
 
-JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltPhysicsBody3D* p_body)
+JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D* p_body)
 	: body(p_body) { }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_total_gravity() const {

--- a/src/jolt_physics_direct_body_state_3d.hpp
+++ b/src/jolt_physics_direct_body_state_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltPhysicsBody3D;
+class JoltBody3D;
 
 class JoltPhysicsDirectBodyState3D final : public PhysicsDirectBodyState3DExtension {
 	GDCLASS_NO_WARN(JoltPhysicsDirectBodyState3D, PhysicsDirectBodyState3DExtension) // NOLINT
@@ -12,7 +12,7 @@ protected:
 public:
 	JoltPhysicsDirectBodyState3D() = default;
 
-	explicit JoltPhysicsDirectBodyState3D(JoltPhysicsBody3D* p_body);
+	explicit JoltPhysicsDirectBodyState3D(JoltBody3D* p_body);
 
 	Vector3 _get_total_gravity() const override;
 
@@ -105,5 +105,5 @@ public:
 	PhysicsDirectSpaceState3D* _get_space_state() override;
 
 private:
-	JoltPhysicsBody3D* body = nullptr;
+	JoltBody3D* body = nullptr;
 };

--- a/src/jolt_physics_group_filter.hpp
+++ b/src/jolt_physics_group_filter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltPhysicsGroupFilter final : public JPH::GroupFilter {
+class JoltGroupFilter final : public JPH::GroupFilter {
 public:
 	bool CanCollide(const JPH::CollisionGroup& p_first, const JPH::CollisionGroup& p_second)
 		const override {

--- a/src/jolt_physics_layer_mapper_3d.cpp
+++ b/src/jolt_physics_layer_mapper_3d.cpp
@@ -2,14 +2,14 @@
 
 #include "utility_functions.hpp"
 
-JoltPhysicsLayerMapper3D::JoltPhysicsLayerMapper3D() {
+JoltLayerMapper::JoltLayerMapper() {
 	mappings[GDJOLT_OBJECT_LAYER_STATIC] = JPH::BroadPhaseLayer(GDJOLT_BROAD_PHASE_LAYER_STATIC);
 	mappings[GDJOLT_OBJECT_LAYER_MOVING] = JPH::BroadPhaseLayer(GDJOLT_BROAD_PHASE_LAYER_MOVING);
 }
 
 #if defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
 
-const char* JoltPhysicsLayerMapper3D::GetBroadPhaseLayerName(JPH::BroadPhaseLayer p_layer) const {
+const char* JoltLayerMapper::GetBroadPhaseLayerName(JPH::BroadPhaseLayer p_layer) const {
 	switch ((JPH::BroadPhaseLayer::Type)p_layer) {
 		case GDJOLT_BROAD_PHASE_LAYER_STATIC: {
 			return "STATIC";
@@ -25,10 +25,7 @@ const char* JoltPhysicsLayerMapper3D::GetBroadPhaseLayerName(JPH::BroadPhaseLaye
 
 #endif // JPH_EXTERNAL_PROFILE || JPH_PROFILE_ENABLED
 
-bool JoltPhysicsLayerMapper3D::can_layers_collide(
-	JPH::ObjectLayer p_layer1,
-	JPH::ObjectLayer p_layer2
-) {
+bool JoltLayerMapper::can_layers_collide(JPH::ObjectLayer p_layer1, JPH::ObjectLayer p_layer2) {
 	switch (p_layer1) {
 		case GDJOLT_OBJECT_LAYER_STATIC: {
 			return p_layer2 == GDJOLT_OBJECT_LAYER_MOVING;
@@ -42,10 +39,7 @@ bool JoltPhysicsLayerMapper3D::can_layers_collide(
 	}
 }
 
-bool JoltPhysicsLayerMapper3D::can_layers_collide(
-	JPH::ObjectLayer p_layer1,
-	JPH::BroadPhaseLayer p_layer2
-) {
+bool JoltLayerMapper::can_layers_collide(JPH::ObjectLayer p_layer1, JPH::BroadPhaseLayer p_layer2) {
 	switch (p_layer1) {
 		case GDJOLT_OBJECT_LAYER_STATIC: {
 			return p_layer2 == JPH::BroadPhaseLayer(GDJOLT_BROAD_PHASE_LAYER_MOVING);

--- a/src/jolt_physics_layer_mapper_3d.hpp
+++ b/src/jolt_physics_layer_mapper_3d.hpp
@@ -3,9 +3,9 @@
 #include "jolt_physics_broad_phase_layer_3d.hpp"
 #include "jolt_physics_object_layer_3d.hpp"
 
-class JoltPhysicsLayerMapper3D final : public JPH::BroadPhaseLayerInterface {
+class JoltLayerMapper final : public JPH::BroadPhaseLayerInterface {
 public:
-	JoltPhysicsLayerMapper3D();
+	JoltLayerMapper();
 
 	uint32_t GetNumBroadPhaseLayers() const override { return GDJOLT_BROAD_PHASE_LAYER_COUNT; }
 

--- a/src/jolt_physics_object_layer_3d.hpp
+++ b/src/jolt_physics_object_layer_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-enum JoltPhysicsObjectLayer3D {
+enum JoltObjectLayer {
 	GDJOLT_OBJECT_LAYER_STATIC,
 	GDJOLT_OBJECT_LAYER_MOVING,
 	GDJOLT_OBJECT_LAYER_COUNT

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -77,7 +77,7 @@ void JoltPhysicsServer3D::init_statics() {
 		(int)std::thread::hardware_concurrency() - 1
 	);
 
-	group_filter = new JoltPhysicsGroupFilter();
+	group_filter = new JoltGroupFilter();
 }
 
 void JoltPhysicsServer3D::finish_statics() {
@@ -111,35 +111,35 @@ RID JoltPhysicsServer3D::_separation_ray_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_sphere_shape_create() {
-	JoltPhysicsShape3D* shape = memnew(JoltPhysicsSphereShape3D);
+	JoltShape3D* shape = memnew(JoltSphereShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_box_shape_create() {
-	JoltPhysicsShape3D* shape = memnew(JoltPhysicsBoxShape3D);
+	JoltShape3D* shape = memnew(JoltBoxShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_capsule_shape_create() {
-	JoltPhysicsShape3D* shape = memnew(JoltPhysicsCapsuleShape3D);
+	JoltShape3D* shape = memnew(JoltCapsuleShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_cylinder_shape_create() {
-	JoltPhysicsShape3D* shape = memnew(JoltPhysicsCylinderShape3D);
+	JoltShape3D* shape = memnew(JoltCylinderShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_convex_polygon_shape_create() {
-	JoltPhysicsShape3D* shape = memnew(JoltPhysicsConvexPolygonShape3D);
+	JoltShape3D* shape = memnew(JoltConvexPolygonShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
@@ -158,7 +158,7 @@ RID JoltPhysicsServer3D::_custom_shape_create() {
 }
 
 void JoltPhysicsServer3D::_shape_set_data(const RID& p_shape, const Variant& p_data) {
-	JoltPhysicsShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	shape->set_data(p_data);
@@ -177,7 +177,7 @@ PhysicsServer3D::ShapeType JoltPhysicsServer3D::_shape_get_type([[maybe_unused]]
 }
 
 Variant JoltPhysicsServer3D::_shape_get_data(const RID& p_shape) const {
-	JoltPhysicsShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_D(shape);
 
 	return shape->get_data();
@@ -200,12 +200,12 @@ double JoltPhysicsServer3D::_shape_get_custom_solver_bias([[maybe_unused]] const
 }
 
 RID JoltPhysicsServer3D::_space_create() {
-	JoltPhysicsSpace3D* space = memnew(JoltPhysicsSpace3D(job_system, group_filter));
+	JoltSpace3D* space = memnew(JoltSpace3D(job_system, group_filter));
 	RID rid = space_owner.make_rid(space);
 	space->set_rid(rid);
 
 	const RID default_area_rid = area_create();
-	JoltPhysicsArea3D* default_area = area_owner.get_or_null(default_area_rid);
+	JoltArea3D* default_area = area_owner.get_or_null(default_area_rid);
 	ERR_FAIL_NULL_D(default_area);
 	space->set_default_area(default_area);
 	default_area->set_space(space);
@@ -214,7 +214,7 @@ RID JoltPhysicsServer3D::_space_create() {
 }
 
 void JoltPhysicsServer3D::_space_set_active(const RID& p_space, bool p_active) {
-	JoltPhysicsSpace3D* space = space_owner.get_or_null(p_space);
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
 	if (p_active) {
@@ -225,7 +225,7 @@ void JoltPhysicsServer3D::_space_set_active(const RID& p_space, bool p_active) {
 }
 
 bool JoltPhysicsServer3D::_space_is_active(const RID& p_space) const {
-	JoltPhysicsSpace3D* space = space_owner.get_or_null(p_space);
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_D(space);
 
 	return active_spaces.has(space);
@@ -247,7 +247,7 @@ double JoltPhysicsServer3D::_space_get_param(
 }
 
 PhysicsDirectSpaceState3D* JoltPhysicsServer3D::_space_get_direct_state(const RID& p_space) {
-	JoltPhysicsSpace3D* space = space_owner.get_or_null(p_space);
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_D(space);
 	ERR_FAIL_COND_D_MSG(
 		!doing_sync || space->is_locked(),
@@ -274,7 +274,7 @@ int64_t JoltPhysicsServer3D::_space_get_contact_count([[maybe_unused]] const RID
 }
 
 RID JoltPhysicsServer3D::_area_create() {
-	JoltPhysicsArea3D* area = memnew(JoltPhysicsArea3D);
+	JoltArea3D* area = memnew(JoltArea3D);
 	RID rid = area_owner.make_rid(area);
 	area->set_rid(rid);
 	return rid;
@@ -354,14 +354,14 @@ void JoltPhysicsServer3D::_area_set_shape_disabled(
 }
 
 void JoltPhysicsServer3D::_area_attach_object_instance_id(const RID& p_area, int64_t p_id) {
-	JoltPhysicsArea3D* area = area_owner.get_or_null(p_area);
+	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_instance_id(p_id);
 }
 
 int64_t JoltPhysicsServer3D::_area_get_object_instance_id(const RID& p_area) const {
-	JoltPhysicsArea3D* area = area_owner.get_or_null(p_area);
+	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_V(area, -1);
 
 	return area->get_instance_id();
@@ -375,11 +375,11 @@ void JoltPhysicsServer3D::_area_set_param(
 	RID area_rid = p_area;
 
 	if (space_owner.owns(area_rid)) {
-		JoltPhysicsSpace3D* space = space_owner.get_or_null(area_rid);
+		JoltSpace3D* space = space_owner.get_or_null(area_rid);
 		area_rid = space->get_default_area()->get_rid();
 	}
 
-	JoltPhysicsArea3D* area = area_owner.get_or_null(area_rid);
+	JoltArea3D* area = area_owner.get_or_null(area_rid);
 	ERR_FAIL_NULL(area);
 
 	area->set_param(p_param, p_value);
@@ -418,7 +418,7 @@ void JoltPhysicsServer3D::_area_set_collision_layer(
 }
 
 void JoltPhysicsServer3D::_area_set_monitorable(const RID& p_area, bool p_monitorable) {
-	JoltPhysicsArea3D* area = area_owner.get_or_null(p_area);
+	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_monitorable(p_monitorable);
@@ -428,7 +428,7 @@ void JoltPhysicsServer3D::_area_set_monitor_callback(
 	const RID& p_area,
 	const Callable& p_callback
 ) {
-	JoltPhysicsArea3D* area = area_owner.get_or_null(p_area);
+	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_monitor_callback(p_callback.is_valid() ? p_callback : Callable());
@@ -438,7 +438,7 @@ void JoltPhysicsServer3D::_area_set_area_monitor_callback(
 	const RID& p_area,
 	const Callable& p_callback
 ) {
-	JoltPhysicsArea3D* area = area_owner.get_or_null(p_area);
+	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_area_monitor_callback(p_callback.is_valid() ? p_callback : Callable());
@@ -452,17 +452,17 @@ void JoltPhysicsServer3D::_area_set_ray_pickable(
 }
 
 RID JoltPhysicsServer3D::_body_create() {
-	JoltPhysicsBody3D* body = memnew(JoltPhysicsBody3D);
+	JoltBody3D* body = memnew(JoltBody3D);
 	RID rid = body_owner.make_rid(body);
 	body->set_rid(rid);
 	return rid;
 }
 
 void JoltPhysicsServer3D::_body_set_space(const RID& p_body, const RID& p_space) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	JoltPhysicsSpace3D* space = nullptr;
+	JoltSpace3D* space = nullptr;
 
 	if (p_space.is_valid()) {
 		space = space_owner.get_or_null(p_space);
@@ -477,7 +477,7 @@ RID JoltPhysicsServer3D::_body_get_space([[maybe_unused]] const RID& p_body) con
 }
 
 void JoltPhysicsServer3D::_body_set_mode(const RID& p_body, BodyMode p_mode) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_mode(p_mode);
@@ -494,10 +494,10 @@ void JoltPhysicsServer3D::_body_add_shape(
 	const Transform3D& p_transform,
 	bool p_disabled
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	JoltPhysicsShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	body->add_shape(shape, p_transform, p_disabled);
@@ -516,7 +516,7 @@ void JoltPhysicsServer3D::_body_set_shape_transform(
 	int64_t p_shape_idx,
 	const Transform3D& p_transform
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_shape_transform(p_shape_idx, p_transform);
@@ -541,7 +541,7 @@ Transform3D JoltPhysicsServer3D::_body_get_shape_transform(
 }
 
 void JoltPhysicsServer3D::_body_remove_shape(const RID& p_body, int64_t p_shape_idx) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->remove_shape((int)p_shape_idx);
@@ -560,14 +560,14 @@ void JoltPhysicsServer3D::_body_set_shape_disabled(
 }
 
 void JoltPhysicsServer3D::_body_attach_object_instance_id(const RID& p_body, int64_t p_id) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_instance_id(p_id);
 }
 
 int64_t JoltPhysicsServer3D::_body_get_object_instance_id(const RID& p_body) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, -1);
 
 	return body->get_instance_id();
@@ -577,42 +577,42 @@ void JoltPhysicsServer3D::_body_set_enable_continuous_collision_detection(
 	const RID& p_body,
 	bool p_enable
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_ccd_enabled(p_enable);
 }
 
 bool JoltPhysicsServer3D::_body_is_continuous_collision_detection_enabled(const RID& p_body) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->is_ccd_enabled();
 }
 
 void JoltPhysicsServer3D::_body_set_collision_layer(const RID& p_body, int64_t p_layer) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_collision_layer((uint32_t)p_layer);
 }
 
 int64_t JoltPhysicsServer3D::_body_get_collision_layer(const RID& p_body) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_collision_layer();
 }
 
 void JoltPhysicsServer3D::_body_set_collision_mask(const RID& p_body, int64_t p_mask) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_collision_mask((uint32_t)p_mask);
 }
 
 int64_t JoltPhysicsServer3D::_body_get_collision_mask(const RID& p_body) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_collision_mask();
@@ -650,14 +650,14 @@ void JoltPhysicsServer3D::_body_set_param(
 	BodyParameter p_param,
 	const Variant& p_value
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_param(p_param, p_value);
 }
 
 Variant JoltPhysicsServer3D::_body_get_param(const RID& p_body, BodyParameter p_param) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_param(p_param);
@@ -672,14 +672,14 @@ void JoltPhysicsServer3D::_body_set_state(
 	BodyState p_state,
 	const Variant& p_value
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_state(p_state, p_value);
 }
 
 Variant JoltPhysicsServer3D::_body_get_state(const RID& p_body, BodyState p_state) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_state(p_state);
@@ -733,7 +733,7 @@ void JoltPhysicsServer3D::_body_add_constant_central_force(
 	const RID& p_body,
 	const Vector3& p_force
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_constant_central_force(p_force);
@@ -744,42 +744,42 @@ void JoltPhysicsServer3D::_body_add_constant_force(
 	const Vector3& p_force,
 	const Vector3& p_position
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_constant_force(p_force, p_position);
 }
 
 void JoltPhysicsServer3D::_body_add_constant_torque(const RID& p_body, const Vector3& p_torque) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_constant_torque(p_torque);
 }
 
 void JoltPhysicsServer3D::_body_set_constant_force(const RID& p_body, const Vector3& p_force) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_constant_force(p_force);
 }
 
 Vector3 JoltPhysicsServer3D::_body_get_constant_force(const RID& p_body) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_constant_force();
 }
 
 void JoltPhysicsServer3D::_body_set_constant_torque(const RID& p_body, const Vector3& p_torque) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_constant_torque(p_torque);
 }
 
 Vector3 JoltPhysicsServer3D::_body_get_constant_torque(const RID& p_body) const {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_constant_torque();
@@ -873,7 +873,7 @@ void JoltPhysicsServer3D::_body_set_state_sync_callback(
 	const RID& p_body,
 	const Callable& p_callable
 ) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_state_sync_callback(p_callable);
@@ -888,7 +888,7 @@ void JoltPhysicsServer3D::_body_set_force_integration_callback(
 }
 
 void JoltPhysicsServer3D::_body_set_ray_pickable(const RID& p_body, bool p_enable) {
-	JoltPhysicsBody3D* body = body_owner.get_or_null(p_body);
+	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_ray_pickable(p_enable);
@@ -1342,16 +1342,16 @@ int64_t JoltPhysicsServer3D::_joint_get_solver_priority([[maybe_unused]] const R
 
 void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 	if (shape_owner.owns(p_rid)) {
-		JoltPhysicsShape3D* shape = shape_owner.get_or_null(p_rid);
+		JoltShape3D* shape = shape_owner.get_or_null(p_rid);
 
-		if (JoltPhysicsCollisionObject3D* owner = shape->get_owner()) {
+		if (JoltCollisionObject3D* owner = shape->get_owner()) {
 			owner->remove_shape(shape);
 		}
 
 		shape_owner.free(p_rid);
 		memdelete(shape);
 	} else if (body_owner.owns(p_rid)) {
-		JoltPhysicsBody3D* body = body_owner.get_or_null(p_rid);
+		JoltBody3D* body = body_owner.get_or_null(p_rid);
 
 		body->set_space(nullptr);
 
@@ -1362,12 +1362,12 @@ void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 		body_owner.free(p_rid);
 		memdelete(body);
 	} else if (area_owner.owns(p_rid)) {
-		JoltPhysicsArea3D* area = area_owner.get_or_null(p_rid);
+		JoltArea3D* area = area_owner.get_or_null(p_rid);
 		area->set_space(nullptr);
 		area_owner.free(p_rid);
 		memdelete(area);
 	} else if (space_owner.owns(p_rid)) {
-		JoltPhysicsSpace3D* space = space_owner.get_or_null(p_rid);
+		JoltSpace3D* space = space_owner.get_or_null(p_rid);
 		space_set_active(p_rid, false);
 		space_owner.free(p_rid);
 		memdelete(space);
@@ -1391,7 +1391,7 @@ void JoltPhysicsServer3D::_step(double p_step) {
 		return;
 	}
 
-	for (JoltPhysicsSpace3D* active_space : active_spaces) {
+	for (JoltSpace3D* active_space : active_spaces) {
 		active_space->step((float)p_step);
 	}
 }
@@ -1407,7 +1407,7 @@ void JoltPhysicsServer3D::_flush_queries() {
 
 	flushing_queries = true;
 
-	for (JoltPhysicsSpace3D* space : active_spaces) {
+	for (JoltSpace3D* space : active_spaces) {
 		space->call_queries();
 	}
 

--- a/src/jolt_physics_server_3d.hpp
+++ b/src/jolt_physics_server_3d.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-class JoltPhysicsArea3D;
-class JoltPhysicsBody3D;
-class JoltPhysicsShape3D;
-class JoltPhysicsSpace3D;
+class JoltArea3D;
+class JoltBody3D;
+class JoltShape3D;
+class JoltSpace3D;
 
 class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
 	GDCLASS_NO_WARN(JoltPhysicsServer3D, PhysicsServer3DExtension) // NOLINT
@@ -555,13 +555,13 @@ private:
 
 	bool flushing_queries = false;
 
-	HashSet<JoltPhysicsSpace3D*> active_spaces;
+	HashSet<JoltSpace3D*> active_spaces;
 
-	mutable RID_PtrOwner<JoltPhysicsSpace3D> space_owner;
+	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 
-	mutable RID_PtrOwner<JoltPhysicsBody3D> body_owner;
+	mutable RID_PtrOwner<JoltBody3D> body_owner;
 
-	mutable RID_PtrOwner<JoltPhysicsArea3D> area_owner;
+	mutable RID_PtrOwner<JoltArea3D> area_owner;
 
-	mutable RID_PtrOwner<JoltPhysicsShape3D> shape_owner;
+	mutable RID_PtrOwner<JoltShape3D> shape_owner;
 };

--- a/src/jolt_physics_shape_3d.cpp
+++ b/src/jolt_physics_shape_3d.cpp
@@ -2,34 +2,34 @@
 
 #include "conversion.hpp"
 
-JoltPhysicsShape3D::~JoltPhysicsShape3D() = default;
+JoltShape3D::~JoltShape3D() = default;
 
-Variant JoltPhysicsSphereShape3D::get_data() const {
+Variant JoltSphereShape3D::get_data() const {
 	return radius;
 }
 
-void JoltPhysicsSphereShape3D::set_data(const Variant& p_data) {
+void JoltSphereShape3D::set_data(const Variant& p_data) {
 	radius = p_data;
 	jref = new JPH::SphereShape(radius);
 }
 
-Variant JoltPhysicsBoxShape3D::get_data() const {
+Variant JoltBoxShape3D::get_data() const {
 	return half_extents;
 }
 
-void JoltPhysicsBoxShape3D::set_data(const Variant& p_data) {
+void JoltBoxShape3D::set_data(const Variant& p_data) {
 	half_extents = p_data;
 	jref = new JPH::BoxShape(to_jolt(half_extents));
 }
 
-Variant JoltPhysicsCapsuleShape3D::get_data() const {
+Variant JoltCapsuleShape3D::get_data() const {
 	Dictionary dict;
 	dict["height"] = height;
 	dict["radius"] = radius;
 	return dict;
 }
 
-void JoltPhysicsCapsuleShape3D::set_data(const Variant& p_data) {
+void JoltCapsuleShape3D::set_data(const Variant& p_data) {
 	const Dictionary dict = p_data;
 
 	const Variant maybe_height = dict.get("height", {});
@@ -44,14 +44,14 @@ void JoltPhysicsCapsuleShape3D::set_data(const Variant& p_data) {
 	jref = new JPH::CapsuleShape(height / 2.0f, radius);
 }
 
-Variant JoltPhysicsCylinderShape3D::get_data() const {
+Variant JoltCylinderShape3D::get_data() const {
 	Dictionary dict;
 	dict["height"] = height;
 	dict["radius"] = radius;
 	return dict;
 }
 
-void JoltPhysicsCylinderShape3D::set_data(const Variant& p_data) {
+void JoltCylinderShape3D::set_data(const Variant& p_data) {
 	const Dictionary dict = p_data;
 
 	const Variant maybe_height = dict.get("height", {});
@@ -66,17 +66,17 @@ void JoltPhysicsCylinderShape3D::set_data(const Variant& p_data) {
 	jref = new JPH::CylinderShape(height / 2.0f, radius);
 }
 
-Variant JoltPhysicsConvexPolygonShape3D::get_data() const {
+Variant JoltConvexPolygonShape3D::get_data() const {
 	return vertices;
 }
 
-void JoltPhysicsConvexPolygonShape3D::set_data(const Variant& p_data) {
+void JoltConvexPolygonShape3D::set_data(const Variant& p_data) {
 	ERR_FAIL_COND(p_data.get_type() != Variant::PACKED_VECTOR3_ARRAY);
 	vertices = p_data;
 	vertices_changed();
 }
 
-void JoltPhysicsConvexPolygonShape3D::vertices_changed() {
+void JoltConvexPolygonShape3D::vertices_changed() {
 	const int64_t num_vertices = vertices.size();
 	ERR_FAIL_COND(num_vertices == 0);
 

--- a/src/jolt_physics_shape_3d.hpp
+++ b/src/jolt_physics_shape_3d.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-class JoltPhysicsCollisionObject3D;
+class JoltCollisionObject3D;
 
-class JoltPhysicsShape3D {
+class JoltShape3D {
 public:
-	virtual ~JoltPhysicsShape3D() = 0;
+	virtual ~JoltShape3D() = 0;
 
 	RID get_rid() const { return rid; }
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
-	virtual JoltPhysicsCollisionObject3D* get_owner() const { return owner; }
+	virtual JoltCollisionObject3D* get_owner() const { return owner; }
 
-	virtual void set_owner(JoltPhysicsCollisionObject3D* p_owner) { owner = p_owner; }
+	virtual void set_owner(JoltCollisionObject3D* p_owner) { owner = p_owner; }
 
 	virtual Variant get_data() const = 0;
 
@@ -23,12 +23,12 @@ public:
 protected:
 	RID rid;
 
-	JoltPhysicsCollisionObject3D* owner = nullptr;
+	JoltCollisionObject3D* owner = nullptr;
 
 	JPH::Ref<JPH::Shape> jref;
 };
 
-class JoltPhysicsSphereShape3D final : public JoltPhysicsShape3D {
+class JoltSphereShape3D final : public JoltShape3D {
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -36,7 +36,7 @@ class JoltPhysicsSphereShape3D final : public JoltPhysicsShape3D {
 	float radius = 0.0f;
 };
 
-class JoltPhysicsBoxShape3D final : public JoltPhysicsShape3D {
+class JoltBoxShape3D final : public JoltShape3D {
 public:
 	Variant get_data() const override;
 
@@ -46,7 +46,7 @@ private:
 	Vector3 half_extents;
 };
 
-class JoltPhysicsCapsuleShape3D final : public JoltPhysicsShape3D {
+class JoltCapsuleShape3D final : public JoltShape3D {
 public:
 	Variant get_data() const override;
 
@@ -58,7 +58,7 @@ private:
 	float radius = 0.0f;
 };
 
-class JoltPhysicsCylinderShape3D final : public JoltPhysicsShape3D {
+class JoltCylinderShape3D final : public JoltShape3D {
 public:
 	Variant get_data() const override;
 
@@ -70,7 +70,7 @@ private:
 	float radius = 0.0f;
 };
 
-class JoltPhysicsConvexPolygonShape3D final : public JoltPhysicsShape3D {
+class JoltConvexPolygonShape3D final : public JoltShape3D {
 public:
 	Variant get_data() const override;
 

--- a/src/jolt_physics_space_3d.hpp
+++ b/src/jolt_physics_space_3d.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-class JoltPhysicsArea3D;
-class JoltPhysicsBody3D;
-class JoltPhysicsCollisionObject3D;
+class JoltArea3D;
+class JoltBody3D;
+class JoltCollisionObject3D;
 
-class JoltPhysicsSpace3D final {
+class JoltSpace3D final {
 public:
-	JoltPhysicsSpace3D(JPH::JobSystem* p_job_system, JPH::GroupFilter* p_group_filter);
+	JoltSpace3D(JPH::JobSystem* p_job_system, JPH::GroupFilter* p_group_filter);
 
-	~JoltPhysicsSpace3D();
+	~JoltSpace3D();
 
 	void step(float p_step);
 
@@ -32,21 +32,21 @@ public:
 
 	PhysicsDirectSpaceState3D* get_direct_state() const;
 
-	void set_default_area(JoltPhysicsArea3D* p_area) { area = p_area; }
+	void set_default_area(JoltArea3D* p_area) { area = p_area; }
 
-	JoltPhysicsArea3D* get_default_area() const { return area; }
+	JoltArea3D* get_default_area() const { return area; }
 
 	Variant get_param(PhysicsServer3D::AreaParameter p_param) const;
 
 	void set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value);
 
-	void create_object(JoltPhysicsCollisionObject3D* p_object);
+	void create_object(JoltCollisionObject3D* p_object);
 
-	void add_object(JoltPhysicsCollisionObject3D* p_object);
+	void add_object(JoltCollisionObject3D* p_object);
 
-	void remove_object(JoltPhysicsCollisionObject3D* p_object);
+	void remove_object(JoltCollisionObject3D* p_object);
 
-	void destroy_object(JoltPhysicsCollisionObject3D* p_object);
+	void destroy_object(JoltCollisionObject3D* p_object);
 
 private:
 	void update_gravity();
@@ -65,11 +65,11 @@ private:
 
 	PhysicsDirectSpaceState3D* direct_state = nullptr;
 
-	SelfList<JoltPhysicsBody3D>::List state_query_list;
+	SelfList<JoltBody3D>::List state_query_list;
 
-	SelfList<JoltPhysicsArea3D>::List monitor_query_list;
+	SelfList<JoltArea3D>::List monitor_query_list;
 
-	JoltPhysicsArea3D* area = nullptr;
+	JoltArea3D* area = nullptr;
 
 	Vector3 gravity_vector = Vector3(0, -1, 0);
 

--- a/src/jolt_physics_temp_allocator.hpp
+++ b/src/jolt_physics_temp_allocator.hpp
@@ -2,13 +2,13 @@
 
 #include "utility_functions.hpp"
 
-class JoltPhysicsTempAllocator final : public JPH::TempAllocator {
+class JoltTempAllocator final : public JPH::TempAllocator {
 public:
-	explicit JoltPhysicsTempAllocator(size_t p_capacity)
+	explicit JoltTempAllocator(size_t p_capacity)
 		: base(static_cast<uint8_t*>(JPH::Allocate(p_capacity)))
 		, capacity(p_capacity) { }
 
-	~JoltPhysicsTempAllocator() override { JPH::Free(base); }
+	~JoltTempAllocator() override { JPH::Free(base); }
 
 	void* Allocate(uint32_t p_size) override {
 		if (p_size == 0) {


### PR DESCRIPTION
This is the first of two PRs. The second one will rename the files to match their new class names.

I split them up in hopes of appeasing the Git rename heuristics and preserve as much file history as possible.