### PR TITLE
Added preliminary support for ray-casts

### DIFF
--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -1,0 +1,219 @@
+#include "jolt_physics_direct_space_state_3d.hpp"
+
+#include "conversion.hpp"
+#include "error_macros.hpp"
+#include "jolt_body_access_3d.hpp"
+#include "jolt_broad_phase_layer.hpp"
+#include "jolt_collision_object_3d.hpp"
+#include "jolt_object_layer.hpp"
+#include "jolt_space_3d.hpp"
+
+class JoltQueryBroadPhaseLayerFilter3D : public JPH::BroadPhaseLayerFilter {
+	bool ShouldCollide(JPH::BroadPhaseLayer p_layer) const override {
+		return p_layer != JPH::BroadPhaseLayer(GDJOLT_BROAD_PHASE_LAYER_NONE);
+	}
+};
+
+class JoltQueryObjectLayerFilter3D : public JPH::ObjectLayerFilter {
+	bool ShouldCollide(JPH::ObjectLayer p_layer) const override {
+		return p_layer != JPH::ObjectLayer(GDJOLT_OBJECT_LAYER_NONE);
+	}
+};
+
+class JoltQueryBodyFilter3D : public JPH::BodyFilter {
+public:
+	JoltQueryBodyFilter3D(
+		uint32_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas
+	)
+		: collision_mask(p_collision_mask)
+		, collide_with_bodies(p_collide_with_bodies)
+		, collide_with_areas(p_collide_with_areas)
+		, collision_group(
+			  nullptr,
+			  (JPH::CollisionGroup::GroupID)0,
+			  (JPH::CollisionGroup::SubGroupID)collision_mask
+		  ) { }
+
+	bool ShouldCollideLocked(const JPH::Body& p_body) const override {
+		if (!collide_with_bodies && !p_body.IsSensor()) {
+			return false;
+		}
+
+		if (!collide_with_areas && p_body.IsSensor()) {
+			return false;
+		}
+
+		return collision_group.CanCollide(p_body.GetCollisionGroup());
+	}
+
+private:
+	uint32_t collision_mask = 0;
+
+	bool collide_with_bodies = false;
+
+	bool collide_with_areas = false;
+
+	JPH::CollisionGroup collision_group;
+};
+
+class JoltQueryShapeFilter3D : public JPH::ShapeFilter {
+	bool ShouldCollide([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id_2) const override {
+		return true;
+	}
+
+	bool ShouldCollide(
+		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id_1,
+		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id_2
+	) const override {
+		return true;
+	}
+};
+
+JoltPhysicsDirectSpaceState3D::JoltPhysicsDirectSpaceState3D(JoltSpace3D* p_space)
+	: space(p_space) { }
+
+bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
+	const Vector3& p_from,
+	const Vector3& p_to,
+	int64_t p_collision_mask,
+	bool p_collide_with_bodies,
+	bool p_collide_with_areas,
+	bool p_hit_from_inside,
+	bool p_hit_back_faces,
+	PhysicsServer3DExtensionRayResult* p_result
+) {
+	const JPH::Vec3 from = to_jolt(p_from);
+	const JPH::Vec3 to = to_jolt(p_to);
+	const JPH::Vec3 vector = to - from;
+
+	const JPH::NarrowPhaseQuery& query = space->get_narrow_phase_query(false);
+
+	const JPH::RRayCast ray(from, vector);
+
+	JPH::RayCastSettings settings;
+	settings.mTreatConvexAsSolid = p_hit_from_inside;
+	settings.mBackFaceMode = p_hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces
+											  : JPH::EBackFaceMode::IgnoreBackFaces;
+
+	JPH::ClosestHitCollisionCollector<JPH::CastRayCollector> collector;
+
+	query.CastRay(
+		ray,
+		settings,
+		collector,
+		JoltQueryBroadPhaseLayerFilter3D(),
+		JoltQueryObjectLayerFilter3D(),
+		JoltQueryBodyFilter3D(
+			(uint32_t)p_collision_mask,
+			p_collide_with_bodies,
+			p_collide_with_areas
+		),
+		JoltQueryShapeFilter3D()
+	);
+
+	if (!collector.HadHit()) {
+		return false;
+	}
+
+	const JPH::BodyID& body_id = collector.mHit.mBodyID;
+	const JPH::SubShapeID& subshape_id = collector.mHit.mSubShapeID2;
+
+	const JoltBodyAccessRead3D body_access(*space, body_id, false);
+	ERR_FAIL_COND_D(!body_access.is_valid());
+
+	const JPH::Body& body = body_access.get_body();
+	const JPH::Vec3 position = ray.GetPointOnRay(collector.mHit.mFraction);
+	const JPH::Vec3 normal = body.GetWorldSpaceSurfaceNormal(subshape_id, position);
+
+	auto* object = reinterpret_cast<JoltCollisionObject3D*>(body.GetUserData());
+	const auto object_id = (uint64_t)object->get_instance_id();
+
+	const JPH::Shape* shape = body.GetShape();
+	const auto shape_idx = (int)shape->GetSubShapeUserData(subshape_id);
+
+	p_result->position = to_godot(position);
+	p_result->normal = to_godot(normal);
+	p_result->rid = object->get_rid();
+	p_result->collider_id = object_id;
+	p_result->collider = ObjectDB::get_instance(object_id);
+	p_result->shape = shape_idx;
+
+	return true;
+}
+
+int64_t JoltPhysicsDirectSpaceState3D::_intersect_point(
+	[[maybe_unused]] const Vector3& p_position,
+	[[maybe_unused]] int64_t p_collision_mask,
+	[[maybe_unused]] bool p_collide_with_bodies,
+	[[maybe_unused]] bool p_collide_with_areas,
+	[[maybe_unused]] PhysicsServer3DExtensionShapeResult* p_results,
+	[[maybe_unused]] int64_t p_max_results
+) {
+	ERR_FAIL_D_NOT_IMPL();
+}
+
+int64_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
+	[[maybe_unused]] const RID& p_shape_rid,
+	[[maybe_unused]] const Transform3D& p_transform,
+	[[maybe_unused]] const Vector3& p_motion,
+	[[maybe_unused]] double p_margin,
+	[[maybe_unused]] int64_t p_collision_mask,
+	[[maybe_unused]] bool p_collide_with_bodies,
+	[[maybe_unused]] bool p_collide_with_areas,
+	[[maybe_unused]] PhysicsServer3DExtensionShapeResult* p_result_count,
+	[[maybe_unused]] int64_t p_max_results
+) {
+	ERR_FAIL_D_NOT_IMPL();
+}
+
+bool JoltPhysicsDirectSpaceState3D::_cast_motion(
+	[[maybe_unused]] const RID& p_shape_rid,
+	[[maybe_unused]] const Transform3D& p_transform,
+	[[maybe_unused]] const Vector3& p_motion,
+	[[maybe_unused]] double p_margin,
+	[[maybe_unused]] int64_t p_collision_mask,
+	[[maybe_unused]] bool p_collide_with_bodies,
+	[[maybe_unused]] bool p_collide_with_areas,
+	[[maybe_unused]] float* p_closest_safe,
+	[[maybe_unused]] float* p_closest_unsafe,
+	[[maybe_unused]] PhysicsServer3DExtensionShapeRestInfo* p_info
+) {
+	ERR_FAIL_D_NOT_IMPL();
+}
+
+bool JoltPhysicsDirectSpaceState3D::_collide_shape(
+	[[maybe_unused]] const RID& p_shape_rid,
+	[[maybe_unused]] const Transform3D& p_transform,
+	[[maybe_unused]] const Vector3& p_motion,
+	[[maybe_unused]] double p_margin,
+	[[maybe_unused]] int64_t p_collision_mask,
+	[[maybe_unused]] bool p_collide_with_bodies,
+	[[maybe_unused]] bool p_collide_with_areas,
+	[[maybe_unused]] void* p_results,
+	[[maybe_unused]] int64_t p_max_results,
+	[[maybe_unused]] int32_t* p_result_count
+) {
+	ERR_FAIL_D_NOT_IMPL();
+}
+
+bool JoltPhysicsDirectSpaceState3D::_rest_info(
+	[[maybe_unused]] const RID& p_shape_rid,
+	[[maybe_unused]] const Transform3D& p_transform,
+	[[maybe_unused]] const Vector3& p_motion,
+	[[maybe_unused]] double p_margin,
+	[[maybe_unused]] int64_t p_collision_mask,
+	[[maybe_unused]] bool p_collide_with_bodies,
+	[[maybe_unused]] bool p_collide_with_areas,
+	[[maybe_unused]] PhysicsServer3DExtensionShapeRestInfo* p_rest_info
+) {
+	ERR_FAIL_D_NOT_IMPL();
+}
+
+Vector3 JoltPhysicsDirectSpaceState3D::_get_closest_point_to_object_volume(
+	[[maybe_unused]] const RID& p_object,
+	[[maybe_unused]] const Vector3& p_point
+) const {
+	ERR_FAIL_D_NOT_IMPL();
+}

