### PR TITLE
Added debug rendering as node type `JoltDebugGeometry3D`

### DIFF
--- a/examples/hello_world.tscn
+++ b/examples/hello_world.tscn
@@ -35,6 +35,8 @@ shadow_enabled = true
 transform = Transform3D(-0.707107, -0.40558, 0.579228, 0, 0.819152, 0.573576, -0.707107, 0.40558, -0.579228, 10, 12, -10)
 current = true
 
+[node name="DebugGeometry" type="JoltDebugGeometry3D" parent="."]
+
 [node name="Sphere" parent="." instance=ExtResource("1_y4gfj")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 13, 0)
 

--- a/src/bind.hpp
+++ b/src/bind.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#define BIND_METHOD(m_class, m_name) ClassDB::bind_method(D_METHOD(#m_name), &m_class::m_name)
+
+#define BIND_PROPERTY(m_name, m_type)  \
+	ClassDB::add_property(             \
+		get_class_static(),            \
+		PropertyInfo(m_type, #m_name), \
+		"set_" #m_name,                \
+		"get_" #m_name                 \
+	)
+
+#define BIND_PROPERTY_ENUM(m_name, m_hint_str)                               \
+	ClassDB::add_property(                                                   \
+		get_class_static(),                                                  \
+		PropertyInfo(Variant::INT, #m_name, PROPERTY_HINT_ENUM, m_hint_str), \
+		"set_" #m_name,                                                      \
+		"get_" #m_name                                                       \
+	)

--- a/src/conversion.hpp
+++ b/src/conversion.hpp
@@ -8,6 +8,19 @@ _ALWAYS_INLINE_ Basis to_godot(const JPH::Quat& p_quat) {
 	return {Quaternion(p_quat.GetX(), p_quat.GetY(), p_quat.GetZ(), p_quat.GetW())};
 }
 
+_ALWAYS_INLINE_ Color to_godot(const JPH::Color& p_color) {
+	const auto r = (float)p_color.r;
+	const auto g = (float)p_color.g;
+	const auto b = (float)p_color.b;
+	const auto a = (float)p_color.a;
+
+	return {
+		r == 0.0f ? 0.0f : 255.0f / r,
+		g == 0.0f ? 0.0f : 255.0f / g,
+		b == 0.0f ? 0.0f : 255.0f / b,
+		a == 0.0f ? 0.0f : 255.0f / a};
+}
+
 _ALWAYS_INLINE_ JPH::Vec3 to_jolt(const Vector3& p_vec) {
 	return {p_vec.x, p_vec.y, p_vec.z};
 }
@@ -15,4 +28,8 @@ _ALWAYS_INLINE_ JPH::Vec3 to_jolt(const Vector3& p_vec) {
 _ALWAYS_INLINE_ JPH::Quat to_jolt(const Basis& p_basis) {
 	const Quaternion quat = p_basis.get_quaternion();
 	return {quat.x, quat.y, quat.z, quat.w};
+}
+
+_ALWAYS_INLINE_ JPH::Color to_jolt(const Color& p_color) {
+	return JPH::Color((JPH::uint32)p_color.to_abgr32());
 }

--- a/src/jolt_debug_geometry_3d.cpp
+++ b/src/jolt_debug_geometry_3d.cpp
@@ -1,0 +1,333 @@
+#include "jolt_debug_geometry_3d.hpp"
+
+#include "bind.hpp"
+#include "error_macros.hpp"
+#include "jolt_debug_renderer.hpp"
+#include "jolt_physics_server_3d.hpp"
+#include "jolt_space_3d.hpp"
+
+void JoltDebugGeometry3D::_bind_methods() {
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_bodies);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_bodies);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_shapes);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_shapes);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraints);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraints);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_bounding_boxes);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_bounding_boxes);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_centers_of_mass);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_centers_of_mass);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_transforms);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_transforms);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_velocities);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_velocities);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraint_reference_frames);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_reference_frames);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraint_limits);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_limits);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_as_wireframe);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_as_wireframe);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_with_color_scheme);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_with_color_scheme);
+
+	BIND_METHOD(JoltDebugGeometry3D, get_material_depth_test);
+	BIND_METHOD(JoltDebugGeometry3D, set_material_depth_test);
+
+	ADD_GROUP("Draw", "draw_");
+
+	BIND_PROPERTY(draw_bodies, Variant::BOOL);
+
+	BIND_PROPERTY(draw_shapes, Variant::BOOL);
+
+	BIND_PROPERTY(draw_constraints, Variant::BOOL);
+
+	BIND_PROPERTY(draw_bounding_boxes, Variant::BOOL);
+
+	BIND_PROPERTY(draw_centers_of_mass, Variant::BOOL);
+
+	BIND_PROPERTY(draw_transforms, Variant::BOOL);
+
+	BIND_PROPERTY(draw_velocities, Variant::BOOL);
+
+	BIND_PROPERTY(draw_constraint_reference_frames, Variant::BOOL);
+
+	BIND_PROPERTY(draw_constraint_limits, Variant::BOOL);
+
+	BIND_PROPERTY(draw_as_wireframe, Variant::BOOL);
+
+	BIND_PROPERTY_ENUM(
+		draw_with_color_scheme,
+		"Instance,Shape Type,Motion Type,Sleep State,Island"
+	);
+
+	ADD_GROUP("Material", "material_");
+
+	BIND_PROPERTY(material_depth_test, Variant::BOOL);
+
+	BIND_ENUM_CONSTANT(COLOR_SCHEME_INSTANCE);
+	BIND_ENUM_CONSTANT(COLOR_SCHEME_SHAPE_TYPE);
+	BIND_ENUM_CONSTANT(COLOR_SCHEME_MOTION_TYPE);
+	BIND_ENUM_CONSTANT(COLOR_SCHEME_SLEEP_STATE);
+	BIND_ENUM_CONSTANT(COLOR_SCHEME_ISLAND);
+}
+
+#ifdef JPH_DEBUG_RENDERER
+
+JoltDebugGeometry3D::JoltDebugGeometry3D()
+	: debug_renderer(JoltDebugRenderer::acquire())
+	, mesh(RenderingServer::get_singleton()->mesh_create()) {
+	set_base(mesh);
+
+	default_material.instantiate();
+	default_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	default_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+}
+
+JoltDebugGeometry3D::~JoltDebugGeometry3D() {
+	if (mesh.is_valid()) {
+		RenderingServer::get_singleton()->free_rid(mesh);
+	}
+
+	JoltDebugRenderer::release(debug_renderer);
+}
+
+#else // JPH_DEBUG_RENDERER
+
+JoltDebugGeometry3D::JoltDebugGeometry3D() = default;
+
+JoltDebugGeometry3D::~JoltDebugGeometry3D() = default;
+
+#endif // JPH_DEBUG_RENDERER
+
+void JoltDebugGeometry3D::_process([[maybe_unused]] double p_delta) {
+#ifdef JPH_DEBUG_RENDERER
+	auto* physics_server = dynamic_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
+	ERR_FAIL_NULL(physics_server);
+
+	JoltSpace3D* space = physics_server->get_space(get_world_3d()->get_space());
+	ERR_FAIL_NULL(space);
+
+	RenderingServer* rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	Viewport* viewport = get_viewport();
+	ERR_FAIL_NULL(viewport);
+
+	Camera3D* camera = viewport->get_camera_3d();
+	ERR_FAIL_NULL(camera);
+
+	debug_renderer->draw(*space, *camera, draw_settings);
+	const int32_t surface_count = debug_renderer->submit(mesh);
+
+	const RID material_rid = default_material->get_rid();
+
+	for (int32_t i = 0; i < surface_count; ++i) {
+		rendering_server->mesh_surface_set_material(mesh, i, material_rid);
+	}
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_bodies() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_bodies;
+#else // JPH_DEBUG_RENDERER
+	return true;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_bodies([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_bodies = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_shapes() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_shapes;
+#else // JPH_DEBUG_RENDERER
+	return true;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_shapes([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_shapes = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_constraints() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_constraints;
+#else // JPH_DEBUG_RENDERER
+	return true;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_constraints([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_constraints = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_bounding_boxes() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_bounding_boxes;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_bounding_boxes([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_bounding_boxes = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_centers_of_mass() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_centers_of_mass;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_centers_of_mass([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_centers_of_mass = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_transforms() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_transforms;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_transforms([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_transforms = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_velocities() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_velocities;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_velocities([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_velocities = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_constraint_reference_frames() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_constraint_reference_frames;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_constraint_reference_frames([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_constraint_reference_frames = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_constraint_limits() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_constraint_limits;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_constraint_limits([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_constraint_limits = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_as_wireframe() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_as_wireframe;
+#else // JPH_DEBUG_RENDERER
+	return true;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_as_wireframe([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_as_wireframe = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+JoltDebugGeometry3D::ColorScheme JoltDebugGeometry3D::get_draw_with_color_scheme() const {
+#ifdef JPH_DEBUG_RENDERER
+	return (ColorScheme)draw_settings.color_scheme;
+#else // JPH_DEBUG_RENDERER
+	return ColorScheme::COLOR_SCHEME_SHAPE_TYPE;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_with_color_scheme([[maybe_unused]] ColorScheme p_color_scheme) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.color_scheme = (JPH::BodyManager::EShapeColor)p_color_scheme;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_material_depth_test() const {
+#ifdef JPH_DEBUG_RENDERER
+	ERR_FAIL_NULL_V(default_material, true);
+	return !default_material->get_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST);
+#else // JPH_DEBUG_RENDERER
+	return true;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_material_depth_test([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	ERR_FAIL_NULL(default_material);
+	default_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, !p_enabled);
+#endif // JPH_DEBUG_RENDERER
+}
+
+static_assert(
+	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_INSTANCE ==
+	(int32_t)JPH::BodyManager::EShapeColor::InstanceColor
+);
+
+static_assert(
+	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_SHAPE_TYPE ==
+	(int32_t)JPH::BodyManager::EShapeColor::ShapeTypeColor
+);
+
+static_assert(
+	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_MOTION_TYPE ==
+	(int32_t)JPH::BodyManager::EShapeColor::MotionTypeColor
+);
+
+static_assert(
+	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_SLEEP_STATE ==
+	(int32_t)JPH::BodyManager::EShapeColor::SleepColor
+);
+
+static_assert(
+	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_ISLAND ==
+	(int32_t)JPH::BodyManager::EShapeColor::IslandColor
+);

--- a/src/jolt_debug_geometry_3d.hpp
+++ b/src/jolt_debug_geometry_3d.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "jolt_debug_renderer.hpp"
+
+class JoltDebugGeometry3D final : public GeometryInstance3D {
+	GDCLASS_NO_WARN(JoltDebugGeometry3D, GeometryInstance3D) // NOLINT
+
+public:
+	enum ColorScheme {
+		COLOR_SCHEME_INSTANCE,
+		COLOR_SCHEME_SHAPE_TYPE,
+		COLOR_SCHEME_MOTION_TYPE,
+		COLOR_SCHEME_SLEEP_STATE,
+		COLOR_SCHEME_ISLAND
+	};
+
+protected:
+	// NOLINTNEXTLINE(readability-identifier-naming)
+	static void _bind_methods();
+
+public:
+	JoltDebugGeometry3D();
+
+	~JoltDebugGeometry3D() override;
+
+	void _process(double p_delta) override;
+
+	bool get_draw_bodies() const;
+
+	void set_draw_bodies(bool p_enabled);
+
+	bool get_draw_shapes() const;
+
+	void set_draw_shapes(bool p_enabled);
+
+	bool get_draw_constraints() const;
+
+	void set_draw_constraints(bool p_enabled);
+
+	bool get_draw_bounding_boxes() const;
+
+	void set_draw_bounding_boxes(bool p_enabled);
+
+	bool get_draw_centers_of_mass() const;
+
+	void set_draw_centers_of_mass(bool p_enabled);
+
+	bool get_draw_transforms() const;
+
+	void set_draw_transforms(bool p_enabled);
+
+	bool get_draw_velocities() const;
+
+	void set_draw_velocities(bool p_enabled);
+
+	bool get_draw_constraint_reference_frames() const;
+
+	void set_draw_constraint_reference_frames(bool p_enabled);
+
+	bool get_draw_constraint_limits() const;
+
+	void set_draw_constraint_limits(bool p_enabled);
+
+	bool get_draw_as_wireframe() const;
+
+	void set_draw_as_wireframe(bool p_enabled);
+
+	ColorScheme get_draw_with_color_scheme() const;
+
+	void set_draw_with_color_scheme(ColorScheme p_color_scheme);
+
+	bool get_material_depth_test() const;
+
+	void set_material_depth_test(bool p_enabled);
+
+private:
+#ifdef JPH_DEBUG_RENDERER
+	JoltDebugRenderer* debug_renderer = nullptr;
+
+	RID mesh;
+
+	Ref<StandardMaterial3D> default_material;
+
+	JoltDebugRenderer::DrawSettings draw_settings;
+#endif // JPH_DEBUG_RENDERER
+};
+
+VARIANT_ENUM_CAST(JoltDebugGeometry3D, ColorScheme);

--- a/src/jolt_debug_renderer.cpp
+++ b/src/jolt_debug_renderer.cpp
@@ -1,0 +1,363 @@
+#include "jolt_debug_renderer.hpp"
+
+#ifdef JPH_DEBUG_RENDERER
+
+#include "conversion.hpp"
+#include "error_macros.hpp"
+#include "jolt_space_3d.hpp"
+
+namespace {
+
+constexpr int64_t GDJOLT_DEBUG_VERTEX_STRIDE = sizeof(Vector3);
+constexpr int64_t GDJOLT_DEBUG_ATTRIBUTE_STRIDE = sizeof(uint32_t);
+
+} // namespace
+
+class JoltDebugTriangleBatch final : public JPH::RefTargetVirtual {
+public:
+	using Vertices = JPH::Array<JPH::Vec3>;
+
+	explicit JoltDebugTriangleBatch(int p_capacity) { vertices.reserve((size_t)p_capacity * 3); }
+
+	void AddRef() override { ++ref_count; }
+
+	void Release() override {
+		if (--ref_count == 0) {
+			delete this;
+		}
+	}
+
+	const Vertices& get_vertices() const { return vertices; }
+
+	void add_triangle(JPH::Vec3 p_vertex1, JPH::Vec3 p_vertex2, JPH::Vec3 p_vertex3) {
+		vertices.push_back(p_vertex1);
+		vertices.push_back(p_vertex2);
+		vertices.push_back(p_vertex3);
+	}
+
+private:
+	int ref_count = 0;
+
+	Vertices vertices;
+};
+
+void JoltDebugRenderer::draw(
+	const JoltSpace3D& p_space,
+	const Camera3D& p_camera,
+	const DrawSettings& p_settings
+) {
+	camera_position = to_jolt(p_camera.get_camera_transform().origin);
+
+	JPH::PhysicsSystem* physics_system = p_space.get_physics_system();
+
+	if (p_settings.draw_bodies) {
+		JPH::BodyManager::DrawSettings jolt_settings;
+		jolt_settings.mDrawGetSupportFunction = false;
+		jolt_settings.mDrawSupportDirection = false;
+		jolt_settings.mDrawGetSupportingFace = false;
+		jolt_settings.mDrawShape = p_settings.draw_shapes;
+		jolt_settings.mDrawShapeWireframe = p_settings.draw_as_wireframe;
+		jolt_settings.mDrawShapeColor = p_settings.color_scheme;
+		jolt_settings.mDrawBoundingBox = p_settings.draw_bounding_boxes;
+		jolt_settings.mDrawCenterOfMassTransform = p_settings.draw_centers_of_mass;
+		jolt_settings.mDrawWorldTransform = p_settings.draw_transforms;
+		jolt_settings.mDrawVelocity = p_settings.draw_velocities;
+		jolt_settings.mDrawMassAndInertia = false;
+		jolt_settings.mDrawSleepStats = false;
+
+		physics_system->DrawBodies(jolt_settings, this);
+	}
+
+	if (p_settings.draw_constraints) {
+		physics_system->DrawConstraints(this);
+	}
+
+	if (p_settings.draw_constraint_reference_frames) {
+		physics_system->DrawConstraintReferenceFrame(this);
+	}
+
+	if (p_settings.draw_constraint_limits) {
+		physics_system->DrawConstraintLimits(this);
+	}
+}
+
+int32_t JoltDebugRenderer::submit(const RID& p_mesh) {
+	RenderingServer* rendering_server = RenderingServer::get_singleton();
+
+	rendering_server->mesh_clear(p_mesh);
+
+	uint32_t vertex_format = 0;
+	vertex_format |= (uint32_t)RenderingServer::ARRAY_FORMAT_VERTEX;
+	vertex_format |= (uint32_t)RenderingServer::ARRAY_FORMAT_COLOR;
+
+	int32_t surface_count = 0;
+
+	if (triangle_count > 0) {
+		const int64_t vertex_count = (int64_t)triangle_count * 3;
+
+		triangle_vertices.resize(vertex_count * GDJOLT_DEBUG_VERTEX_STRIDE);
+		triangle_attributes.resize(vertex_count * GDJOLT_DEBUG_ATTRIBUTE_STRIDE);
+
+		Dictionary triangles_surface_data;
+		triangles_surface_data["format"] = vertex_format;
+		triangles_surface_data["primitive"] = RenderingServer::PRIMITIVE_TRIANGLES;
+		triangles_surface_data["vertex_data"] = triangle_vertices;
+		triangles_surface_data["vertex_count"] = vertex_count;
+		triangles_surface_data["aabb"] = triangles_aabb;
+		triangles_surface_data["attribute_data"] = triangle_attributes;
+
+		rendering_server->mesh_add_surface(p_mesh, triangles_surface_data);
+
+		triangle_capacity = triangle_count;
+		triangle_count = 0;
+		triangles_aabb = AABB();
+
+		surface_count++;
+	}
+
+	if (line_count > 0) {
+		const int64_t vertex_count = (int64_t)line_count * 2;
+
+		line_vertices.resize(vertex_count * GDJOLT_DEBUG_VERTEX_STRIDE);
+		line_attributes.resize(vertex_count * GDJOLT_DEBUG_ATTRIBUTE_STRIDE);
+
+		Dictionary lines_surface_data;
+		lines_surface_data["format"] = vertex_format;
+		lines_surface_data["primitive"] = RenderingServer::PRIMITIVE_LINES;
+		lines_surface_data["vertex_data"] = line_vertices;
+		lines_surface_data["vertex_count"] = vertex_count;
+		lines_surface_data["aabb"] = lines_aabb;
+		lines_surface_data["attribute_data"] = line_attributes;
+
+		rendering_server->mesh_add_surface(p_mesh, lines_surface_data);
+
+		line_capacity = line_count;
+		line_count = 0;
+		lines_aabb = AABB();
+
+		surface_count++;
+	}
+
+	return surface_count;
+}
+
+void JoltDebugRenderer::DrawLine(JPH::Vec3 p_from, JPH::Vec3 p_to, JPH::Color p_color) {
+	reserve_lines(1);
+	add_line(to_godot(p_from), to_godot(p_to), to_godot(p_color).to_abgr32());
+}
+
+void JoltDebugRenderer::DrawTriangle(
+	JPH::Vec3 p_vertex1,
+	JPH::Vec3 p_vertex2,
+	JPH::Vec3 p_vertex3,
+	JPH::Color p_color
+) {
+	reserve_triangles(1);
+
+	add_triangle(
+		to_godot(p_vertex3),
+		to_godot(p_vertex2),
+		to_godot(p_vertex1),
+		to_godot(p_color).to_abgr32()
+	);
+}
+
+JPH::DebugRenderer::Batch JoltDebugRenderer::CreateTriangleBatch(
+	const JPH::DebugRenderer::Triangle* p_triangles,
+	int p_triangle_count
+) {
+	auto* triangle_batch = new JoltDebugTriangleBatch(p_triangle_count);
+
+	const JPH::DebugRenderer::Triangle* triangles_begin = p_triangles;
+	const JPH::DebugRenderer::Triangle* triangles_end = triangles_begin + p_triangle_count;
+
+	for (const auto* it = triangles_begin; it != triangles_end; ++it) {
+		triangle_batch->add_triangle(
+			JPH::Vec3(it->mV[0].mPosition),
+			JPH::Vec3(it->mV[1].mPosition),
+			JPH::Vec3(it->mV[2].mPosition)
+		);
+	}
+
+	return triangle_batch;
+}
+
+JPH::DebugRenderer::Batch JoltDebugRenderer::CreateTriangleBatch(
+	const JPH::DebugRenderer::Vertex* p_vertices,
+	[[maybe_unused]] int p_vertex_count,
+	const JPH::uint32* p_indices,
+	int p_index_count
+) {
+	auto* triangle_batch = new JoltDebugTriangleBatch(p_index_count / 3);
+
+	for (int i = 0; i < p_index_count; i += 3) {
+		const JPH::uint32 i0 = *(p_indices + i + 0);
+		const JPH::uint32 i1 = *(p_indices + i + 1);
+		const JPH::uint32 i2 = *(p_indices + i + 2);
+
+		triangle_batch->add_triangle(
+			JPH::Vec3(p_vertices[i0].mPosition),
+			JPH::Vec3(p_vertices[i1].mPosition),
+			JPH::Vec3(p_vertices[i2].mPosition)
+		);
+	}
+
+	return triangle_batch;
+}
+
+void JoltDebugRenderer::DrawGeometry(
+	const JPH::Mat44& p_model_matrix,
+	const JPH::AABox& p_world_space_bounds,
+	float p_lod_scale_sq,
+	JPH::Color p_model_color,
+	const JPH::DebugRenderer::GeometryRef& p_geometry,
+	JPH::DebugRenderer::ECullMode p_cull_mode,
+	[[maybe_unused]] JPH::DebugRenderer::ECastShadow p_cast_shadow,
+	JPH::DebugRenderer::EDrawMode p_draw_mode
+) {
+	const float camera_distance_sq = p_world_space_bounds.GetSqDistanceTo(camera_position);
+
+	const JPH::DebugRenderer::LOD* model_lod = nullptr;
+
+	for (const JPH::DebugRenderer::LOD& lod : p_geometry->mLODs) {
+		const float lod_distance_sq = lod.mDistance * lod.mDistance;
+		if (camera_distance_sq <= lod_distance_sq * p_lod_scale_sq) {
+			model_lod = &lod;
+		}
+	}
+
+	auto* triangle_batch = static_cast<JoltDebugTriangleBatch*>(model_lod->mTriangleBatch.GetPtr());
+	const JoltDebugTriangleBatch::Vertices& model_vertices = triangle_batch->get_vertices();
+	const JPH::Vec3* model_vertices_ptr = model_vertices.data();
+
+	const auto model_vertex_count = (int32_t)model_vertices.size();
+	const int32_t model_triangle_count = model_vertex_count / 3;
+
+	const uint32_t model_color_abgr = to_godot(p_model_color).to_abgr32();
+
+	if (p_draw_mode == JPH::DebugRenderer::EDrawMode::Solid) {
+		if (p_cull_mode != JPH::DebugRenderer::ECullMode::Off) {
+			reserve_triangles(model_triangle_count);
+		} else {
+			reserve_triangles(model_triangle_count * 2);
+		}
+
+		for (int32_t i = 0; i < model_triangle_count; ++i) {
+			const int32_t vertex_offset = i * 3;
+
+			const Vector3 v0 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 0]);
+			const Vector3 v1 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 1]);
+			const Vector3 v2 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 2]);
+
+			switch (p_cull_mode) {
+				case JPH::DebugRenderer::ECullMode::CullBackFace: {
+					add_triangle(v2, v1, v0, model_color_abgr);
+				} break;
+				case JPH::DebugRenderer::ECullMode::CullFrontFace: {
+					add_triangle(v0, v1, v2, model_color_abgr);
+				} break;
+				case JPH::DebugRenderer::ECullMode::Off: {
+					add_triangle(v0, v1, v2, model_color_abgr);
+					add_triangle(v2, v1, v0, model_color_abgr);
+				} break;
+			}
+		}
+	} else {
+		reserve_lines(model_triangle_count * 3);
+
+		for (int32_t i = 0; i < model_triangle_count; ++i) {
+			const int32_t vertex_offset = i * 3;
+
+			const Vector3 v0 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 0]);
+			const Vector3 v1 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 1]);
+			const Vector3 v2 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 2]);
+
+			add_line(v0, v1, model_color_abgr);
+			add_line(v1, v2, model_color_abgr);
+			add_line(v2, v0, model_color_abgr);
+		}
+	}
+}
+
+void JoltDebugRenderer::DrawText3D(
+	[[maybe_unused]] const JPH::Vec3 p_position,
+	[[maybe_unused]] const JPH::string_view& p_string,
+	[[maybe_unused]] JPH::Color p_color,
+	[[maybe_unused]] float p_height
+) {
+	ERR_FAIL_NOT_IMPL();
+}
+
+void JoltDebugRenderer::reserve_triangles(int32_t p_extra_capacity) {
+	if (triangle_count + p_extra_capacity <= triangle_capacity) {
+		return;
+	}
+
+	triangle_capacity += p_extra_capacity;
+
+	const int64_t vertex_count = (int64_t)triangle_capacity * 3;
+	triangle_vertices.resize(vertex_count * GDJOLT_DEBUG_VERTEX_STRIDE);
+	triangle_attributes.resize(vertex_count * GDJOLT_DEBUG_ATTRIBUTE_STRIDE);
+}
+
+void JoltDebugRenderer::reserve_lines(int32_t p_extra_capacity) {
+	if (line_count + p_extra_capacity <= line_capacity) {
+		return;
+	}
+
+	line_capacity += p_extra_capacity;
+
+	const int64_t vertex_count = (int64_t)line_capacity * 2;
+	line_vertices.resize(vertex_count * GDJOLT_DEBUG_VERTEX_STRIDE);
+	line_attributes.resize(vertex_count * GDJOLT_DEBUG_ATTRIBUTE_STRIDE);
+}
+
+void JoltDebugRenderer::add_triangle(
+	const Vector3& p_vertex1,
+	const Vector3& p_vertex2,
+	const Vector3& p_vertex3,
+	uint32_t p_color_abgr
+) {
+	const int32_t vertex_count = triangle_count * 3;
+
+	auto* vertices_ptr = reinterpret_cast<Vector3*>(triangle_vertices.ptrw()) + vertex_count;
+	auto* attributes_ptr = reinterpret_cast<uint32_t*>(triangle_attributes.ptrw()) + vertex_count;
+
+	*vertices_ptr++ = p_vertex1;
+	*vertices_ptr++ = p_vertex2;
+	*vertices_ptr++ = p_vertex3;
+
+	*attributes_ptr++ = p_color_abgr;
+	*attributes_ptr++ = p_color_abgr;
+	*attributes_ptr++ = p_color_abgr;
+
+	triangles_aabb.expand_to(p_vertex1);
+	triangles_aabb.expand_to(p_vertex2);
+	triangles_aabb.expand_to(p_vertex3);
+
+	triangle_count++;
+}
+
+void JoltDebugRenderer::add_line(
+	const Vector3& p_from,
+	const Vector3& p_to,
+	uint32_t p_color_abgr
+) {
+	const int32_t vertex_count = line_count * 2;
+
+	auto* vertices_ptr = reinterpret_cast<Vector3*>(line_vertices.ptrw()) + vertex_count;
+	auto* attributes_ptr = reinterpret_cast<uint32_t*>(line_attributes.ptrw()) + vertex_count;
+
+	*vertices_ptr++ = p_from;
+	*vertices_ptr++ = p_to;
+
+	*attributes_ptr++ = p_color_abgr;
+	*attributes_ptr++ = p_color_abgr;
+
+	lines_aabb.expand_to(p_from);
+	lines_aabb.expand_to(p_to);
+
+	line_count++;
+}
+
+#endif // JPH_DEBUG_RENDERER

--- a/src/jolt_debug_renderer.hpp
+++ b/src/jolt_debug_renderer.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#ifdef JPH_DEBUG_RENDERER
+
+class JoltSpace3D;
+
+class JoltDebugRenderer final : public JPH::DebugRenderer {
+public:
+	struct DrawSettings {
+		bool draw_bodies = true;
+
+		bool draw_shapes = true;
+
+		bool draw_constraints = true;
+
+		bool draw_bounding_boxes = false;
+
+		bool draw_centers_of_mass = false;
+
+		bool draw_transforms = false;
+
+		bool draw_velocities = false;
+
+		bool draw_constraint_reference_frames = false;
+
+		bool draw_constraint_limits = false;
+
+		bool draw_as_wireframe = true;
+
+		JPH::BodyManager::EShapeColor color_scheme = JPH::BodyManager::EShapeColor::ShapeTypeColor;
+	};
+
+	static JoltDebugRenderer* acquire() {
+		if (ref_count++ == 0) {
+			singleton = new JoltDebugRenderer();
+		}
+
+		return singleton;
+	}
+
+	static void release(JoltDebugRenderer*& p_ptr) {
+		ERR_FAIL_NULL(p_ptr);
+
+		if (--ref_count == 0) {
+			delete singleton;
+			singleton = nullptr;
+		}
+
+		p_ptr = nullptr;
+	}
+
+	void draw(const JoltSpace3D& p_space, const Camera3D& p_camera, const DrawSettings& p_settings);
+
+	int32_t submit(const RID& p_mesh);
+
+private:
+	JoltDebugRenderer() { Initialize(); }
+
+	void DrawLine(JPH::Vec3 p_from, JPH::Vec3 p_to, JPH::Color p_color) override;
+
+	void DrawTriangle(
+		JPH::Vec3 p_vertex1,
+		JPH::Vec3 p_vertex2,
+		JPH::Vec3 p_vertex3,
+		JPH::Color p_color
+	) override;
+
+	JPH::DebugRenderer::Batch CreateTriangleBatch(
+		const JPH::DebugRenderer::Triangle* p_triangles,
+		int p_triangle_count
+	) override;
+
+	JPH::DebugRenderer::Batch CreateTriangleBatch(
+		const JPH::DebugRenderer::Vertex* p_vertices,
+		int p_vertex_count,
+		const JPH::uint32* p_indices,
+		int p_index_count
+	) override;
+
+	void DrawGeometry(
+		const JPH::Mat44& p_model_matrix,
+		const JPH::AABox& p_world_space_bounds,
+		float p_lod_scale_sq,
+		JPH::Color p_model_color,
+		const JPH::DebugRenderer::GeometryRef& p_geometry,
+		JPH::DebugRenderer::ECullMode p_cull_mode,
+		JPH::DebugRenderer::ECastShadow p_cast_shadow,
+		JPH::DebugRenderer::EDrawMode p_draw_mode
+	) override;
+
+	void DrawText3D(
+		JPH::Vec3 p_position,
+		const JPH::string_view& p_string,
+		JPH::Color p_color = JPH::Color::sWhite,
+		float p_height = 0.5f
+	) override;
+
+	void reserve_triangles(int32_t p_extra_capacity);
+
+	void reserve_lines(int32_t p_extra_capacity);
+
+	void add_triangle(
+		const Vector3& p_vertex1,
+		const Vector3& p_vertex2,
+		const Vector3& p_vertex3,
+		uint32_t p_color_abgr
+	);
+
+	void add_line(const Vector3& p_from, const Vector3& p_to, uint32_t p_color_abgr);
+
+	inline static JoltDebugRenderer* singleton = nullptr;
+
+	inline static int32_t ref_count = 0;
+
+	int32_t triangle_capacity = 0;
+
+	int32_t triangle_count = 0;
+
+	int32_t line_capacity = 0;
+
+	int32_t line_count = 0;
+
+	PackedByteArray triangle_vertices;
+
+	PackedByteArray triangle_attributes;
+
+	PackedByteArray line_vertices;
+
+	PackedByteArray line_attributes;
+
+	AABB triangles_aabb;
+
+	AABB lines_aabb;
+
+	JPH::Vec3 camera_position = {0, 0, 0};
+};
+
+#endif // JPH_DEBUG_RENDERER

--- a/src/jolt_physics_server_3d.hpp
+++ b/src/jolt_physics_server_3d.hpp
@@ -543,6 +543,16 @@ public:
 
 	int64_t _get_process_info(PhysicsServer3D::ProcessInfo p_process_info) override;
 
+	JoltSpace3D* get_space(const RID& p_rid) const { return space_owner.get_or_null(p_rid); }
+
+	JoltBody3D* get_body(const RID& p_rid) const { return body_owner.get_or_null(p_rid); }
+
+	JoltArea3D* get_area(const RID& p_rid) const { return area_owner.get_or_null(p_rid); }
+
+	JoltShape3D* get_shape(const RID& p_rid) const { return shape_owner.get_or_null(p_rid); }
+
+	JoltJoint3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
+
 private:
 	inline static int32_t server_count;
 

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -26,6 +26,8 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
+	JPH::PhysicsSystem* get_physics_system() const { return physics_system; }
+
 	JPH::BodyInterface& get_body_iface(bool p_locked = true);
 
 	const JPH::BodyInterface& get_body_iface(bool p_locked = true) const;

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -12,6 +12,9 @@
 
 #include <gdextension_interface.h>
 
+#include <godot_cpp/classes/camera3d.hpp>
+#include <godot_cpp/classes/geometry_instance3d.hpp>
+#include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/object.hpp>
 #include <godot_cpp/classes/physics_direct_body_state3d_extension.hpp>
 #include <godot_cpp/classes/physics_direct_space_state3d_extension.hpp>
@@ -22,6 +25,10 @@
 #include <godot_cpp/classes/physics_server3d_extension_shape_result.hpp>
 #include <godot_cpp/classes/physics_server3d_manager.hpp>
 #include <godot_cpp/classes/physics_server3d_rendering_server_handler.hpp>
+#include <godot_cpp/classes/rendering_server.hpp>
+#include <godot_cpp/classes/standard_material3d.hpp>
+#include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/classes/world3d.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/core/error_macros.hpp>
@@ -69,6 +76,10 @@
 #include <Jolt/Physics/Constraints/PointConstraint.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 #include <Jolt/RegisterTypes.h>
+
+#ifdef JPH_DEBUG_RENDERER
+#include <Jolt/Renderer/DebugRenderer.h>
+#endif // JPH_DEBUG_RENDERER
 
 #include <fmt/format.h>
 #include <mimalloc.h>

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,3 +1,4 @@
+#include "jolt_debug_geometry_3d.hpp"
 #include "jolt_physics_direct_body_state_3d.hpp"
 #include "jolt_physics_direct_space_state_3d.hpp"
 #include "jolt_physics_server_3d.hpp"
@@ -5,38 +6,47 @@
 
 namespace {
 
-constexpr ModuleInitializationLevel GDJOLT_INIT_LEVEL = MODULE_INITIALIZATION_LEVEL_SERVERS;
-
 JoltPhysicsServerFactory3D* server_factory = nullptr;
 
 void on_initialize(ModuleInitializationLevel p_level) {
-	if (p_level != GDJOLT_INIT_LEVEL) {
-		return;
+	switch (p_level) {
+		case MODULE_INITIALIZATION_LEVEL_CORE: {
+		} break;
+		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
+			ClassDB::register_class<JoltPhysicsDirectBodyState3D>();
+			ClassDB::register_class<JoltPhysicsDirectSpaceState3D>();
+			ClassDB::register_class<JoltPhysicsServer3D>();
+			ClassDB::register_class<JoltPhysicsServerFactory3D>();
+
+			server_factory = memnew(JoltPhysicsServerFactory3D);
+
+			PhysicsServer3DManager::get_singleton()->register_server(
+				"JoltPhysics3D",
+				Callable(server_factory, "create_server")
+			);
+		} break;
+		case MODULE_INITIALIZATION_LEVEL_SCENE: {
+			ClassDB::register_class<JoltDebugGeometry3D>();
+		} break;
+		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
+		} break;
 	}
-
-	ClassDB::register_class<JoltPhysicsDirectBodyState3D>();
-	ClassDB::register_class<JoltPhysicsDirectSpaceState3D>();
-	ClassDB::register_class<JoltPhysicsServer3D>();
-	ClassDB::register_class<JoltPhysicsServerFactory3D>();
-
-	if (server_factory == nullptr) {
-		server_factory = memnew(JoltPhysicsServerFactory3D);
-	}
-
-	PhysicsServer3DManager::get_singleton()->register_server(
-		"JoltPhysics3D",
-		Callable(server_factory, "create_server")
-	);
 }
 
 void on_terminate(ModuleInitializationLevel p_level) {
-	if (p_level != GDJOLT_INIT_LEVEL) {
-		return;
-	}
-
-	if (server_factory != nullptr) {
-		memdelete(server_factory);
-		server_factory = nullptr;
+	switch (p_level) {
+		case MODULE_INITIALIZATION_LEVEL_CORE: {
+		} break;
+		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
+			if (server_factory != nullptr) {
+				memdelete(server_factory);
+				server_factory = nullptr;
+			}
+		} break;
+		case MODULE_INITIALIZATION_LEVEL_SCENE: {
+		} break;
+		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
+		} break;
 	}
 }
 
@@ -54,7 +64,7 @@ GDExtensionBool GDE_EXPORT godot_jolt_main(
 	init_obj.register_initializer(&on_initialize);
 	init_obj.register_terminator(&on_terminate);
 
-	init_obj.set_minimum_library_initialization_level(GDJOLT_INIT_LEVEL);
+	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SERVERS);
 
 	return init_obj.init();
 }


### PR DESCRIPTION
This implements the `JPH::DebugRenderer` interface that Jolt exposes, which allows for relatively efficient debug rendering of all the shapes, constraints and other metadata across the scene.

I decided to implement this as a `GeometryInstance3D`-derived node type. All you need to do is place it at the center of the scene and it will render all the shapes as an unshaded wireframe. This means you can technically place the whole thing somewhere else as well. This seemed annoying at first, but I think there might be some legit use-cases for it. Using `GeometryInstance3D` also has the added benefit of letting you override the material used, if need be.

You can also configure what things you want to be rendered using the properties exposed on the node, as well as how they're rendered, like whether to render as wireframe or solid, and what color scheme to use for the rendered shapes.

Note that this does not implement text rendering (yet). Because of this some of Jolt's debug rendering features are not included, like debug drawing of mass, inertia and sleep stats.