### PR TITLE
Split `build-with-cmake` into separate configure/build actions

### DIFF
--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -9,12 +9,13 @@ inputs:
     required: true
   config:
     required: true
-  args:
-    default: ''
 
 runs:
   using: composite
   steps:
+    - shell: pwsh
+      run: cmake --version
+
     - shell: pwsh
       run: |
         $Platform = "${{ inputs.platform }}"
@@ -24,24 +25,7 @@ runs:
         $ConfigurePreset = "$Platform$Arch"
         $BuildPreset = "$ConfigurePreset$Editor$BuildConfig"
 
-        "GDJOLT_CONFIGURE_PRESET=$ConfigurePreset" >> $env:GITHUB_ENV
-        "GDJOLT_BUILD_PRESET=$BuildPreset" >> $env:GITHUB_ENV
-
-    - shell: pwsh
-      run: cmake --version
-
-    - shell: pwsh
-      run: >
-        cmake
-        --log-level=VERBOSE
-        --warn-uninitialized
-        -Werror=dev
-        --preset ${{ env.GDJOLT_CONFIGURE_PRESET }}
-        ${{ inputs.args }}
-
-    - shell: pwsh
-      run: >
-        cmake
-        --build
-        --verbose
-        --preset ${{ env.GDJOLT_BUILD_PRESET }}
+        cmake `
+          --build `
+          --verbose `
+          --preset $BuildPreset

--- a/.github/actions/cmake-configure/action.yml
+++ b/.github/actions/cmake-configure/action.yml
@@ -1,0 +1,28 @@
+name: Configure with CMake
+
+inputs:
+  platform:
+    required: true
+  arch:
+    default: null
+  args:
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      run: cmake --version
+
+    - shell: pwsh
+      run: |
+        $Platform = "${{ inputs.platform }}"
+        $Arch = "${{ inputs.arch != null && format('-{0}', inputs.arch) || '' }}"
+        $ConfigurePreset = "$Platform$Arch"
+
+        cmake `
+          --log-level=VERBOSE `
+          --warn-uninitialized `
+          -Werror=dev `
+          --preset $ConfigurePreset `
+          ${{ inputs.args }}

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -47,8 +47,14 @@ jobs:
           toolchain: llvm
           version: 14
 
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: linux-clang
+          arch: ${{ matrix.arch }}
+
       - name: Build 'Debug' configuration
-        uses: ./.github/actions/build-with-cmake
+        uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
@@ -56,7 +62,7 @@ jobs:
           config: debug
 
       - name: Build 'Development' configuration
-        uses: ./.github/actions/build-with-cmake
+        uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
@@ -64,7 +70,7 @@ jobs:
           config: development
 
       - name: Build 'Distribution' configuration
-        uses: ./.github/actions/build-with-cmake
+        uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
@@ -72,7 +78,7 @@ jobs:
           config: distribution
 
       - name: Build 'EditorDebug' configuration
-        uses: ./.github/actions/build-with-cmake
+        uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
@@ -80,7 +86,7 @@ jobs:
           config: debug
 
       - name: Build 'EditorDevelopment' configuration
-        uses: ./.github/actions/build-with-cmake
+        uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
@@ -88,7 +94,7 @@ jobs:
           config: development
 
       - name: Build 'EditorDistribution' configuration
-        uses: ./.github/actions/build-with-cmake
+        uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -40,8 +40,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           version: ${{ matrix.version }}
 
-      - name: Configure and build
-        uses: ./.github/actions/build-with-cmake
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+
+      - name: Build
+        uses: ./.github/actions/cmake-build
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,8 +30,14 @@ jobs:
         with:
           version: ${{ matrix.version }}
 
-      - name: Configure and build
-        uses: ./.github/actions/build-with-cmake
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: ${{ matrix.platform }}
+          editor: ${{ matrix.editor }}
+
+      - name: Build
+        uses: ./.github/actions/cmake-build
         with:
           platform: ${{ matrix.platform }}
           editor: ${{ matrix.editor }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,11 +38,17 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
 
-      - name: Configure and build
-        uses: ./.github/actions/build-with-cmake
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          args: ${{ matrix.args }}
+
+      - name: Build
+        uses: ./.github/actions/cmake-build
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
           editor: ${{ matrix.editor }}
           config: ${{ matrix.config }}
-          args: ${{ matrix.args }}


### PR DESCRIPTION
This is to allow CI runs of clang-tidy to run only configure, in order to produce `compile_commands.json`, and not do any building, which we don't need to do now that we can disable precompiled headers (#83).