### PR TITLE
Updated godot-cpp to 4.0-beta9

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -128,7 +128,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".+"$'
     Priority: 1
-  - Regex: '^<godot/.+>$'
+  - Regex: '^<gdextension_interface.h>$'
     Priority: 2
   - Regex: '^<godot_cpp/.+>$'
     Priority: 3

--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,11 +19,11 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 9fa1326f76e3a2f265b1f26352c59fd74181c194
+	GIT_COMMIT 0ac46329ca44f6c864489196c97a441f873b9ffd
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES
-		<SOURCE_DIR>/godot-headers
+		<SOURCE_DIR>/gdextension
 		<SOURCE_DIR>/include
 		<BINARY_DIR>/gen/include
 	COMPILE_DEFINITIONS

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -10,7 +10,7 @@
 #pragma warning(disable : 4245 4365)
 #endif // _MSC_VER
 
-#include <godot/gdnative_interface.h>
+#include <gdextension_interface.h>
 
 #include <godot_cpp/classes/object.hpp>
 #include <godot_cpp/classes/physics_direct_body_state3d_extension.hpp>

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -42,12 +42,12 @@ void on_terminate(ModuleInitializationLevel p_level) {
 
 extern "C" {
 
-GDNativeBool GDN_EXPORT godot_jolt_main(
-	GDNativeInterface* p_native_iface,
-	GDNativeExtensionClassLibraryPtr p_native_lib,
-	GDNativeInitialization* p_native_init
+GDExtensionBool GDE_EXPORT godot_jolt_main(
+	GDExtensionInterface* p_interface,
+	GDExtensionClassLibraryPtr p_class_library,
+	GDExtensionInitialization* p_initialization
 ) {
-	const GDExtensionBinding::InitObject init_obj(p_native_iface, p_native_lib, p_native_init);
+	const GDExtensionBinding::InitObject init_obj(p_interface, p_class_library, p_initialization);
 
 	init_obj.register_initializer(&on_initialize);
 	init_obj.register_terminator(&on_terminate);


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@9fa1326f76e3a2f265b1f26352c59fd74181c194 aka `4.0-beta8` to godot-jolt/godot-cpp@0ac46329ca44f6c864489196c97a441f873b9ffd aka `4.0-beta9` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/9fa1326f76e3a2f265b1f26352c59fd74181c194...0ac46329ca44f6c864489196c97a441f873b9ffd)).