### PR TITLE
Updated godot-cpp to 4.0-rc1

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 6fbafc4ba35cbb19229d972800e770f1aa67a6f3
+	GIT_COMMIT 40e679fd6acde90ee087b201fb1024cd9509547b
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@6fbafc4ba35cbb19229d972800e770f1aa67a6f3 aka `4.0-beta17` to godot-jolt/godot-cpp@40e679fd6acde90ee087b201fb1024cd9509547b aka `4.0-rc1` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/6fbafc4ba35cbb19229d972800e770f1aa67a6f3...40e679fd6acde90ee087b201fb1024cd9509547b)).