### PR TITLE
Added support for `_integrate_forces`

### DIFF
--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -370,7 +370,10 @@ void JoltBody3D::integrate_forces(bool p_lock) {
 }
 
 void JoltBody3D::call_queries() {
-	// TODO(mihe): Call force integration callback
+	if (force_integration_callback.is_valid()) {
+		const Array arguments = Array::make(get_direct_state(), force_integration_userdata);
+		force_integration_callback.callv(arguments);
+	}
 
 	if (body_state_callback.is_valid()) {
 		body_state_callback.callv(Array::make(get_direct_state()));

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -19,6 +19,13 @@ public:
 
 	void set_state_sync_callback(const Callable& p_callback);
 
+	bool has_force_integration_callback() const { return force_integration_callback.is_valid(); }
+
+	void set_force_integration_callback(const Callable& p_callback, const Variant& p_userdata) {
+		force_integration_callback = p_callback;
+		force_integration_userdata = p_userdata;
+	}
+
 	bool get_initial_sleep_state() const override { return initial_sleep_state; }
 
 	bool get_sleep_state(bool p_lock = true) const;
@@ -161,6 +168,10 @@ private:
 	Vector3 constant_torque;
 
 	Callable body_state_callback;
+
+	Callable force_integration_callback;
+
+	Variant force_integration_userdata;
 
 	JoltPhysicsDirectBodyState3D* direct_state = nullptr;
 };

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -808,14 +808,14 @@ double JoltPhysicsServer3D::_body_get_contacts_reported_depth_threshold(
 
 void JoltPhysicsServer3D::_body_set_omit_force_integration(
 	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] bool p_enable
+	bool p_enable
 ) {
-	ERR_FAIL_NOT_IMPL();
+	ERR_FAIL_COND_MSG(p_enable, "Custom integrators are not supported by Godot Jolt.");
 }
 
 bool JoltPhysicsServer3D::_body_is_omitting_force_integration([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_NOT_IMPL();
+	return false;
 }
 
 void JoltPhysicsServer3D::_body_set_state_sync_callback(
@@ -829,11 +829,14 @@ void JoltPhysicsServer3D::_body_set_state_sync_callback(
 }
 
 void JoltPhysicsServer3D::_body_set_force_integration_callback(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] const Callable& p_callable,
-	[[maybe_unused]] const Variant& p_userdata
+	const RID& p_body,
+	const Callable& p_callable,
+	const Variant& p_userdata
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_force_integration_callback(p_callable, p_userdata);
 }
 
 void JoltPhysicsServer3D::_body_set_ray_pickable(const RID& p_body, bool p_enable) {


### PR DESCRIPTION
Related to #93.

This adds support for the virtual method `_integrate_forces` of `RigidBody3D`.