### PR TITLE
Changed default `new`/`delete` to use mimalloc

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -5,6 +5,8 @@
 #include "jolt_physics_server_3d.hpp"
 #include "jolt_physics_server_factory_3d.hpp"
 
+#include <mimalloc-new-delete.h>
+
 namespace {
 
 JoltPhysicsServerFactory3D* server_factory = nullptr;


### PR DESCRIPTION
I could've sworn I ran into issues when trying this when I first introduced mimalloc, but apparently this just works. Granted, most of the allocations are already done either through godot-cpp's `memnew`/`memdelete` or through Jolt's overridden allocators, but this should complement #151 nicely, as all containers utilize these default operators.