### PR TITLE
Updated godot-cpp to 4.0-beta8

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT ebfed62e9ce920a8d6e8fd8e6d93906b06784b27
+	GIT_COMMIT 9fa1326f76e3a2f265b1f26352c59fd74181c194
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@ebfed62e9ce920a8d6e8fd8e6d93906b06784b27 aka `4.0-beta7` to godot-jolt/godot-cpp@9fa1326f76e3a2f265b1f26352c59fd74181c194 aka `4.0-beta8` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/ebfed62e9ce920a8d6e8fd8e6d93906b06784b27...9fa1326f76e3a2f265b1f26352c59fd74181c194)).