--- a/src/jolt_physics_direct_space_state_3d.hpp
+++ b/src/jolt_physics_direct_space_state_3d.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+class JoltSpace3D;
+
+class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3DExtension {
+	GDCLASS_NO_WARN(JoltPhysicsDirectSpaceState3D, PhysicsDirectSpaceState3DExtension) // NOLINT
+
+protected:
+	// NOLINTNEXTLINE(readability-identifier-naming)
+	static void _bind_methods() { }
+
+public:
+	JoltPhysicsDirectSpaceState3D() = default;
+
+	explicit JoltPhysicsDirectSpaceState3D(JoltSpace3D* p_space);
+
+	bool _intersect_ray(
+		const Vector3& p_from,
+		const Vector3& p_to,
+		int64_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas,
+		bool p_hit_from_inside,
+		bool p_hit_back_faces,
+		PhysicsServer3DExtensionRayResult* p_result
+	) override;
+
+	int64_t _intersect_point(
+		const Vector3& p_position,
+		int64_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas,
+		PhysicsServer3DExtensionShapeResult* p_results,
+		int64_t p_max_results
+	) override;
+
+	int64_t _intersect_shape(
+		const RID& p_shape_rid,
+		const Transform3D& p_transform,
+		const Vector3& p_motion,
+		double p_margin,
+		int64_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas,
+		PhysicsServer3DExtensionShapeResult* p_result_count,
+		int64_t p_max_results
+	) override;
+
+	bool _cast_motion(
+		const RID& p_shape_rid,
+		const Transform3D& p_transform,
+		const Vector3& p_motion,
+		double p_margin,
+		int64_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas,
+		float* p_closest_safe,
+		float* p_closest_unsafe,
+		PhysicsServer3DExtensionShapeRestInfo* p_info
+	) override;
+
+	bool _collide_shape(
+		const RID& p_shape_rid,
+		const Transform3D& p_transform,
+		const Vector3& p_motion,
+		double p_margin,
+		int64_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas,
+		void* p_results,
+		int64_t p_max_results,
+		int32_t* p_result_count
+	) override;
+
+	bool _rest_info(
+		const RID& p_shape_rid,
+		const Transform3D& p_transform,
+		const Vector3& p_motion,
+		double p_margin,
+		int64_t p_collision_mask,
+		bool p_collide_with_bodies,
+		bool p_collide_with_areas,
+		PhysicsServer3DExtensionShapeRestInfo* p_rest_info
+	) override;
+
+	Vector3 _get_closest_point_to_object_volume(const RID& p_object, const Vector3& p_point)
+		const override;
+
+private:
+	JoltSpace3D* space = nullptr;
+};

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -5,6 +5,7 @@
 #include "jolt_body_3d.hpp"
 #include "jolt_group_filter.hpp"
 #include "jolt_joint_3d.hpp"
