### PR TITLE
Added CMake option for precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include(GodotJoltExternalFmt)
 include(GodotJoltExternalMimalloc)
 
 set(source_dir ${CMAKE_CURRENT_LIST_DIR}/src)
+set(pch_file ${source_dir}/pch.hpp)
 
 file(GLOB_RECURSE godot-jolt_SOURCES CONFIGURE_DEPENDS ${source_dir}/*.cpp)
 file(GLOB_RECURSE godot-jolt_HEADERS CONFIGURE_DEPENDS ${source_dir}/*.hpp)
@@ -30,8 +31,6 @@ target_link_libraries(godot-jolt
 	godot-jolt::fmt
 	godot-jolt::mimalloc
 )
-
-target_precompile_headers(godot-jolt PRIVATE ${source_dir}/pch.hpp)
 
 set(is_editor_config $<CONFIG:EditorDebug,EditorDevelopment,EditorDistribution>)
 set(is_debug_config $<CONFIG:Debug,EditorDebug>)
@@ -102,6 +101,16 @@ target_compile_features(godot-jolt
 target_compile_definitions(godot-jolt
 	PRIVATE $<IF:${is_debug_config},_DEBUG,NDEBUG>
 )
+
+if(GDJOLT_PRECOMPILE_HEADERS)
+	target_precompile_headers(godot-jolt PRIVATE ${pch_file})
+else()
+	if(MSVC)
+		target_compile_options(godot-jolt PRIVATE /FI${pch_file})
+	else()
+		target_compile_options(godot-jolt PRIVATE "-include${pch_file}")
+	endif()
+endif()
 
 if(MSVC)
 	set(pdb_file $<TARGET_PDB_FILE:godot-jolt>)

--- a/cmake/GodotJoltOptions.cmake
+++ b/cmake/GodotJoltOptions.cmake
@@ -19,6 +19,11 @@ set(GDJOLT_LTO TRUE
 	"Enable link-time optimizations for any optimized builds."
 )
 
+set(GDJOLT_PRECOMPILE_HEADERS TRUE
+	CACHE BOOL
+	"Precompile header files that don't change often, like external ones."
+)
+
 if(NOT APPLE)
 	set(GDJOLT_X86_INSTRUCTION_SET SSE2
 		CACHE STRING

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -39,6 +39,11 @@ defaults by passing `-DGDJOLT_SOME_VARIABLE=VALUE` to CMake.
 - `GDJOLT_LTO`
   - Enables link-time optimizations for optimized builds, also called link-time code generation.
   - Default is `TRUE`.
+- `GDJOLT_PRECOMPILE_HEADERS`
+  - Enables precompiling of header files that don't change often, like external ones, which speeds
+    up compilations.
+  - Disabling this will make it so any precompiled headers gets force-included instead.
+  - Default is `TRUE`.
 - `GDJOLT_STATIC_RUNTIME_LIBRARY`
   - Whether to statically link against the platform-specific C++ runtime, for added portability.
   - ⚠️ This flag is not available on Apple platforms.


### PR DESCRIPTION
This is to allow disabling the precompiling of headers for clang-tidy runs, so we don't have to build every single configuration, or any configuration for that matter, before running it.

It might also be useful in other cases where you need a `compile_commands.json` that doesn't use any precompiled headers.