### PR TITLE
Refactored shapes to be instantiated when objects are

### DIFF
--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -20,9 +20,9 @@ public:
 
 	virtual void set_data(const Variant& p_data) = 0;
 
-	const JPH::ShapeRefC& get_jolt_ref() const { return jolt_ref; }
+	virtual bool is_valid() const = 0;
 
-	bool is_valid() const { return jolt_ref != nullptr; }
+	virtual JPH::ShapeRefC try_build(uint64_t p_user_data) const = 0;
 
 	static JPH::ShapeRefC with_scale(const JPH::ShapeRefC& p_shape, const Vector3& p_scale);
 
@@ -50,8 +50,6 @@ public:
 protected:
 	RID rid;
 
-	JPH::ShapeRefC jolt_ref;
-
 	HashMap<JoltCollisionObject3D*, int> ref_count_by_owner;
 };
 
@@ -59,6 +57,10 @@ class JoltSphereShape3D final : public JoltShape3D {
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	bool is_valid() const override { return radius > 0; }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
 
 private:
 	void clear_data();
@@ -72,6 +74,10 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	bool is_valid() const override { return half_extents.x > 0; }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+
 private:
 	void clear_data();
 
@@ -83,6 +89,10 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	bool is_valid() const override { return radius > 0; }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
 
 private:
 	void clear_data();
@@ -98,6 +108,10 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	bool is_valid() const override { return radius > 0; }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+
 private:
 	void clear_data();
 
@@ -112,6 +126,10 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	bool is_valid() const override { return !vertices.is_empty(); }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+
 private:
 	void clear_data();
 
@@ -123,6 +141,10 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	bool is_valid() const override { return !faces.is_empty(); }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
 
 private:
 	void clear_data();
@@ -137,6 +159,10 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	bool is_valid() const override { return width > 0; }
+
+	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
 
 private:
 	void clear_data();

--- a/src/jolt_shape_instance_3d.cpp
+++ b/src/jolt_shape_instance_3d.cpp
@@ -1,0 +1,78 @@
+#include "jolt_shape_instance_3d.hpp"
+
+#include "conversion.hpp"
+#include "error_macros.hpp"
+#include "jolt_shape_3d.hpp"
+#include "variant.hpp"
+
+bool JoltShapeInstance3D::try_build(
+	const JoltShapeInstance3D& p_shape,
+	uint64_t p_user_data,
+	Built& p_built_shape
+) {
+	if (p_shape.is_disabled()) {
+		return false;
+	}
+
+	JPH::ShapeRefC jolt_ref = p_shape->try_build(p_user_data);
+
+	if (jolt_ref == nullptr) {
+		return false;
+	}
+
+	p_built_shape.shape = &p_shape;
+	p_built_shape.jolt_ref = std::move(jolt_ref);
+
+	return true;
+}
+
+void JoltShapeInstance3D::try_build(
+	const Vector<JoltShapeInstance3D>& p_shapes,
+	Vector<Built>& p_built_shapes
+) {
+	p_built_shapes.clear();
+	p_built_shapes.resize(p_shapes.size());
+
+	Built* built_shapes_begin = p_built_shapes.ptrw();
+	Built* built_shapes_end = built_shapes_begin;
+
+	for (int shape_idx = 0; shape_idx < p_shapes.size(); ++shape_idx) {
+		Built built_shape;
+		if (try_build(p_shapes[shape_idx], (uint64_t)shape_idx, built_shape)) {
+			*built_shapes_end++ = std::move(built_shape);
+		}
+	}
+
+	const auto built_shape_count = int(built_shapes_end - built_shapes_begin);
+
+	p_built_shapes.resize(built_shape_count);
+}
+
+JPH::ShapeRefC JoltShapeInstance3D::build_compound(const Vector<Built>& p_built_shapes) {
+	JPH::StaticCompoundShapeSettings shape_settings;
+
+	for (const Built& built_shape : p_built_shapes) {
+		const JoltShapeInstance3D& shape = *built_shape.shape;
+		const JPH::ShapeRefC& jolt_ref = built_shape.jolt_ref;
+
+		shape_settings.AddShape(
+			to_jolt(shape.get_transform().origin),
+			to_jolt(shape.get_transform().basis),
+			jolt_ref
+		);
+	}
+
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+
+	ERR_FAIL_COND_D_MSG(
+		shape_result.HasError(),
+		vformat(
+			"Failed to create compound shape with sub-shape count '{}'. "
+			"Jolt returned the following error: '{}'.",
+			p_built_shapes.size(),
+			shape_result.GetError()
+		)
+	);
+
+	return shape_result.Get();
+}

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -4,6 +4,11 @@ class JoltShape3D;
 
 class JoltShapeInstance3D {
 public:
+	struct Built {
+		const JoltShapeInstance3D* shape = nullptr;
+		JPH::ShapeRefC jolt_ref;
+	};
+
 	JoltShapeInstance3D() = default;
 
 	JoltShapeInstance3D(JoltShape3D* p_shape, const Transform3D& p_transform, bool p_disabled)
@@ -38,6 +43,19 @@ public:
 	friend bool operator==(JoltShape3D* p_lhs, const JoltShapeInstance3D& p_rhs) {
 		return p_lhs == p_rhs.shape;
 	}
+
+	static bool try_build(
+		const JoltShapeInstance3D& p_shape,
+		uint64_t p_user_data,
+		Built& p_built_shape
+	);
+
+	static void try_build(
+		const Vector<JoltShapeInstance3D>& p_shapes,
+		Vector<Built>& p_built_shapes
+	);
+
+	static JPH::ShapeRefC build_compound(const Vector<Built>& p_built_shapes);
 
 private:
 	Transform3D transform;


### PR DESCRIPTION
This moves the instantiation of shapes from each shape's respective `set_data` method to instead happen at object instantiation. This means that `JPH::Shape` references can no longer be shared between objects and instead each instance of a particular shape will create its own unique `JPH::Shape`. This is unfortunately needed in order to bundle the shape index as user data with each `JPH::Shape`, which will be needed for things like ray casting.

I've left out a lot of the error handling related to checking for degenerate/invalid shapes, since Godot in general seems to be a lot more forgiving about such configurations, and we have a fallback for such invalid shapes, so I figured it might be better to try to mimick that.

As part of changing the error handling I've also made (what Jolt calls) the convex radius of the shapes more explicit, which is a value that can be tweaked for balancing performance versus accuracy. I've currently set this to 0, favoring accuracy over performance, which is supposed to be fine according to Jolt's documentation. I mostly did this to not create unintuitive invalid shapes when the extents are smaller than this convex radius, which Jolt doesn't allow. This value will eventually be made configurable in the upcoming project settings, but I made it into a file-scope constant for now.