### PR TITLE
Moved Jolt hooks to extension initialization/termination

### DIFF
--- a/src/jolt_hooks.cpp
+++ b/src/jolt_hooks.cpp
@@ -1,0 +1,66 @@
+#include "jolt_hooks.hpp"
+
+#include "variant.hpp"
+
+void* jolt_alloc(size_t p_size) {
+	return mi_malloc(p_size);
+}
+
+void jolt_free(void* p_mem) {
+	mi_free(p_mem);
+}
+
+void* jolt_aligned_alloc(size_t p_size, size_t p_alignment) {
+	return mi_aligned_alloc(p_alignment, p_size);
+}
+
+void jolt_aligned_free(void* p_mem) {
+	mi_free(p_mem);
+}
+
+void jolt_trace(const char* p_format, ...) {
+	va_list args; // NOLINT(cppcoreguidelines-init-variables)
+	va_start(args, p_format);
+	char buffer[1024] = {'\0'};
+	vsnprintf(buffer, sizeof(buffer), p_format, args);
+	va_end(args);
+	UtilityFunctions::print_verbose(buffer);
+}
+
+#ifdef JPH_ENABLE_ASSERTS
+
+bool jolt_assert(const char* p_expr, const char* p_msg, const char* p_file, uint32_t p_line) {
+	ERR_PRINT(vformat(
+		"Assertion '{}' failed with message '{}' at '{}:{}'",
+		p_expr,
+		p_msg != nullptr ? p_msg : "",
+		p_file,
+		p_line
+	));
+
+	CRASH_NOW();
+
+	return false;
+}
+
+#endif // JPH_ENABLE_ASSERTS
+
+void initialize_jolt_hooks() {
+	JPH::Allocate = &jolt_alloc;
+	JPH::Free = &jolt_free;
+	JPH::AlignedAllocate = &jolt_aligned_alloc;
+	JPH::AlignedFree = &jolt_aligned_free;
+
+	JPH::Trace = &jolt_trace;
+
+	JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = jolt_assert;)
+
+	JPH::Factory::sInstance = new JPH::Factory();
+
+	JPH::RegisterTypes();
+}
+
+void deinitialize_jolt_hooks() {
+	delete JPH::Factory::sInstance;
+	JPH::Factory::sInstance = nullptr;
+}

--- a/src/jolt_hooks.hpp
+++ b/src/jolt_hooks.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+void initialize_jolt_hooks();
+
+void deinitialize_jolt_hooks();

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,4 +1,5 @@
 #include "jolt_debug_geometry_3d.hpp"
+#include "jolt_hooks.hpp"
 #include "jolt_physics_direct_body_state_3d.hpp"
 #include "jolt_physics_direct_space_state_3d.hpp"
 #include "jolt_physics_server_3d.hpp"
@@ -13,6 +14,8 @@ void on_initialize(ModuleInitializationLevel p_level) {
 		case MODULE_INITIALIZATION_LEVEL_CORE: {
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
+			initialize_jolt_hooks();
+
 			ClassDB::register_class<JoltPhysicsDirectBodyState3D>();
 			ClassDB::register_class<JoltPhysicsDirectSpaceState3D>();
 			ClassDB::register_class<JoltPhysicsServer3D>();
@@ -42,6 +45,8 @@ void on_terminate(ModuleInitializationLevel p_level) {
 				memdelete(server_factory);
 				server_factory = nullptr;
 			}
+
+			deinitialize_jolt_hooks();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
 		} break;


### PR DESCRIPTION
This is to lessen the friction involved with switching back-and-forth between the Jolt-based physics server and the default Godot Physics server during development.

Previously the Jolt hooks were assigned by the physics server. Not having the Jolt allocation functions assigned creates problems when trying to create instances of any Jolt-related types, such as the new `JoltDebugRenderer`.

Assigning these hooks at extension initialization instead makes that a bit more forgiving.