+#include "jolt_physics_direct_space_state_3d.hpp"
 #include "jolt_shape_3d.hpp"
 #include "jolt_space_3d.hpp"
 #include "variant.hpp"

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -7,6 +7,7 @@
 #include "jolt_joint_3d.hpp"
 #include "jolt_layer_mapper.hpp"
 #include "jolt_object_layer.hpp"
+#include "jolt_physics_direct_space_state_3d.hpp"
 #include "jolt_shape_3d.hpp"
 #include "jolt_temp_allocator.hpp"
 #include "variant.hpp"
@@ -39,6 +40,10 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system, JPH::GroupFilter* p_group
 }
 
 JoltSpace3D::~JoltSpace3D() {
+	if (direct_state != nullptr) {
+		memdelete(direct_state);
+	}
+
 	delete physics_system;
 	delete layer_mapper;
 	delete temp_allocator;
@@ -101,7 +106,19 @@ const JPH::BodyLockInterface& JoltSpace3D::get_body_lock_iface(bool p_locked) co
 	}
 }
 
-PhysicsDirectSpaceState3D* JoltSpace3D::get_direct_state() const {
+const JPH::NarrowPhaseQuery& JoltSpace3D::get_narrow_phase_query(bool p_locked) const {
+	if (p_locked) {
+		return physics_system->GetNarrowPhaseQuery();
+	} else {
+		return physics_system->GetNarrowPhaseQueryNoLock();
+	}
+}
+
+JoltPhysicsDirectSpaceState3D* JoltSpace3D::get_direct_state() {
+	if (!direct_state) {
+		direct_state = memnew(JoltPhysicsDirectSpaceState3D(this));
+	}
+
 	return direct_state;
 }
 

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -4,6 +4,7 @@ class JoltArea3D;
 class JoltBody3D;
 class JoltCollisionObject3D;
 class JoltJoint3D;
+class JoltPhysicsDirectSpaceState3D;
 
 class JoltSpace3D final {
 public:
@@ -31,7 +32,9 @@ public:
 
 	const JPH::BodyLockInterface& get_body_lock_iface(bool p_locked = true) const;
 
-	PhysicsDirectSpaceState3D* get_direct_state() const;
+	const JPH::NarrowPhaseQuery& get_narrow_phase_query(bool p_locked = true) const;
+
+	JoltPhysicsDirectSpaceState3D* get_direct_state();
 
 	void set_default_area(JoltArea3D* p_area) { area = p_area; }
 
@@ -68,7 +71,7 @@ private:
 
 	JPH::GroupFilter* group_filter = nullptr;
 
-	PhysicsDirectSpaceState3D* direct_state = nullptr;
+	JoltPhysicsDirectSpaceState3D* direct_state = nullptr;
 
 	JoltArea3D* area = nullptr;
 

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -17,6 +17,9 @@
 #include <godot_cpp/classes/physics_direct_space_state3d_extension.hpp>
 #include <godot_cpp/classes/physics_server3d_extension.hpp>
 #include <godot_cpp/classes/physics_server3d_extension_motion_result.hpp>
+#include <godot_cpp/classes/physics_server3d_extension_ray_result.hpp>
+#include <godot_cpp/classes/physics_server3d_extension_shape_rest_info.hpp>
+#include <godot_cpp/classes/physics_server3d_extension_shape_result.hpp>
 #include <godot_cpp/classes/physics_server3d_manager.hpp>
 #include <godot_cpp/classes/physics_server3d_rendering_server_handler.hpp>
 #include <godot_cpp/core/class_db.hpp>
@@ -44,9 +47,13 @@
 #include <Jolt/Physics/Body/BodyLock.h>
 #include <Jolt/Physics/Body/BodyLockMulti.h>
 #include <Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h>
+#include <Jolt/Physics/Collision/CastResult.h>
+#include <Jolt/Physics/Collision/CollisionCollectorImpl.h>
 #include <Jolt/Physics/Collision/CollisionGroup.h>
 #include <Jolt/Physics/Collision/GroupFilter.h>
+#include <Jolt/Physics/Collision/NarrowPhaseQuery.h>
 #include <Jolt/Physics/Collision/ObjectLayer.h>
+#include <Jolt/Physics/Collision/RayCast.h>
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/Collision/Shape/CapsuleShape.h>
 #include <Jolt/Physics/Collision/Shape/ConvexHullShape.h>

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,4 +1,5 @@
 #include "jolt_physics_direct_body_state_3d.hpp"
+#include "jolt_physics_direct_space_state_3d.hpp"
 #include "jolt_physics_server_3d.hpp"
 #include "jolt_physics_server_factory_3d.hpp"
 
@@ -14,6 +15,7 @@ void on_initialize(ModuleInitializationLevel p_level) {
 	}
 
 	ClassDB::register_class<JoltPhysicsDirectBodyState3D>();
+	ClassDB::register_class<JoltPhysicsDirectSpaceState3D>();
 	ClassDB::register_class<JoltPhysicsServer3D>();
 	ClassDB::register_class<JoltPhysicsServerFactory3D>();
 


### PR DESCRIPTION
Related to #112.

This PR adds a partial implementation of `PhysicsDirectSpaceState3D`, which should stop the editor from crashing when dragging stuff onto the viewport. The only supported method currently is `intersect_ray`, which seems to be what the viewport needs for said viewport picking.

Note that this is a partial implementation, due to the `exclude` parameter not being exposed by Godot currently, which I made a PR for at godotengine/godot#70707. This means that the "Snap Object to Floor" (Page Down) functionality will not work until that PR is merged.