### PR TITLE
Updated godot-cpp to 4.0-beta16

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 015a4a3d23b82e005e58f8b5f933750e9919bed3
+	GIT_COMMIT 632bf3721ba8e3226e5a20354d8b73278b7a4e15
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES

--- a/examples/scenes/common/scripts/free_look_camera.gd
+++ b/examples/scenes/common/scripts/free_look_camera.gd
@@ -1,7 +1,7 @@
 class_name FreeLookCamera3D extends Camera3D
 
 @export_range(0.0, 1000.0, 0.1, "or_greater", "exp", "suffix:u/s")
-var initial_speed = 10.0
+var initial_speed := 10.0
 
 @export_range(0.0, 100.0, 0.5, "or_greater")
 var interpolation_speed := 15.0


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@015a4a3d23b82e005e58f8b5f933750e9919bed3 aka `4.0-beta15` to godot-jolt/godot-cpp@632bf3721ba8e3226e5a20354d8b73278b7a4e15 aka `4.0-beta16` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/015a4a3d23b82e005e58f8b5f933750e9919bed3...632bf3721ba8e3226e5a20354d8b73278b7a4e15)).