### PR TITLE
Fixed bookkeeping of shapes-to-objects and vice versa

### DIFF
--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -231,7 +231,7 @@ void JoltCollisionObject3D::add_shape(
 	bool p_lock
 ) {
 	shapes.push_back({p_shape, p_transform, p_disabled});
-	p_shape->set_owner(this);
+	p_shape->add_owner(this);
 	rebuild_shape(p_lock);
 }
 
@@ -245,8 +245,19 @@ void JoltCollisionObject3D::remove_shape(JoltShape3D* p_shape, bool p_lock) {
 void JoltCollisionObject3D::remove_shape(int32_t p_index, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
-	shapes[p_index]->set_owner(nullptr);
+	shapes[p_index]->remove_owner(this);
 	shapes.remove_at(p_index);
+	rebuild_shape(p_lock);
+}
+
+void JoltCollisionObject3D::remove_shapes(bool p_lock) {
+	const int shape_count = shapes.size();
+
+	for (int i = shape_count - 1; i >= 0; --i) {
+		shapes[i]->remove_owner(this);
+		shapes.remove_at(i);
+	}
+
 	rebuild_shape(p_lock);
 }
 

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -60,6 +60,8 @@ public:
 
 	void remove_shape(int32_t p_index, bool p_lock = true);
 
+	void remove_shapes(bool p_lock = true);
+
 	const Vector<JoltShapeInstance3D>& get_shapes() const { return shapes; }
 
 	int32_t get_shape_count() const { return shapes.size(); }

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -1424,22 +1424,13 @@ int64_t JoltPhysicsServer3D::_joint_get_solver_priority(const RID& p_joint) cons
 void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 	if (shape_owner.owns(p_rid)) {
 		JoltShape3D* shape = shape_owner.get_or_null(p_rid);
-
-		if (JoltCollisionObject3D* owner = shape->get_owner()) {
-			owner->remove_shape(shape);
-		}
-
+		shape->remove_self();
 		shape_owner.free(p_rid);
 		memdelete(shape);
 	} else if (body_owner.owns(p_rid)) {
 		JoltBody3D* body = body_owner.get_or_null(p_rid);
-
 		body->set_space(nullptr);
-
-		while (body->get_shape_count() > 0) {
-			body->remove_shape(0);
-		}
-
+		body->remove_shapes();
 		body_owner.free(p_rid);
 		memdelete(body);
 	} else if (joint_owner.owns(p_rid)) {
@@ -1449,6 +1440,7 @@ void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 	} else if (area_owner.owns(p_rid)) {
 		JoltArea3D* area = area_owner.get_or_null(p_rid);
 		area->set_space(nullptr);
+		area->remove_shapes();
 		area_owner.free(p_rid);
 		memdelete(area);
 	} else if (space_owner.owns(p_rid)) {

--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -2,10 +2,32 @@
 
 #include "conversion.hpp"
 #include "error_macros.hpp"
+#include "jolt_collision_object_3d.hpp"
 #include "utility_functions.hpp"
 #include "variant.hpp"
 
 JoltShape3D::~JoltShape3D() = default;
+
+void JoltShape3D::add_owner(JoltCollisionObject3D* p_owner) {
+	ref_count_by_owner[p_owner]++;
+}
+
+void JoltShape3D::remove_owner(JoltCollisionObject3D* p_owner) {
+	if (--ref_count_by_owner[p_owner] <= 0) {
+		ref_count_by_owner.erase(p_owner);
+	}
+}
+
+void JoltShape3D::remove_self(bool p_lock) {
+	// TODO(mihe): Is this necessary? Are iterators invalidated when erasing?
+	const auto ref_count_by_owner_copy = ref_count_by_owner;
+
+	for (const auto& [owner, ref_count] : ref_count_by_owner_copy) {
+		for (int i = 0; i < ref_count; ++i) {
+			owner->remove_shape(this, p_lock);
+		}
+	}
+}
 
 JPH::ShapeRefC JoltShape3D::with_scale(
 	[[maybe_unused]] const JPH::ShapeRefC& p_shape,

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -10,9 +10,11 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
-	virtual JoltCollisionObject3D* get_owner() const { return owner; }
+	void add_owner(JoltCollisionObject3D* p_owner);
 
-	virtual void set_owner(JoltCollisionObject3D* p_owner) { owner = p_owner; }
+	void remove_owner(JoltCollisionObject3D* p_owner);
+
+	void remove_self(bool p_lock = true);
 
 	virtual Variant get_data() const = 0;
 
@@ -48,9 +50,9 @@ public:
 protected:
 	RID rid;
 
-	JoltCollisionObject3D* owner = nullptr;
-
 	JPH::ShapeRefC jolt_ref;
+
+	HashMap<JoltCollisionObject3D*, int> ref_count_by_owner;
 };
 
 class JoltSphereShape3D final : public JoltShape3D {

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -25,6 +25,7 @@
 #include <godot_cpp/core/math.hpp>
 #include <godot_cpp/core/memory.hpp>
 #include <godot_cpp/core/object.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/rid_owner.hpp>
 #include <godot_cpp/templates/vector.hpp>


### PR DESCRIPTION
Previously shapes had the notion of a singular owner/object. This was incorrect, since there can be multiple instances of the same shape across multiple owners/objects.

This PR addresses that by adding support for multiple owners per shape, bringing it in line with the Godot Physics equivalent.

This PR also refactors the way shapes are removed when an object is freed, which is mostly cosmetic.