### PR TITLE
Disabled clang-tidy check `bugprone-branch-clone`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,7 @@ Checks: >
   -bugprone-assignment-in-if-condition,
   -bugprone-bad-signal-to-kill-thread,
   bugprone-bool-pointer-implicit-conversion,
-  bugprone-branch-clone,
+  -bugprone-branch-clone,
   bugprone-copy-constructor-init,
   bugprone-dangling-handle,
   bugprone-dynamic-static-initializers,


### PR DESCRIPTION
This conflicts in annoying ways with the GCC/Clang warning `-Wswitch`, so one of them had to go.