### PR TITLE
Added user data decorator shape to allow sharing of shapes

### DIFF
--- a/src/jolt_hooks.cpp
+++ b/src/jolt_hooks.cpp
@@ -1,5 +1,7 @@
 #include "jolt_hooks.hpp"
 
+#include "jolt_override_user_data_shape.hpp"
+
 void* jolt_alloc(size_t p_size) {
 	return mi_malloc(p_size);
 }
@@ -57,6 +59,8 @@ void initialize_jolt_hooks() {
 	JPH::Factory::sInstance = new JPH::Factory();
 
 	JPH::RegisterTypes();
+
+	JoltOverrideUserDataShape::register_type();
 }
 
 void deinitialize_jolt_hooks() {

--- a/src/jolt_override_user_data_shape.cpp
+++ b/src/jolt_override_user_data_shape.cpp
@@ -1,0 +1,177 @@
+#include "jolt_override_user_data_shape.hpp"
+
+namespace {
+
+JPH::Shape* construct_override_user_data() {
+	return new JoltOverrideUserDataShape();
+}
+
+void collide_override_user_data_vs_shape(
+	const JPH::Shape* p_shape1,
+	const JPH::Shape* p_shape2,
+	JPH::Vec3Arg p_scale1,
+	JPH::Vec3Arg p_scale2,
+	JPH::Mat44Arg p_center_of_mass_transform1,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	const JPH::CollideShapeSettings& p_collide_shape_settings,
+	JPH::CollideShapeCollector& p_collector,
+	const JPH::ShapeFilter& p_shape_filter
+) {
+	ERR_FAIL_COND(p_shape1->GetSubType() != JPH::EShapeSubType::User1);
+
+	const auto* shape1 = static_cast<const JoltOverrideUserDataShape*>(p_shape1);
+
+	JPH::CollisionDispatch::sCollideShapeVsShape(
+		shape1->GetInnerShape(),
+		p_shape2,
+		p_scale1,
+		p_scale2,
+		p_center_of_mass_transform1,
+		p_center_of_mass_transform2,
+		p_sub_shape_id_creator1,
+		p_sub_shape_id_creator2,
+		p_collide_shape_settings,
+		p_collector,
+		p_shape_filter
+	);
+}
+
+void collide_shape_vs_override_user_data(
+	const JPH::Shape* p_shape1,
+	const JPH::Shape* p_shape2,
+	JPH::Vec3Arg p_scale1,
+	JPH::Vec3Arg p_scale2,
+	JPH::Mat44Arg p_center_of_mass_transform1,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	const JPH::CollideShapeSettings& p_collide_shape_settings,
+	JPH::CollideShapeCollector& p_collector,
+	const JPH::ShapeFilter& p_shape_filter
+) {
+	ERR_FAIL_COND(p_shape2->GetSubType() != JPH::EShapeSubType::User1);
+
+	const auto* shape2 = static_cast<const JoltOverrideUserDataShape*>(p_shape2);
+
+	JPH::CollisionDispatch::sCollideShapeVsShape(
+		p_shape1,
+		shape2->GetInnerShape(),
+		p_scale1,
+		p_scale2,
+		p_center_of_mass_transform1,
+		p_center_of_mass_transform2,
+		p_sub_shape_id_creator1,
+		p_sub_shape_id_creator2,
+		p_collide_shape_settings,
+		p_collector,
+		p_shape_filter
+	);
+}
+
+void cast_override_user_data_vs_shape(
+	const JPH::ShapeCast& p_shape_cast,
+	const JPH::ShapeCastSettings& p_shape_cast_settings,
+	const JPH::Shape* p_shape,
+	JPH::Vec3Arg p_scale,
+	const JPH::ShapeFilter& p_shape_filter,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	JPH::CastShapeCollector& p_collector
+) {
+	ERR_FAIL_COND(p_shape_cast.mShape->GetSubType() != JPH::EShapeSubType::User1);
+
+	const auto* shape = static_cast<const JoltOverrideUserDataShape*>(p_shape_cast.mShape);
+
+	const JPH::ShapeCast shape_cast(
+		shape->GetInnerShape(),
+		p_shape_cast.mScale,
+		p_shape_cast.mCenterOfMassStart,
+		p_shape_cast.mDirection
+	);
+
+	JPH::CollisionDispatch::sCastShapeVsShapeLocalSpace(
+		shape_cast,
+		p_shape_cast_settings,
+		p_shape,
+		p_scale,
+		p_shape_filter,
+		p_center_of_mass_transform2,
+		p_sub_shape_id_creator1,
+		p_sub_shape_id_creator2,
+		p_collector
+	);
+}
+
+void cast_shape_vs_override_user_data(
+	const JPH::ShapeCast& p_shape_cast,
+	const JPH::ShapeCastSettings& p_shape_cast_settings,
+	const JPH::Shape* p_shape,
+	JPH::Vec3Arg p_scale,
+	const JPH::ShapeFilter& p_shape_filter,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	JPH::CastShapeCollector& p_collector
+) {
+	ERR_FAIL_COND(p_shape->GetSubType() != JPH::EShapeSubType::User1);
+
+	const auto* shape = static_cast<const JoltOverrideUserDataShape*>(p_shape);
+
+	JPH::CollisionDispatch::sCastShapeVsShapeLocalSpace(
+		p_shape_cast,
+		p_shape_cast_settings,
+		shape->GetInnerShape(),
+		p_scale,
+		p_shape_filter,
+		p_center_of_mass_transform2,
+		p_sub_shape_id_creator1,
+		p_sub_shape_id_creator2,
+		p_collector
+	);
+}
+
+} // namespace
+
+void JoltOverrideUserDataShape::register_type() {
+	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JPH::EShapeSubType::User1);
+
+	shape_functions.mConstruct = construct_override_user_data;
+	shape_functions.mColor = JPH::Color::sCyan;
+
+	for (const JPH::EShapeSubType sub_type : JPH::sAllSubShapeTypes) {
+		JPH::CollisionDispatch::sRegisterCollideShape(
+			JPH::EShapeSubType::User1,
+			sub_type,
+			collide_override_user_data_vs_shape
+		);
+
+		JPH::CollisionDispatch::sRegisterCollideShape(
+			sub_type,
+			JPH::EShapeSubType::User1,
+			collide_shape_vs_override_user_data
+		);
+
+		JPH::CollisionDispatch::sRegisterCastShape(
+			JPH::EShapeSubType::User1,
+			sub_type,
+			cast_override_user_data_vs_shape
+		);
+
+		JPH::CollisionDispatch::sRegisterCastShape(
+			sub_type,
+			JPH::EShapeSubType::User1,
+			cast_shape_vs_override_user_data
+		);
+	}
+}
+
+JPH::ShapeSettings::ShapeResult JoltOverrideUserDataShapeSettings::Create() const {
+	if (mCachedResult.IsEmpty()) {
+		new JoltOverrideUserDataShape(*this, mCachedResult);
+	}
+
+	return mCachedResult;
+}

