### PR TITLE
Improved error handling when creating shapes

### DIFF
--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -18,20 +18,25 @@ public:
 
 	virtual void set_data(const Variant& p_data) = 0;
 
-	JPH::Shape* get_jref() const { return jref; }
+	const JPH::Shape* get_jref() const { return jref; }
 
 protected:
+	virtual void clear_data();
+
 	RID rid;
 
 	JoltCollisionObject3D* owner = nullptr;
 
-	JPH::Ref<JPH::Shape> jref;
+	JPH::RefConst<JPH::Shape> jref;
 };
 
 class JoltSphereShape3D final : public JoltShape3D {
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+private:
+	void clear_data() override;
 
 	float radius = 0.0f;
 };
@@ -43,6 +48,8 @@ public:
 	void set_data(const Variant& p_data) override;
 
 private:
+	void clear_data() override;
+
 	Vector3 half_extents;
 };
 
@@ -53,6 +60,8 @@ public:
 	void set_data(const Variant& p_data) override;
 
 private:
+	void clear_data() override;
+
 	float height = 0.0f;
 
 	float radius = 0.0f;
@@ -65,6 +74,8 @@ public:
 	void set_data(const Variant& p_data) override;
 
 private:
+	void clear_data() override;
+
 	float height = 0.0f;
 
 	float radius = 0.0f;
@@ -77,7 +88,7 @@ public:
 	void set_data(const Variant& p_data) override;
 
 private:
-	void vertices_changed();
+	void clear_data() override;
 
 	PackedVector3Array vertices;
 };


### PR DESCRIPTION
Instead of relying on the shape constructors that use `JPH_ASSERT`, which does nothing outside of `*Debug` builds, we now make use of each respective `JPH::*ShapeSettings` class instead, which gives us a `JPH::Shape::ShapeResult` from which we can get an actual error message if an error occurred.

I also changed so we clear any old data first, and only store the new data once everything's succeeded, to ensure that we don't end up with stale data/shapes.