### PR TITLE
Added missing godot-cpp definitions for `EditorDevelopment`

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -30,6 +30,8 @@ GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 		$<${is_msvc_like}:TYPED_METHOD_BIND>
 	COMPILE_DEFINITIONS_EDITORDEBUG
 		${editor_definitions}
+	COMPILE_DEFINITIONS_EDITORDEVELOPMENT
+		${editor_definitions}
 	COMPILE_DEFINITIONS_EDITORDISTRIBUTION
 		${editor_definitions}
 	CMAKE_CACHE_ARGS


### PR DESCRIPTION
This adds the editor (what Godot calls "debug") definitions `DEBUG_ENABLED`, `DEBUG_METHODS_ENABLED`, and `TOOLS_ENABLED` to the `EditorDevelopment` configuration.

Not sure how I missed this one, nor how this configuration ever worked before this. I can only assume that godot-cpp doesn't alter its interface based on any of these definitions.