### PR TITLE
Removed most builds from clang-tidy CI workflow

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -52,54 +52,15 @@ jobs:
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
+          args: -DGDJOLT_PRECOMPILE_HEADERS=FALSE
 
-      - name: Build 'Debug' configuration
+      - name: Build
         uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
           editor: false
           config: debug
-
-      - name: Build 'Development' configuration
-        uses: ./.github/actions/cmake-build
-        with:
-          platform: linux-clang
-          arch: ${{ matrix.arch }}
-          editor: false
-          config: development
-
-      - name: Build 'Distribution' configuration
-        uses: ./.github/actions/cmake-build
-        with:
-          platform: linux-clang
-          arch: ${{ matrix.arch }}
-          editor: false
-          config: distribution
-
-      - name: Build 'EditorDebug' configuration
-        uses: ./.github/actions/cmake-build
-        with:
-          platform: linux-clang
-          arch: ${{ matrix.arch }}
-          editor: true
-          config: debug
-
-      - name: Build 'EditorDevelopment' configuration
-        uses: ./.github/actions/cmake-build
-        with:
-          platform: linux-clang
-          arch: ${{ matrix.arch }}
-          editor: true
-          config: development
-
-      - name: Build 'EditorDistribution' configuration
-        uses: ./.github/actions/cmake-build
-        with:
-          platform: linux-clang
-          arch: ${{ matrix.arch }}
-          editor: true
-          config: distribution
 
       - name: Identify clang-tidy
         shell: pwsh


### PR DESCRIPTION
Now that we can disable precompiled headers (#83), we can finally remove all but one of the builds from clang-tidy runs and hopefully shorten the time they take by a significant amount.

We still need one build because it downloads our external projects for us. It also runs any necessary code generation, like the bindings generation in godot-cpp.