### PR TITLE
Renamed registered physics server to `JoltPhysics3D`

### DIFF
--- a/examples/project.godot
+++ b/examples/project.godot
@@ -21,7 +21,7 @@ window/size/viewport_height=900
 
 [physics]
 
-3d/physics_engine="Jolt"
+3d/physics_engine="JoltPhysics3D"
 
 [rendering]
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -22,7 +22,7 @@ void on_initialize(ModuleInitializationLevel p_level) {
 	}
 
 	PhysicsServer3DManager::get_singleton()->register_server(
-		"Jolt",
+		"JoltPhysics3D",
 		Callable(server_factory, "create_server")
 	);
 }


### PR DESCRIPTION
I figured this lines up better with Godot's `GodotPhysics3D`.