### PR TITLE
Updated godot-cpp to 4.0-beta12

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 1e565c836b6edc4097893bb4e2d83ce011a31fca
+	GIT_COMMIT 9b48a745e44d398fdb745946682894109b0b3feb
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@1e565c836b6edc4097893bb4e2d83ce011a31fca aka `4.0-beta11` to godot-jolt/godot-cpp@9b48a745e44d398fdb745946682894109b0b3feb aka `4.0-beta12` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/1e565c836b6edc4097893bb4e2d83ce011a31fca...9b48a745e44d398fdb745946682894109b0b3feb)).