--- a/src/jolt_override_user_data_shape.hpp
+++ b/src/jolt_override_user_data_shape.hpp
@@ -1,0 +1,233 @@
+#pragma once
+
+class JoltOverrideUserDataShapeSettings final : public JPH::DecoratedShapeSettings {
+public:
+	JoltOverrideUserDataShapeSettings() = default;
+
+	explicit JoltOverrideUserDataShapeSettings(const JPH::ShapeSettings* p_shape_settings)
+		: DecoratedShapeSettings(p_shape_settings) { }
+
+	explicit JoltOverrideUserDataShapeSettings(const JPH::Shape* p_shape)
+		: DecoratedShapeSettings(p_shape) { }
+
+	ShapeResult Create() const override;
+};
+
+class JoltOverrideUserDataShape final : public JPH::DecoratedShape {
+public:
+	static void register_type();
+
+	JoltOverrideUserDataShape()
+		: DecoratedShape(JPH::EShapeSubType::User1) { }
+
+	JoltOverrideUserDataShape(
+		const JoltOverrideUserDataShapeSettings& p_settings,
+		ShapeResult& p_result
+	)
+		: DecoratedShape(JPH::EShapeSubType::User1, p_settings, p_result) {
+		if (!p_result.HasError()) {
+			p_result.Set(this);
+		}
+	}
+
+	JPH::AABox GetLocalBounds() const override { return mInnerShape->GetLocalBounds(); }
+
+	JPH::AABox GetWorldSpaceBounds(JPH::Mat44Arg p_center_of_mass_transform, JPH::Vec3Arg p_scale)
+		const override {
+		return mInnerShape->GetWorldSpaceBounds(p_center_of_mass_transform, p_scale);
+	}
+
+	float GetInnerRadius() const override { return mInnerShape->GetInnerRadius(); }
+
+	JPH::MassProperties GetMassProperties() const override {
+		return mInnerShape->GetMassProperties();
+	}
+
+	JPH::Vec3 GetSurfaceNormal(
+		const JPH::SubShapeID& p_sub_shape_id,
+		JPH::Vec3Arg p_local_surface_position
+	) const override {
+		return mInnerShape->GetSurfaceNormal(p_sub_shape_id, p_local_surface_position);
+	}
+
+	JPH::uint64 GetSubShapeUserData([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id
+	) const override {
+		return GetUserData();
+	}
+
+	JPH::TransformedShape GetSubShapeTransformedShape(
+		const JPH::SubShapeID& p_sub_shape_id,
+		JPH::Vec3Arg p_position_com,
+		JPH::QuatArg p_rotation,
+		JPH::Vec3Arg p_scale,
+		JPH::SubShapeID& p_remainder
+	) const override {
+		return mInnerShape->GetSubShapeTransformedShape(
+			p_sub_shape_id,
+			p_position_com,
+			p_rotation,
+			p_scale,
+			p_remainder
+		);
+	}
+
+	// clang-format off
+
+	void GetSubmergedVolume(
+		JPH::Mat44Arg p_center_of_mass_transform,
+		JPH::Vec3Arg p_scale,
+		const JPH::Plane& p_surface,
+		float& p_total_volume,
+		float& p_submerged_volume,
+		JPH::Vec3& p_center_of_buoyancy
+		JPH_IF_DEBUG_RENDERER(, JPH::RVec3Arg p_base_offset)
+	) const override {
+		mInnerShape->GetSubmergedVolume(
+			p_center_of_mass_transform,
+			p_scale,
+			p_surface,
+			p_total_volume,
+			p_submerged_volume,
+			p_center_of_buoyancy
+			JPH_IF_DEBUG_RENDERER(, p_base_offset)
+		);
+	}
+
+	// clang-format on
+
+#ifdef JPH_DEBUG_RENDERER
+	void Draw(
+		JPH::DebugRenderer* p_renderer,
+		JPH::RMat44Arg p_center_of_mass_transform,
+		JPH::Vec3Arg p_scale,
+		JPH::ColorArg p_color,
+		bool p_use_material_colors,
+		bool p_draw_wireframe
+	) const override {
+		mInnerShape->Draw(
+			p_renderer,
+			p_center_of_mass_transform,
+			p_scale,
+			p_color,
+			p_use_material_colors,
+			p_draw_wireframe
+		);
+	}
+
+	void DrawGetSupportFunction(
+		JPH::DebugRenderer* p_renderer,
+		JPH::RMat44Arg p_center_of_mass_transform,
+		JPH::Vec3Arg p_scale,
+		JPH::ColorArg p_color,
+		bool p_draw_support_direction
+	) const override {
+		mInnerShape->DrawGetSupportFunction(
+			p_renderer,
+			p_center_of_mass_transform,
+			p_scale,
+			p_color,
+			p_draw_support_direction
+		);
+	}
+
+	void DrawGetSupportingFace(
+		JPH::DebugRenderer* p_renderer,
+		JPH::RMat44Arg p_center_of_mass_transform,
+		JPH::Vec3Arg p_scale
+	) const override {
+		mInnerShape->DrawGetSupportingFace(p_renderer, p_center_of_mass_transform, p_scale);
+	}
+#endif // JPH_DEBUG_RENDERER
+
+	bool CastRay(
+		const JPH::RayCast& p_ray,
+		const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		JPH::RayCastResult& p_hit
+	) const override {
+		return mInnerShape->CastRay(p_ray, p_sub_shape_id_creator, p_hit);
+	}
+
+	void CastRay(
+		const JPH::RayCast& p_ray,
+		const JPH::RayCastSettings& p_ray_cast_settings,
+		const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		JPH::CastRayCollector& p_collector,
+		const JPH::ShapeFilter& p_shape_filter = {}
+	) const override {
+		return mInnerShape->CastRay(
+			p_ray,
+			p_ray_cast_settings,
+			p_sub_shape_id_creator,
+			p_collector,
+			p_shape_filter
+		);
+	}
+
+	void CollidePoint(
+		JPH::Vec3Arg p_point,
+		const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		JPH::CollidePointCollector& p_collector,
+		const JPH::ShapeFilter& p_shape_filter = {}
+	) const override {
+		mInnerShape->CollidePoint(p_point, p_sub_shape_id_creator, p_collector, p_shape_filter);
+	}
+
+	void CollectTransformedShapes(
+		const JPH::AABox& p_box,
+		JPH::Vec3Arg p_position_com,
+		JPH::QuatArg p_rotation,
+		JPH::Vec3Arg p_scale,
+		const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		JPH::TransformedShapeCollector& p_collector,
+		const JPH::ShapeFilter& p_shape_filter = {}
+	) const override {
+		mInnerShape->CollectTransformedShapes(
+			p_box,
+			p_position_com,
+			p_rotation,
+			p_scale,
+			p_sub_shape_id_creator,
+			p_collector,
+			p_shape_filter
+		);
+	}
+
+	void TransformShape(
+		JPH::Mat44Arg p_center_of_mass_transform,
+		JPH::TransformedShapeCollector& p_collector
+	) const override {
+		mInnerShape->TransformShape(p_center_of_mass_transform, p_collector);
+	}
+
+	void GetTrianglesStart(
+		GetTrianglesContext& p_context,
+		const JPH::AABox& p_box,
+		JPH::Vec3Arg p_position_com,
+		JPH::QuatArg p_rotation,
+		JPH::Vec3Arg p_scale
+	) const override {
+		mInnerShape->GetTrianglesStart(p_context, p_box, p_position_com, p_rotation, p_scale);
+	}
+
+	int GetTrianglesNext(
+		GetTrianglesContext& p_context,
+		int p_max_triangles_requested,
+		JPH::Float3* p_triangle_vertices,
+		const JPH::PhysicsMaterial** p_materials = nullptr
+	) const override {
+		return mInnerShape->GetTrianglesNext(
+			p_context,
+			p_max_triangles_requested,
+			p_triangle_vertices,
+			p_materials
+		);
+	}
+
+	Stats GetStats() const override { return {sizeof(*this), 0}; }
+
+	float GetVolume() const override { return mInnerShape->GetVolume(); }
+
+	bool IsValidScale(JPH::Vec3Arg p_scale) const override {
+		return mInnerShape->IsValidScale(p_scale);
+	}
+};

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -22,7 +22,9 @@ public:
 
 	virtual bool is_valid() const = 0;
 
-	virtual JPH::ShapeRefC try_build(uint64_t p_user_data) const = 0;
+	virtual JPH::ShapeRefC try_build() = 0;
+
+	JPH::ShapeRefC get_jolt_ref() const { return jolt_ref; }
 
 	static JPH::ShapeRefC with_scale(const JPH::ShapeRefC& p_shape, const Vector3& p_scale);
 
@@ -47,8 +49,12 @@ public:
 		const Vector3& p_center_of_mass
 	);
 
