### PR TITLE
Added support for hinge joints

### DIFF
--- a/src/jolt_hinge_joint_3d.cpp
+++ b/src/jolt_hinge_joint_3d.cpp
@@ -1,0 +1,231 @@
+#include "jolt_hinge_joint_3d.hpp"
+
+#include "conversion.hpp"
+#include "error_macros.hpp"
+#include "jolt_body_3d.hpp"
+#include "jolt_body_access_3d.hpp"
+#include "utility_functions.hpp"
+#include "variant.hpp"
+
+namespace {
+
+constexpr double GDJOLT_HINGE_JOINT_DEFAULT_BIAS = 0.3;
+constexpr double GDJOLT_HINGE_JOINT_DEFAULT_LIMIT_BIAS = 0.3;
+constexpr double GDJOLT_HINGE_JOINT_DEFAULT_SOFTNESS = 0.9;
+constexpr double GDJOLT_HINGE_JOINT_DEFAULT_RELAXATION = 1.0;
+
+} // namespace
+
+JoltHingeJoint3D::JoltHingeJoint3D(
+	JoltSpace3D* p_space,
+	const JoltBody3D& p_body_a,
+	const JoltBody3D& p_body_b,
+	const Transform3D& p_hinge_a,
+	const Transform3D& p_hinge_b,
+	bool p_lock
+)
+	: JoltJoint3D(p_space) {
+	const JPH::BodyID body_ids[] = {p_body_a.get_jolt_id(), p_body_b.get_jolt_id()};
+	const JoltMultiBodyAccessWrite3D body_access(*space, body_ids, count_of(body_ids), p_lock);
+
+	JPH::Body* jolt_body_a = body_access.get_body(0);
+	ERR_FAIL_NULL(jolt_body_a);
+
+	JPH::Body* jolt_body_b = body_access.get_body(1);
+	ERR_FAIL_NULL(jolt_body_b);
+
+	const JPH::Shape* jolt_shape_a = jolt_body_a->GetShape();
+	ERR_FAIL_NULL(jolt_shape_a);
+
+	const JPH::Shape* jolt_shape_b = jolt_body_b->GetShape();
+	ERR_FAIL_NULL(jolt_shape_b);
+
+	JPH::HingeConstraintSettings constraint_settings;
+	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
+	constraint_settings.mPoint1 = to_jolt(p_hinge_a.origin) - jolt_shape_a->GetCenterOfMass();
+	constraint_settings.mHingeAxis1 = to_jolt(-p_hinge_a.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mNormalAxis1 = to_jolt(p_hinge_a.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mPoint2 = to_jolt(p_hinge_b.origin) - jolt_shape_b->GetCenterOfMass();
+	constraint_settings.mHingeAxis2 = to_jolt(-p_hinge_b.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mNormalAxis2 = to_jolt(p_hinge_b.basis.get_column(Vector3::AXIS_X));
+
+	jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
+
+	space->add_joint(this);
+}
+
+JoltHingeJoint3D::JoltHingeJoint3D(
+	JoltSpace3D* p_space,
+	const JoltBody3D& p_body_a,
+	const Transform3D& p_hinge_a,
+	const Transform3D& p_hinge_b,
+	bool p_lock
+)
+	: JoltJoint3D(p_space) {
+	const JoltBodyAccessWrite3D body_access(*space, p_body_a.get_jolt_id(), p_lock);
+	ERR_FAIL_COND(!body_access.is_valid());
+
+	JPH::Body& jolt_body_a = body_access.get_body();
+
+	const JPH::Shape* jolt_shape_a = jolt_body_a.GetShape();
+	ERR_FAIL_NULL(jolt_shape_a);
+
+	JPH::HingeConstraintSettings constraint_settings;
+	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
+	constraint_settings.mPoint1 = to_jolt(p_hinge_a.origin) - jolt_shape_a->GetCenterOfMass();
+	constraint_settings.mHingeAxis1 = to_jolt(-p_hinge_a.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mNormalAxis1 = to_jolt(p_hinge_a.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mPoint2 = to_jolt(p_hinge_b.origin);
+	constraint_settings.mHingeAxis2 = to_jolt(-p_hinge_b.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mNormalAxis2 = to_jolt(p_hinge_b.basis.get_column(Vector3::AXIS_X));
+
+	jolt_ref = constraint_settings.Create(jolt_body_a, JPH::Body::sFixedToWorld);
+
+	space->add_joint(this);
+}
+
+double JoltHingeJoint3D::get_param(PhysicsServer3D::HingeJointParam p_param) {
+	auto* jolt_hinge = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_D(jolt_hinge);
+
+	switch (p_param) {
+		case PhysicsServer3D::HINGE_JOINT_BIAS: {
+			return GDJOLT_HINGE_JOINT_DEFAULT_BIAS;
+		}
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER: {
+			return limit_upper;
+		}
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_LOWER: {
+			return limit_lower;
+		}
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_BIAS: {
+			return GDJOLT_HINGE_JOINT_DEFAULT_LIMIT_BIAS;
+		}
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_SOFTNESS: {
+			return GDJOLT_HINGE_JOINT_DEFAULT_SOFTNESS;
+		}
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_RELAXATION: {
+			return GDJOLT_HINGE_JOINT_DEFAULT_RELAXATION;
+		}
+		case PhysicsServer3D::HINGE_JOINT_MOTOR_TARGET_VELOCITY: {
+			return jolt_hinge->GetTargetAngularVelocity();
+		}
+		case PhysicsServer3D::HINGE_JOINT_MOTOR_MAX_IMPULSE: {
+			return motor_max_impulse;
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled hinge joint parameter: '{}'", p_param));
+		}
+	}
+}
+
+void JoltHingeJoint3D::set_param(PhysicsServer3D::HingeJointParam p_param, double p_value) {
+	auto* jolt_hinge = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL(jolt_hinge);
+
+	switch (p_param) {
+		case PhysicsServer3D::HINGE_JOINT_BIAS: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_HINGE_JOINT_DEFAULT_BIAS)) {
+				WARN_PRINT(
+					"Hinge joint bias is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER: {
+			limit_upper = p_value;
+			angular_limits_changed();
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_LOWER: {
+			limit_lower = p_value;
+			angular_limits_changed();
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_BIAS: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_HINGE_JOINT_DEFAULT_LIMIT_BIAS)) {
+				WARN_PRINT(
+					"Hinge joint bias limit is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_SOFTNESS: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_HINGE_JOINT_DEFAULT_SOFTNESS)) {
+				WARN_PRINT(
+					"Hinge joint softness is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_LIMIT_RELAXATION: {
+			if (!Math::is_equal_approx(p_value, GDJOLT_HINGE_JOINT_DEFAULT_RELAXATION)) {
+				WARN_PRINT(
+					"Hinge joint relaxation is not supported by Godot Jolt. "
+					"Any such value will be ignored."
+				);
+			}
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_MOTOR_TARGET_VELOCITY: {
+			jolt_hinge->SetTargetAngularVelocity((float)p_value);
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_MOTOR_MAX_IMPULSE: {
+			motor_max_impulse = p_value;
+
+			const double max_torque = motor_max_impulse / calculate_physics_step();
+
+			JPH::MotorSettings& motor_settings = jolt_hinge->GetMotorSettings();
+			motor_settings.mMinTorqueLimit = (float)-max_torque;
+			motor_settings.mMaxTorqueLimit = (float)+max_torque;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled hinge joint parameter: '{}'", p_param));
+		} break;
+	}
+}
+
+bool JoltHingeJoint3D::get_flag(PhysicsServer3D::HingeJointFlag p_flag) {
+	auto* jolt_hinge = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_D(jolt_hinge);
+
+	switch (p_flag) {
+		case PhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT: {
+			return use_limits;
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_FLAG_ENABLE_MOTOR: {
+			return jolt_hinge->GetMotorState() != JPH::EMotorState::Off;
+		} break;
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled hinge joint flag: '{}'", p_flag));
+		} break;
+	}
+}
+
+void JoltHingeJoint3D::set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled) {
+	auto* jolt_hinge = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL(jolt_hinge);
+
+	switch (p_flag) {
+		case PhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT: {
+			use_limits = p_enabled;
+			angular_limits_changed();
+		} break;
+		case PhysicsServer3D::HINGE_JOINT_FLAG_ENABLE_MOTOR: {
+			jolt_hinge->SetMotorState(
+				p_enabled ? JPH::EMotorState::Velocity : JPH::EMotorState::Off
+			);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled hinge joint flag: '{}'", p_flag));
+		} break;
+	}
+}
+
+void JoltHingeJoint3D::angular_limits_changed() {
+	auto* jolt_hinge = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL(jolt_hinge);
+
+	if (use_limits) {
+		jolt_hinge->SetLimits((float)limit_lower, (float)limit_upper);
+	} else {
+		jolt_hinge->SetLimits(-JPH::JPH_PI, JPH::JPH_PI);
+	}
+}

--- a/src/jolt_hinge_joint_3d.hpp
+++ b/src/jolt_hinge_joint_3d.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "jolt_joint_3d.hpp"
+
+class JoltHingeJoint3D final : public JoltJoint3D {
+public:
+	JoltHingeJoint3D(
+		JoltSpace3D* p_space,
+		const JoltBody3D& p_body_a,
+		const JoltBody3D& p_body_b,
+		const Transform3D& p_hinge_a,
+		const Transform3D& p_hinge_b,
+		bool p_lock = true
+	);
+
+	JoltHingeJoint3D(
+		JoltSpace3D* p_space,
+		const JoltBody3D& p_body_a,
+		const Transform3D& p_hinge_a,
+		const Transform3D& p_hinge_b,
+		bool p_lock = true
+	);
+
+	JoltHingeJoint3D(
+		JoltSpace3D* p_space,
+		const JoltBody3D& p_body_a,
+		const JoltBody3D& p_body_b,
+		const Vector3& p_pivot_a,
+		const Vector3& p_axis_a,
+		const Vector3& p_pivot_b,
+		const Vector3& p_axis_b,
+		bool p_lock = true
+	);
+
+	JoltHingeJoint3D(
+		JoltSpace3D* p_space,
+		const JoltBody3D& p_body_a,
+		const Vector3& p_pivot_a,
+		const Vector3& p_axis_a,
+		const Vector3& p_pivot_b,
+		const Vector3& p_axis_b,
+		bool p_lock = true
+	);
+
+	PhysicsServer3D::JointType get_type() const override {
+		return PhysicsServer3D::JOINT_TYPE_HINGE;
+	}
+
+	double get_param(PhysicsServer3D::HingeJointParam p_param);
+
+	void set_param(PhysicsServer3D::HingeJointParam p_param, double p_value);
+
+	bool get_flag(PhysicsServer3D::HingeJointFlag p_flag);
+
+	void set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled);
+
+private:
+	void angular_limits_changed();
+
+	double limit_lower = 0.0;
+
+	double limit_upper = 0.0;
+
+	double motor_max_impulse = 0.0;
+
+	bool use_limits = false;
+};

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -65,6 +65,7 @@
 #include <Jolt/Physics/Collision/Shape/ScaledShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
 #include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
+#include <Jolt/Physics/Constraints/HingeConstraint.h>
 #include <Jolt/Physics/Constraints/PointConstraint.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 #include <Jolt/RegisterTypes.h>

--- a/src/utility_functions.hpp
+++ b/src/utility_functions.hpp
@@ -37,3 +37,15 @@ template<typename TElement, int32_t TSize>
 constexpr int32_t count_of([[maybe_unused]] TElement (&p_array)[TSize]) {
 	return TSize;
 }
+
+inline double calculate_physics_step() {
+	// TODO(mihe): Replace these constants with the appropriate singleton calls once
+	// godotengine/godot-cpp#889 is fixed
+	const int32_t ticks_per_second = 60; // Engine::get_physics_ticks_per_second()
+	const double time_scale = 1.0; // Engine::get_time_scale()
+
+	const double step = 1.0 / ticks_per_second;
+	const double step_scaled = step * time_scale;
+
+	return step_scaled;
+}


### PR DESCRIPTION
Related to #107.

This adds preliminary support for the `HingeJoint3D` node type.

Much like with pin joints (#121), it will currently emit errors saying:

```
Required virtual method JoltPhysicsServer3D::_joint_disable_collisions_between_bodies must be overridden before calling.
```

... which can be addressed once 4.0 Beta 11 rolls around.