### PR TITLE
Added support for pin joints

### DIFF
--- a/src/jolt_joint_3d.cpp
+++ b/src/jolt_joint_3d.cpp
@@ -1,0 +1,135 @@
+#include "jolt_joint_3d.hpp"
+
+#include "conversion.hpp"
+#include "error_macros.hpp"
+#include "jolt_body_3d.hpp"
+#include "jolt_body_access_3d.hpp"
+#include "utility_functions.hpp"
+#include "variant.hpp"
+
+constexpr int64_t GDJOLT_JOINT_DEFAULT_SOLVER_PRIORITY = 1;
+constexpr double GDJOLT_PIN_JOINT_DEFAULT_BIAS = 0.3;
+constexpr double GDJOLT_PIN_JOINT_DEFAULT_DAMPING = 1.0;
+constexpr double GDJOLT_PIN_JOINT_DEFAULT_IMPULSE_CLAMP = 0.0;
+
+JoltJoint3D::JoltJoint3D(JoltSpace3D* p_space)
+	: space(p_space) { }
+
+JoltJoint3D::~JoltJoint3D() {
+	if (jolt_ref != nullptr) {
+		space->remove_joint(this);
+	}
+}
+
+int64_t JoltJoint3D::get_solver_priority() const {
+	return GDJOLT_JOINT_DEFAULT_SOLVER_PRIORITY;
+}
+
+void JoltJoint3D::set_solver_priority(int64_t p_priority) {
+	if (p_priority != GDJOLT_JOINT_DEFAULT_SOLVER_PRIORITY) {
+		WARN_PRINT(
+			"Joint solver priority is not supported by Godot Jolt. "
+			"Any such value will be ignored."
+		);
+	}
+}
+
+JoltPinJoint3D::JoltPinJoint3D(
+	JoltSpace3D* p_space,
+	const JoltBody3D* p_body_a,
+	const JoltBody3D* p_body_b,
+	const Vector3& p_local_a,
+	const Vector3& p_local_b,
+	bool p_lock
+)
+	: JoltJoint3D(p_space)
+	, local_a(p_local_a)
+	, local_b(p_local_b) {
+	if (p_body_b != nullptr) {
+		const JPH::BodyID body_ids[] = {p_body_a->get_jolt_id(), p_body_b->get_jolt_id()};
+
+		const JoltMultiBodyAccessWrite3D
+			body_access(*p_space, body_ids, count_of(body_ids), p_lock);
+
+		JPH::Body* jolt_body_a = body_access.get_body(0);
+		ERR_FAIL_NULL(jolt_body_a);
+
+		JPH::Body* jolt_body_b = body_access.get_body(1);
+		ERR_FAIL_NULL(jolt_body_b);
+
+		const JPH::Mat44 world_transform_a = jolt_body_a->GetWorldTransform();
+		const JPH::Mat44 world_transform_b = jolt_body_b->GetWorldTransform();
+
+		JPH::PointConstraintSettings constraint_settings;
+		constraint_settings.mSpace = JPH::EConstraintSpace::WorldSpace;
+		constraint_settings.mPoint1 = world_transform_a * to_jolt(p_local_a);
+		constraint_settings.mPoint2 = world_transform_b * to_jolt(p_local_b);
+
+		jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
+	} else {
+		const JoltBodyAccessWrite3D body_access(*p_space, p_body_a->get_jolt_id(), p_lock);
+		ERR_FAIL_COND(!body_access.is_valid());
+
+		JPH::Body& jolt_body_a = body_access.get_body();
+
+		const JPH::Mat44 world_transform_a = jolt_body_a.GetWorldTransform();
+
+		JPH::PointConstraintSettings constraint_settings;
+		constraint_settings.mSpace = JPH::EConstraintSpace::WorldSpace;
+		constraint_settings.mPoint1 = world_transform_a * to_jolt(p_local_a);
+		constraint_settings.mPoint2 = to_jolt(p_local_b);
+
+		jolt_ref = constraint_settings.Create(jolt_body_a, JPH::Body::sFixedToWorld);
+	}
+
+	p_space->add_joint(this);
+}
+
+double JoltPinJoint3D::get_param(PhysicsServer3D::PinJointParam p_param) {
+	switch (p_param) {
+		case PhysicsServer3D::PIN_JOINT_BIAS: {
+			return GDJOLT_PIN_JOINT_DEFAULT_BIAS;
+		}
+		case PhysicsServer3D::PIN_JOINT_DAMPING: {
+			return GDJOLT_PIN_JOINT_DEFAULT_DAMPING;
+		}
+		case PhysicsServer3D::PIN_JOINT_IMPULSE_CLAMP: {
+			return GDJOLT_PIN_JOINT_DEFAULT_IMPULSE_CLAMP;
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled pin joint parameter: '{}'", p_param));
+		}
+	}
+}
+
+void JoltPinJoint3D::set_param(PhysicsServer3D::PinJointParam p_param, double p_value) {
+	switch (p_param) {
+		case PhysicsServer3D::PIN_JOINT_BIAS: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_PIN_JOINT_DEFAULT_BIAS)) {
+				WARN_PRINT(
+					"Pin joint bias is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		case PhysicsServer3D::PIN_JOINT_DAMPING: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_PIN_JOINT_DEFAULT_DAMPING)) {
+				WARN_PRINT(
+					"Pin joint damping is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		case PhysicsServer3D::PIN_JOINT_IMPULSE_CLAMP: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_PIN_JOINT_DEFAULT_IMPULSE_CLAMP)) {
+				WARN_PRINT(
+					"Pin joint impulse clamp is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled pin joint parameter: '{}'", p_param));
+		} break;
+	}
+}

