### PR TITLE
Disabled LTO for x86 clang-cl CI builds

### DIFF
--- a/.github/actions/build-with-cmake/action.yml
+++ b/.github/actions/build-with-cmake/action.yml
@@ -9,6 +9,8 @@ inputs:
     required: true
   config:
     required: true
+  args:
+    default: ''
 
 runs:
   using: composite
@@ -35,6 +37,7 @@ runs:
         --warn-uninitialized
         -Werror=dev
         --preset ${{ env.GDJOLT_CONFIGURE_PRESET }}
+        ${{ inputs.args }}
 
     - shell: pwsh
       run: >

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,6 +23,11 @@ jobs:
         config: [debug, development, distribution]
         version: [17]
 
+        include:
+          - platform: windows-clangcl
+            arch: x86
+            args: -DGDJOLT_LTO=FALSE
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -40,3 +45,4 @@ jobs:
           arch: ${{ matrix.arch }}
           editor: ${{ matrix.editor }}
           config: ${{ matrix.config }}
+          args: ${{ matrix.args }}


### PR DESCRIPTION
This solution is not ideal, but I keep seeing x86 clang-cl builds failing from what looks like it being out of memory.

This stems from Visual Studio only shipping two editions of LLVM, one for x86 and for x64, instead of the four editions it ships of Visual C++, where you have one pair for each host architecture. This means that x86 clang-cl builds are currently being compiled with a 32-bit compiler/linker, which seem to hit their memory ceiling at random times.

LTO has historically been a real memory hog, so I'm hoping this will give me some breathing room until I can fix this in some other way.

The proper solution will most likely be to make a [CMake toolchain file](https://cmake.org/cmake/help/v3.22/manual/cmake-toolchains.7.html) for clang-cl on Windows, which should let me bypass CMake's [scanning of output binaries](https://github.com/Kitware/CMake/blob/6db3519c41e8d58401607be1020a9d4aab645c39/Modules/CMakeDetermineCompilerId.cmake#L892-L894) and effectively cross-compile x86-on-x64. This would also let us use the official release of LLVM, instead of having to rely on the (seemingly custom) Microsoft-provided one, which should help shorten `scripts/ci_setup_windows.ps1` a fair bit.