### PR TITLE
Added support for "Exclude Nodes From Collision" in joints

### DIFF
--- a/src/jolt_cone_twist_joint_3d.cpp
+++ b/src/jolt_cone_twist_joint_3d.cpp
@@ -13,14 +13,14 @@ constexpr double GDJOLT_CONE_TWIST_JOINT_DEFAULT_RELAXATION = 1.0;
 
 JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D& p_body_a,
-	const JoltBody3D& p_body_b,
+	JoltBody3D* p_body_a,
+	JoltBody3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space) {
-	const JPH::BodyID body_ids[] = {p_body_a.get_jolt_id(), p_body_b.get_jolt_id()};
+	: JoltJoint3D(p_space, p_body_a, p_body_b) {
+	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
 	const JoltWritableBody3D jolt_body_a = bodies[0];
@@ -48,13 +48,13 @@ JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 
 JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D& p_body_a,
+	JoltBody3D* p_body_a,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space) {
-	const JoltWritableBody3D jolt_body_a = space->write_body(p_body_a, p_lock);
+	: JoltJoint3D(p_space, p_body_a) {
+	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
 	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();

--- a/src/jolt_cone_twist_joint_3d.hpp
+++ b/src/jolt_cone_twist_joint_3d.hpp
@@ -6,8 +6,8 @@ class JoltConeTwistJoint3D final : public JoltJoint3D {
 public:
 	JoltConeTwistJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D& p_body_a,
-		const JoltBody3D& p_body_b,
+		JoltBody3D* p_body_a,
+		JoltBody3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -15,7 +15,7 @@ public:
 
 	JoltConeTwistJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D& p_body_a,
+		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true

--- a/src/jolt_generic_6dof_joint_3d.cpp
+++ b/src/jolt_generic_6dof_joint_3d.cpp
@@ -27,32 +27,29 @@ constexpr double GDJOLT_G6DOF_ANG_SPRING_EQUILIBRIUM_POINT = 0.0;
 
 JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D* p_body_a,
-	const JoltBody3D* p_body_b,
+	JoltBody3D* p_body_a,
+	JoltBody3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	[[maybe_unused]] const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space)
-	, body_a(p_body_a)
-	, body_b(p_body_b) {
+	: JoltJoint3D(p_space, p_body_a, p_body_b) {
 	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
-	world_ref = p_body_a->get_transform(false) * p_local_ref_a;
+	world_ref = body_a->get_transform(false) * p_local_ref_a;
 
 	rebuild(false);
 }
 
 JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D* p_body_a,
+	JoltBody3D* p_body_a,
 	[[maybe_unused]] const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space)
-	, body_a(p_body_a)
+	: JoltJoint3D(p_space, p_body_a)
 	, world_ref(p_local_ref_b) {
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());

--- a/src/jolt_generic_6dof_joint_3d.hpp
+++ b/src/jolt_generic_6dof_joint_3d.hpp
@@ -20,8 +20,8 @@ class JoltGeneric6DOFJoint3D final : public JoltJoint3D {
 public:
 	JoltGeneric6DOFJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D* p_body_a,
-		const JoltBody3D* p_body_b,
+		JoltBody3D* p_body_a,
+		JoltBody3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -29,7 +29,7 @@ public:
 
 	JoltGeneric6DOFJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D* p_body_a,
+		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -63,10 +63,6 @@ private:
 	bool use_limits[AXIS_COUNT] = {};
 
 	bool motor_enabled[AXIS_COUNT] = {};
-
-	const JoltBody3D* body_a = nullptr;
-
-	const JoltBody3D* body_b = nullptr;
 
 	double limit_lower[AXIS_COUNT] = {};
 

--- a/src/jolt_hinge_joint_3d.cpp
+++ b/src/jolt_hinge_joint_3d.cpp
@@ -14,14 +14,14 @@ constexpr double GDJOLT_HINGE_JOINT_DEFAULT_RELAXATION = 1.0;
 
 JoltHingeJoint3D::JoltHingeJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D& p_body_a,
-	const JoltBody3D& p_body_b,
+	JoltBody3D* p_body_a,
+	JoltBody3D* p_body_b,
 	const Transform3D& p_hinge_a,
 	const Transform3D& p_hinge_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space) {
-	const JPH::BodyID body_ids[] = {p_body_a.get_jolt_id(), p_body_b.get_jolt_id()};
+	: JoltJoint3D(p_space, p_body_a, p_body_b) {
+	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
 	const JoltWritableBody3D jolt_body_a = bodies[0];
@@ -49,13 +49,13 @@ JoltHingeJoint3D::JoltHingeJoint3D(
 
 JoltHingeJoint3D::JoltHingeJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D& p_body_a,
+	JoltBody3D* p_body_a,
 	const Transform3D& p_hinge_a,
 	const Transform3D& p_hinge_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space) {
-	const JoltWritableBody3D jolt_body_a = space->write_body(p_body_a, p_lock);
+	: JoltJoint3D(p_space, p_body_a) {
+	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
 	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();

--- a/src/jolt_hinge_joint_3d.hpp
+++ b/src/jolt_hinge_joint_3d.hpp
@@ -6,8 +6,8 @@ class JoltHingeJoint3D final : public JoltJoint3D {
 public:
 	JoltHingeJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D& p_body_a,
-		const JoltBody3D& p_body_b,
+		JoltBody3D* p_body_a,
+		JoltBody3D* p_body_b,
 		const Transform3D& p_hinge_a,
 		const Transform3D& p_hinge_b,
 		bool p_lock = true
@@ -15,7 +15,7 @@ public:
 
 	JoltHingeJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D& p_body_a,
+		JoltBody3D* p_body_a,
 		const Transform3D& p_hinge_a,
 		const Transform3D& p_hinge_b,
 		bool p_lock = true

--- a/src/jolt_joint_3d.cpp
+++ b/src/jolt_joint_3d.cpp
@@ -1,5 +1,6 @@
 #include "jolt_joint_3d.hpp"
 
+#include "jolt_body_3d.hpp"
 #include "jolt_space_3d.hpp"
 
 namespace {
@@ -8,8 +9,10 @@ constexpr int64_t GDJOLT_JOINT_DEFAULT_SOLVER_PRIORITY = 1;
 
 } // namespace
 
-JoltJoint3D::JoltJoint3D(JoltSpace3D* p_space)
-	: space(p_space) { }
+JoltJoint3D::JoltJoint3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b)
+	: space(p_space)
+	, body_a(p_body_a)
+	, body_b(p_body_b) { }
 
 JoltJoint3D::~JoltJoint3D() {
 	if (jolt_ref != nullptr) {
@@ -27,5 +30,23 @@ void JoltJoint3D::set_solver_priority(int64_t p_priority) {
 			"Joint solver priority is not supported by Godot Jolt. "
 			"Any such value will be ignored."
 		);
+	}
+}
+
+void JoltJoint3D::set_collision_disabled(bool p_disabled) {
+	collision_disabled = p_disabled;
+
+	if (body_b == nullptr) {
+		return;
+	}
+
+	PhysicsServer3D* physics_server = PhysicsServer3D::get_singleton();
+
+	if (collision_disabled) {
+		physics_server->body_add_collision_exception(body_a->get_rid(), body_b->get_rid());
+		physics_server->body_add_collision_exception(body_b->get_rid(), body_a->get_rid());
+	} else {
+		physics_server->body_remove_collision_exception(body_a->get_rid(), body_b->get_rid());
+		physics_server->body_remove_collision_exception(body_b->get_rid(), body_a->get_rid());
 	}
 }

--- a/src/jolt_joint_3d.hpp
+++ b/src/jolt_joint_3d.hpp
@@ -7,7 +7,7 @@ class JoltJoint3D {
 public:
 	JoltJoint3D() = default;
 
-	explicit JoltJoint3D(JoltSpace3D* p_space);
+	JoltJoint3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b = nullptr);
 
 	virtual ~JoltJoint3D();
 
@@ -25,10 +25,20 @@ public:
 
 	void set_solver_priority(int64_t p_priority);
 
+	bool is_collision_disabled() const { return collision_disabled; }
+
+	void set_collision_disabled(bool p_disabled);
+
 protected:
 	RID rid;
 
 	JoltSpace3D* space = nullptr;
 
+	JoltBody3D* body_a = nullptr;
+
+	JoltBody3D* body_b = nullptr;
+
 	JPH::Ref<JPH::Constraint> jolt_ref;
+
+	bool collision_disabled = false;
 };

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -1120,6 +1120,7 @@ void JoltPhysicsServer3D::_joint_make_pin(
 		: memnew(JoltPinJoint3D(space, body_a, p_local_a, p_local_b));
 
 	new_joint->set_rid(old_joint->get_rid());
+	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1209,10 +1210,11 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	ERR_FAIL_NULL(space);
 
 	JoltJoint3D* new_joint = body_b != nullptr
-		? memnew(JoltHingeJoint3D(space, *body_a, *body_b, p_hinge_a, p_hinge_b))
-		: memnew(JoltHingeJoint3D(space, *body_a, p_hinge_a, p_hinge_b));
+		? memnew(JoltHingeJoint3D(space, body_a, body_b, p_hinge_a, p_hinge_b))
+		: memnew(JoltHingeJoint3D(space, body_a, p_hinge_a, p_hinge_b));
 
 	new_joint->set_rid(old_joint->get_rid());
+	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1301,10 +1303,11 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	ERR_FAIL_NULL(space);
 
 	JoltJoint3D* new_joint = body_b != nullptr
-		? memnew(JoltSliderJoint3D(space, *body_a, *body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltSliderJoint3D(space, *body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltSliderJoint3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltSliderJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
+	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1355,10 +1358,11 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	ERR_FAIL_NULL(space);
 
 	JoltJoint3D* new_joint = body_b != nullptr
-		? memnew(JoltConeTwistJoint3D(space, *body_a, *body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltConeTwistJoint3D(space, *body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltConeTwistJoint3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltConeTwistJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
+	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1415,6 +1419,7 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 		: memnew(JoltGeneric6DOFJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
+	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1500,16 +1505,20 @@ int64_t JoltPhysicsServer3D::_joint_get_solver_priority(const RID& p_joint) cons
 }
 
 void JoltPhysicsServer3D::_joint_disable_collisions_between_bodies(
-	[[maybe_unused]] const RID& p_joint,
-	[[maybe_unused]] bool p_disable
+	const RID& p_joint,
+	bool p_disable
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	joint->set_collision_disabled(p_disable);
 }
 
-bool JoltPhysicsServer3D::_joint_is_disabled_collisions_between_bodies(
-	[[maybe_unused]] const RID& p_joint
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+bool JoltPhysicsServer3D::_joint_is_disabled_collisions_between_bodies(const RID& p_joint) const {
+	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	return joint->is_collision_disabled();
 }
 
 void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {

--- a/src/jolt_pin_joint_3d.cpp
+++ b/src/jolt_pin_joint_3d.cpp
@@ -13,15 +13,13 @@ constexpr double GDJOLT_PIN_JOINT_DEFAULT_IMPULSE_CLAMP = 0.0;
 
 JoltPinJoint3D::JoltPinJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D* p_body_a,
-	const JoltBody3D* p_body_b,
+	JoltBody3D* p_body_a,
+	JoltBody3D* p_body_b,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space)
-	, body_a(p_body_a)
-	, body_b(p_body_b)
+	: JoltJoint3D(p_space, p_body_a, p_body_b)
 	, local_a(p_local_a)
 	, local_b(p_local_b) {
 	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
@@ -48,13 +46,12 @@ JoltPinJoint3D::JoltPinJoint3D(
 
 JoltPinJoint3D::JoltPinJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D* p_body_a,
+	JoltBody3D* p_body_a,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space)
-	, body_a(p_body_a)
+	: JoltJoint3D(p_space, p_body_a)
 	, local_a(p_local_a)
 	, local_b(p_local_b) {
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);

--- a/src/jolt_pin_joint_3d.hpp
+++ b/src/jolt_pin_joint_3d.hpp
@@ -9,8 +9,8 @@ class JoltPinJoint3D final : public JoltJoint3D {
 public:
 	JoltPinJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D* p_body_a,
-		const JoltBody3D* p_body_b,
+		JoltBody3D* p_body_a,
+		JoltBody3D* p_body_b,
 		const Vector3& p_local_a,
 		const Vector3& p_local_b,
 		bool p_lock = true
@@ -18,7 +18,7 @@ public:
 
 	JoltPinJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D* p_body_a,
+		JoltBody3D* p_body_a,
 		const Vector3& p_local_a,
 		const Vector3& p_local_b,
 		bool p_lock = true
@@ -39,10 +39,6 @@ public:
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
 
 private:
-	const JoltBody3D* body_a = nullptr;
-
-	const JoltBody3D* body_b = nullptr;
-
 	Vector3 local_a;
 
 	Vector3 local_b;

--- a/src/jolt_slider_joint_3d.cpp
+++ b/src/jolt_slider_joint_3d.cpp
@@ -36,14 +36,14 @@ constexpr double GDJOLT_SLIDER_ANG_ORTHO_DAMPING = 1.0;
 
 JoltSliderJoint3D::JoltSliderJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D& p_body_a,
-	const JoltBody3D& p_body_b,
+	JoltBody3D* p_body_a,
+	JoltBody3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space) {
-	const JPH::BodyID body_ids[] = {p_body_a.get_jolt_id(), p_body_b.get_jolt_id()};
+	: JoltJoint3D(p_space, p_body_a, p_body_b) {
+	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
 	const JoltWritableBody3D jolt_body_a = bodies[0];
@@ -72,13 +72,13 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 
 JoltSliderJoint3D::JoltSliderJoint3D(
 	JoltSpace3D* p_space,
-	const JoltBody3D& p_body_a,
+	JoltBody3D* p_body_a,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space) {
-	const JoltWritableBody3D jolt_body_a = space->write_body(p_body_a, p_lock);
+	: JoltJoint3D(p_space, p_body_a) {
+	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
 	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();

--- a/src/jolt_slider_joint_3d.hpp
+++ b/src/jolt_slider_joint_3d.hpp
@@ -6,8 +6,8 @@ class JoltSliderJoint3D final : public JoltJoint3D {
 public:
 	JoltSliderJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D& p_body_a,
-		const JoltBody3D& p_body_b,
+		JoltBody3D* p_body_a,
+		JoltBody3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -15,7 +15,7 @@ public:
 
 	JoltSliderJoint3D(
 		JoltSpace3D* p_space,
-		const JoltBody3D& p_body_a,
+		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true


### PR DESCRIPTION
Related to #106, #107, #108, #109, #110.

This makes use of the collision exceptions introduced in #162 and should pretty much finish up all the joints, or at least as much as they can be with regards to being a drop-in replacement.