### PR TITLE
Removed heap allocations when accessing few bodies

### DIFF
--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -95,6 +95,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace godot;


### PR DESCRIPTION
This fixes the unfortunate side effect of #148, where every single access of a `JPH::Body` would result in a heap allocation, because the underlying storage of `JoltBodyAccessor3D` was always a `JPH::BodyIDVector`.

This PR addressed that by changing the underlying storage to a `std::variant` of either `JPH::BodyID`, `JPH::BodyIDVector` or the new `BodyIDSpan`. This allows for omitting the heap-allocating `JPH::BodyIDVector` when it's not needed.