+	static JPH::ShapeRefC with_user_data(const JPH::ShapeRefC& p_shape, uint64_t p_user_data);
+
 protected:
 	RID rid;
+
+	JPH::ShapeRefC jolt_ref;
 
 	HashMap<JoltCollisionObject3D*, int32_t> ref_counts_by_owner;
 };
@@ -60,7 +66,7 @@ class JoltSphereShape3D final : public JoltShape3D {
 
 	bool is_valid() const override { return radius > 0; }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();
@@ -76,7 +82,7 @@ public:
 
 	bool is_valid() const override { return half_extents.x > 0; }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();
@@ -92,7 +98,7 @@ public:
 
 	bool is_valid() const override { return radius > 0; }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();
@@ -110,7 +116,7 @@ public:
 
 	bool is_valid() const override { return radius > 0; }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();
@@ -128,7 +134,7 @@ public:
 
 	bool is_valid() const override { return !vertices.is_empty(); }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();
@@ -144,7 +150,7 @@ public:
 
 	bool is_valid() const override { return !faces.is_empty(); }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();
@@ -162,7 +168,7 @@ public:
 
 	bool is_valid() const override { return width > 0; }
 
-	JPH::ShapeRefC try_build(uint64_t p_user_data) const override;
+	JPH::ShapeRefC try_build() override;
 
 private:
 	void clear_data();

--- a/src/jolt_shape_instance_3d.cpp
+++ b/src/jolt_shape_instance_3d.cpp
@@ -11,11 +11,13 @@ bool JoltShapeInstance3D::try_build(
 		return false;
 	}
 
-	JPH::ShapeRefC jolt_ref = p_shape->try_build(p_user_data);
+	JPH::ShapeRefC jolt_ref = p_shape->try_build();
 
 	if (jolt_ref == nullptr) {
 		return false;
 	}
+
+	jolt_ref = JoltShape3D::with_user_data(jolt_ref, p_user_data);
 
 	p_built_shape.shape = &p_shape;
 	p_built_shape.jolt_ref = std::move(jolt_ref);

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -52,6 +52,7 @@
 #include <Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h>
 #include <Jolt/Physics/Collision/CastResult.h>
 #include <Jolt/Physics/Collision/CollisionCollectorImpl.h>
+#include <Jolt/Physics/Collision/CollisionDispatch.h>
 #include <Jolt/Physics/Collision/CollisionGroup.h>
 #include <Jolt/Physics/Collision/GroupFilter.h>
 #include <Jolt/Physics/Collision/NarrowPhaseQuery.h>


### PR DESCRIPTION
This PR fixes some of the unfortunate side effects of #128, specifically the inability to share shapes between objects.

This is achieved by implementing a custom decorator shape called `JoltOverrideUserDataShape`, which is about as simple as you can possibly make a decorator shape. Its only purpose is to forward everything to its inner shape, except for `GetSubShapeUserData`, where it will return its own user data instead.

This means we don't have to recreate the Jolt representation of shapes for every instance of those shapes just for the sake of bundling a unique user data, and instead we can cache and reuse shapes and simply wrap them in this new decorator shape for every shape instance.

Note that this can be a bit of a footgun if you wrap something like a `JPH::StaticCompoundShape`, since you'd be overriding the user data for all of its sub shapes as well. Thankfully we create any compound shapes _after_ we've wrapped the shapes in our user data, so this shouldn't be a problem.