### PR TITLE
Added support for `get_velocity_at_local_position`

### DIFF
--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -129,6 +129,18 @@ Vector3 JoltCollisionObject3D::get_center_of_mass(bool p_lock) const {
 	return to_godot(body->GetCenterOfMassPosition());
 }
 
+Vector3 JoltCollisionObject3D::get_velocity_at_local_position(
+	const Vector3& p_position,
+	bool p_lock
+) const {
+	ERR_FAIL_NULL_D(space);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetPointVelocity(body->GetWorldTransform() * to_jolt(p_position)));
+}
+
 JPH::MassProperties JoltCollisionObject3D::calculate_mass_properties(const JPH::Shape& p_shape
 ) const {
 	const float mass = get_mass();

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -49,6 +49,8 @@ public:
 
 	Vector3 get_center_of_mass(bool p_lock = true) const;
 
+	Vector3 get_velocity_at_local_position(const Vector3& p_position, bool p_lock = true) const;
+
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 
 	JPH::MassProperties calculate_mass_properties(bool p_lock = true) const;

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -72,9 +72,10 @@ Transform3D JoltPhysicsDirectBodyState3D::_get_transform() const {
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_velocity_at_local_position(
-	[[maybe_unused]] const Vector3& p_local_position
+	const Vector3& p_local_position
 ) const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return body->get_velocity_at_local_position(p_local_position);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_central_impulse(const Vector3& p_impulse) {


### PR DESCRIPTION
This is needed for an upcoming PR that adds contact reporting, which needs velocity at the contact points.