### PR TITLE
Added emplace and perfect forwarding to containers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -209,7 +209,7 @@ Checks: >
   -modernize-replace-auto-ptr,
   modernize-replace-random-shuffle,
   modernize-shrink-to-fit,
-  modernize-use-emplace,
+  -modernize-use-emplace,
   modernize-use-transparent-functors,
   performance-faster-string-find,
   performance-inefficient-algorithm,

--- a/src/hash_set.hpp
+++ b/src/hash_set.hpp
@@ -47,7 +47,14 @@ public:
 
 	_FORCE_INLINE_ void remove(ConstIterator p_iter) { storage.erase(p_iter); }
 
-	_FORCE_INLINE_ Iterator insert(TKey p_key) { return storage.insert(std::move(p_key)).first; }
+	_FORCE_INLINE_ Iterator insert(const TKey& p_key) { return emplace(p_key); }
+
+	_FORCE_INLINE_ Iterator insert(TKey&& p_key) { return emplace(std::move(p_key)); }
+
+	template<typename... TArgs>
+	_FORCE_INLINE_ Iterator emplace(TArgs&&... p_args) {
+		return storage.emplace(std::forward<TArgs>(p_args)...).first;
+	}
 
 	_FORCE_INLINE_ Iterator begin() { return storage.begin(); }
 

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -244,7 +244,7 @@ void JoltCollisionObject3D::add_shape(
 	bool p_disabled,
 	bool p_lock
 ) {
-	shapes.push_back({p_shape, p_transform, p_disabled});
+	shapes.emplace_back(p_shape, p_transform, p_disabled);
 	p_shape->add_owner(this);
 	rebuild_shape(p_lock);
 }

--- a/src/local_vector.hpp
+++ b/src/local_vector.hpp
@@ -17,7 +17,14 @@ public:
 	LocalVector(std::initializer_list<TElement> p_list)
 		: storage(p_list) { }
 
-	_FORCE_INLINE_ void push_back(TElement p_value) { storage.push_back(std::move(p_value)); }
+	_FORCE_INLINE_ void push_back(const TElement& p_value) { emplace_back(p_value); }
+
+	_FORCE_INLINE_ void push_back(TElement&& p_value) { emplace_back(std::move(p_value)); }
+
+	template<typename... TArgs>
+	_FORCE_INLINE_ void emplace_back(TArgs&&... p_args) {
+		storage.emplace_back(std::forward<TArgs>(p_args)...);
+	}
 
 	_FORCE_INLINE_ void remove_at(int32_t p_index) {
 		ERR_FAIL_INDEX(p_index, size());
@@ -59,13 +66,27 @@ public:
 
 	_FORCE_INLINE_ void resize(int32_t p_size) { storage.resize((size_t)p_size); }
 
-	_FORCE_INLINE_ void insert(int32_t p_index, TElement p_value) {
-		ERR_FAIL_INDEX(p_index, size() + 1);
-
-		storage.insert(begin() + p_index, std::move(p_value));
+	_FORCE_INLINE_ void insert(int32_t p_index, const TElement& p_value) {
+		emplace(p_index, p_value);
 	}
 
-	_FORCE_INLINE_ void ordered_insert(TElement p_val) {
+	_FORCE_INLINE_ void insert(int32_t p_index, TElement&& p_value) {
+		emplace(p_index, std::move(p_value));
+	}
+
+	template<typename... TArgs>
+	_FORCE_INLINE_ void emplace(int32_t p_index, TArgs&&... p_args) {
+		ERR_FAIL_INDEX(p_index, size() + 1);
+
+		storage.emplace(begin() + p_index, std::forward<TArgs>(p_args)...);
+	}
+
+	_FORCE_INLINE_ void ordered_insert(const TElement& p_val) {
+		auto position = std::lower_bound(begin(), end(), p_val);
+		storage.insert(position, p_val);
+	}
+
+	_FORCE_INLINE_ void ordered_insert(TElement&& p_val) {
 		auto position = std::lower_bound(begin(), end(), p_val);
 		storage.insert(position, std::move(p_val));
 	}


### PR DESCRIPTION
I also disabled the `modernize-use-emplace` clang-tidy check because I found it to be kinda flaky with custom containers.