### PR TITLE
Updated Jolt to ea157155bb

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -29,7 +29,7 @@ set(dev_definitions
 
 GodotJoltExternalLibrary_Add(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 4fdbb72c08c652b1bc6a7c059840eda33852c165
+	GIT_COMMIT ea157155bb979e8772cd29bd1d2824a828e300b6
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@4fdbb72c08c652b1bc6a7c059840eda33852c165 to godot-jolt/jolt@ea157155bb979e8772cd29bd1d2824a828e300b6 (see diff [here](https://github.com/godot-jolt/jolt/compare/4fdbb72c08c652b1bc6a7c059840eda33852c165...ea157155bb979e8772cd29bd1d2824a828e300b6)).

This brings in the new `ScaledShapeSettings` constructor that takes a concrete shape.