--- a/src/jolt_joint_3d.hpp
+++ b/src/jolt_joint_3d.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+class JoltBody3D;
+class JoltSpace3D;
+
+class JoltJoint3D {
+public:
+	JoltJoint3D() = default;
+
+	explicit JoltJoint3D(JoltSpace3D* p_space);
+
+	virtual ~JoltJoint3D();
+
+	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_TYPE_MAX; }
+
+	RID get_rid() const { return rid; }
+
+	void set_rid(const RID& p_rid) { rid = p_rid; }
+
+	JoltSpace3D* get_space() const { return space; }
+
+	JPH::Constraint* get_jolt_ref() const { return jolt_ref; }
+
+	int64_t get_solver_priority() const;
+
+	void set_solver_priority(int64_t p_priority);
+
+protected:
+	RID rid;
+
+	JoltSpace3D* space = nullptr;
+
+	JPH::Ref<JPH::Constraint> jolt_ref;
+};
+
+class JoltPinJoint3D final : public JoltJoint3D {
+public:
+	JoltPinJoint3D(
+		JoltSpace3D* p_space,
+		const JoltBody3D* p_body_a,
+		const JoltBody3D* p_body_b,
+		const Vector3& p_local_a,
+		const Vector3& p_local_b,
+		bool p_lock = true
+	);
+
+	PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_PIN; }
+
+	double get_param(PhysicsServer3D::PinJointParam p_param);
+
+	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
+
+	const JoltBody3D* get_body_a() const { return body_a; }
+
+	const JoltBody3D* get_body_b() const { return body_b; }
+
+	Vector3 get_local_a() const { return local_a; }
+
+	Vector3 get_local_b() const { return local_b; }
+
+	JoltPinJoint3D* with_local_a(const Vector3& p_local_a, bool p_lock = true) const {
+		return memnew(JoltPinJoint3D(space, body_a, body_b, p_local_a, local_b, p_lock));
+	}
+
+	JoltPinJoint3D* with_local_b(const Vector3& p_local_b, bool p_lock = true) const {
+		return memnew(JoltPinJoint3D(space, body_a, body_b, local_a, p_local_b, p_lock));
+	}
+
+private:
+	const JoltBody3D* body_a = nullptr;
+
+	const JoltBody3D* body_b = nullptr;
+
+	Vector3 local_a;
+
+	Vector3 local_b;
+};

--- a/src/jolt_physics_server_3d.hpp
+++ b/src/jolt_physics_server_3d.hpp
@@ -2,6 +2,7 @@
 
 class JoltArea3D;
 class JoltBody3D;
+class JoltJoint3D;
 class JoltShape3D;
 class JoltSpace3D;
 
@@ -564,4 +565,6 @@ private:
 	mutable RID_PtrOwner<JoltArea3D> area_owner;
 
 	mutable RID_PtrOwner<JoltShape3D> shape_owner;
+
+	mutable RID_PtrOwner<JoltJoint3D> joint_owner;
 };

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -4,6 +4,7 @@
 #include "error_macros.hpp"
 #include "jolt_broad_phase_layer.hpp"
 #include "jolt_collision_object_3d.hpp"
+#include "jolt_joint_3d.hpp"
 #include "jolt_layer_mapper.hpp"
 #include "jolt_object_layer.hpp"
 #include "jolt_shape_3d.hpp"
@@ -216,6 +217,14 @@ void JoltSpace3D::remove_object(JoltCollisionObject3D* p_object) {
 void JoltSpace3D::destroy_object(JoltCollisionObject3D* p_object) {
 	physics_system->GetBodyInterface().DestroyBody(p_object->get_jolt_id());
 	p_object->set_jolt_id({});
+}
+
+void JoltSpace3D::add_joint(JoltJoint3D* p_joint) {
+	physics_system->AddConstraint(p_joint->get_jolt_ref());
+}
+
+void JoltSpace3D::remove_joint(JoltJoint3D* p_joint) {
+	physics_system->RemoveConstraint(p_joint->get_jolt_ref());
 }
 
 void JoltSpace3D::update_gravity() {

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -3,6 +3,7 @@
 class JoltArea3D;
 class JoltBody3D;
 class JoltCollisionObject3D;
+class JoltJoint3D;
 
 class JoltSpace3D final {
 public:
@@ -47,6 +48,10 @@ public:
 	void remove_object(JoltCollisionObject3D* p_object);
 
 	void destroy_object(JoltCollisionObject3D* p_object);
+
+	void add_joint(JoltJoint3D* p_joint);
+
+	void remove_joint(JoltJoint3D* p_joint);
 
 private:
 	void update_gravity();

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -62,6 +62,7 @@
 #include <Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h>
 #include <Jolt/Physics/Collision/Shape/ScaledShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/Constraints/PointConstraint.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 #include <Jolt/RegisterTypes.h>
 

--- a/src/utility_functions.hpp
+++ b/src/utility_functions.hpp
@@ -32,3 +32,8 @@ template<typename TValue>
 constexpr bool is_power_of_2(TValue p_value) {
 	return (p_value & (p_value - 1)) == 0;
 }
+
+template<typename TElement, int TSize>
+constexpr int count_of([[maybe_unused]] TElement (&p_array)[TSize]) {
+	return TSize;
+}


### PR DESCRIPTION
Related to #106.

This adds preliminary support for the `PinJoint3D` node type.

Note that Jolt does not seem to support any of the parameters that `PinJoint3D` offers, like bias, damping and impulse clamping.

It will also currently emit some errors saying:

```
Required virtual method JoltPhysicsServer3D::_joint_disable_collisions_between_bodies must be overridden before calling.
```

... which is due to some bindings being left out on the engine side of things. This also means that it's impossible to implement the "Exclude Nodes From Collision" property right now.

I created a PR to resolve the error, godotengine/godot#70477, which was thankfully merged very quickly.