### PR TITLE
Refactored `JoltCollisionObject3D::Shape` into a proper class

### DIFF
--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -1,16 +1,12 @@
 #pragma once
 
+#include "jolt_shape_instance_3d.hpp"
+
 class JoltSpace3D;
 class JoltShape3D;
 
 class JoltCollisionObject3D {
 public:
-	struct Shape {
-		JoltShape3D* ref = nullptr;
-		bool disabled = false;
-		Transform3D transform;
-	};
-
 	virtual ~JoltCollisionObject3D() = 0;
 
 	RID get_rid() const { return rid; }
@@ -60,13 +56,15 @@ public:
 
 	void remove_shape(int p_index, bool p_lock = true);
 
-	const Vector<Shape>& get_shapes() const { return shapes; }
+	const Vector<JoltShapeInstance3D>& get_shapes() const { return shapes; }
 
 	int get_shape_count() const { return shapes.size(); }
 
 	int find_shape_index(JoltShape3D* p_shape);
 
 	void set_shape_transform(int64_t p_index, const Transform3D& p_transform, bool p_lock = true);
+
+	void set_shape_disabled(int64_t p_index, bool p_disabled, bool p_lock = true);
 
 	bool is_ray_pickable() const { return ray_pickable; }
 
@@ -119,7 +117,7 @@ protected:
 
 	uint32_t collision_mask = 1;
 
-	Vector<Shape> shapes;
+	Vector<JoltShapeInstance3D> shapes;
 
 	bool ray_pickable = false;
 

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -556,7 +556,10 @@ void JoltPhysicsServer3D::_body_set_shape_disabled(
 	[[maybe_unused]] int64_t p_shape_idx,
 	[[maybe_unused]] bool p_disabled
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
 void JoltPhysicsServer3D::_body_attach_object_instance_id(const RID& p_body, int64_t p_id) {

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+class JoltShape3D;
+
+class JoltShapeInstance3D {
+public:
+	JoltShapeInstance3D() = default;
+
+	JoltShapeInstance3D(JoltShape3D* p_shape, const Transform3D& p_transform, bool p_disabled)
+		: transform(p_transform)
+		, shape(p_shape)
+		, disabled(p_disabled) { }
+
+	JoltShape3D* get() const { return shape; }
+
+	const Transform3D& get_transform() const { return transform; }
+
+	void set_transform(const Transform3D& p_transform) { transform = p_transform; }
+
+	bool is_disabled() const { return disabled; }
+
+	bool is_enabled() const { return !disabled; }
+
+	void set_disabled(bool p_disabled) { disabled = p_disabled; }
+
+	JoltShape3D* operator->() const { return shape; }
+
+	JoltShape3D& operator*() const { return *shape; }
+
+	explicit operator JoltShape3D*() const { return shape; }
+
+	bool operator==(const JoltShapeInstance3D& p_other) { return shape == p_other.shape; }
+
+	friend bool operator==(const JoltShapeInstance3D& p_lhs, JoltShape3D* p_rhs) {
+		return p_lhs.shape == p_rhs;
+	}
+
+	friend bool operator==(JoltShape3D* p_lhs, const JoltShapeInstance3D& p_rhs) {
+		return p_lhs == p_rhs.shape;
+	}
+
+private:
+	Transform3D transform;
+
+	JoltShape3D* shape = nullptr;
+
+	bool disabled = false;
+};

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -140,11 +140,11 @@ void JoltSpace3D::create_object(JoltCollisionObject3D* p_object) {
 
 	JPH::Ref compound_shape = new JPH::MutableCompoundShapeSettings();
 
-	for (const JoltCollisionObject3D::Shape& shape : p_object->get_shapes()) {
+	for (const JoltShapeInstance3D& shape : p_object->get_shapes()) {
 		compound_shape->AddShape(
-			to_jolt(shape.transform.origin),
-			to_jolt(shape.transform.basis),
-			shape.ref->get_jref()
+			to_jolt(shape.get_transform().origin),
+			to_jolt(shape.get_transform().basis),
+			shape->get_jref()
 		);
 	}
 


### PR DESCRIPTION
This is in preparation for a bigger refactoring of how shapes are constructed, as mentioned in #56.

This PR turns `JoltCollisionObject3D::Shape` into something resembling a smart pointer, that can use `foo->some_shape_member` to access its underlying shape, or access its instance-specific state using `foo.some_instance_member`.

This PR also fixes a subtle bug where `set_shape_transform` was mistakenly manipulating a copy of `JoltCollisionObject3D::Shape`, leading to nothing being changed at all. The solution was to use `VectorWriteProxy`, through `Vector::write`, in order to grab a mutable reference to the element.

This PR also implements the ability to set the "Disabled" property of a collision shape at runtime, although it doesn't do anything at the moment.