### PR TITLE
Refactored shape instances

### DIFF
--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -55,7 +55,7 @@ public:
 
 	JPH::MassProperties calculate_mass_properties(bool p_lock = true) const;
 
-	JPH::ShapeRefC try_build_shape() const;
+	JPH::ShapeRefC try_build_shape();
 
 	void rebuild_shape(bool p_lock = true);
 
@@ -70,13 +70,7 @@ public:
 
 	void remove_shape(int32_t p_index, bool p_lock = true);
 
-	void remove_shapes(bool p_lock = true);
-
-	const LocalVector<JoltShapeInstance3D>& get_shapes() const { return shapes; }
-
-	int32_t get_shape_count() const { return shapes.size(); }
-
-	int32_t find_shape_index(JoltShape3D* p_shape);
+	int32_t find_shape_index(uint32_t p_shape_instance_id) const;
 
 	void set_shape_transform(int32_t p_index, const Transform3D& p_transform, bool p_lock = true);
 

--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -130,7 +130,9 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	const auto object_id = (uint64_t)object->get_instance_id();
 
 	const JPH::Shape& shape = *body->GetShape();
-	const auto shape_idx = (int32_t)shape.GetSubShapeUserData(subshape_id);
+	const auto shape_instance_id = (uint32_t)shape.GetSubShapeUserData(subshape_id);
+	const int32_t shape_idx = object->find_shape_index(shape_instance_id);
+	ERR_FAIL_COND_D(shape_idx == -1);
 
 	p_result->position = to_godot(position);
 	p_result->normal = to_godot(normal);

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -1600,7 +1600,6 @@ void JoltPhysicsServer3D::free_area(JoltArea3D* p_area) {
 	ERR_FAIL_NULL(p_area);
 
 	p_area->set_space(nullptr);
-	p_area->remove_shapes();
 	area_owner.free(p_area->get_rid());
 	memdelete_safely(p_area);
 }
@@ -1609,7 +1608,6 @@ void JoltPhysicsServer3D::free_body(JoltBody3D* p_body) {
 	ERR_FAIL_NULL(p_body);
 
 	p_body->set_space(nullptr);
-	p_body->remove_shapes();
 	body_owner.free(p_body->get_rid());
 	memdelete_safely(p_body);
 }

--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -27,9 +27,7 @@ void JoltShape3D::remove_self(bool p_lock) {
 	const auto ref_counts_by_owner_copy = ref_counts_by_owner;
 
 	for (const auto& [owner, ref_count] : ref_counts_by_owner_copy) {
-		for (int32_t i = 0; i < ref_count; ++i) {
-			owner->remove_shape(this, p_lock);
-		}
+		owner->remove_shape(this, p_lock);
 	}
 }
 

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -51,6 +51,9 @@ public:
 
 	static JPH::ShapeRefC with_user_data(const JPH::ShapeRefC& p_shape, uint64_t p_user_data);
 
+	template<typename TCallable>
+	static JPH::ShapeRefC as_compound(TCallable&& p_callable);
+
 protected:
 	virtual JPH::ShapeRefC build() const = 0;
 
@@ -181,3 +184,5 @@ private:
 
 	int32_t depth = 0;
 };
+
+#include "jolt_shape_3d.inl"

--- a/src/jolt_shape_3d.inl
+++ b/src/jolt_shape_3d.inl
@@ -1,0 +1,28 @@
+#pragma once
+
+template<typename TCallable>
+JPH::ShapeRefC JoltShape3D::as_compound(TCallable&& p_callable) {
+	JPH::StaticCompoundShapeSettings shape_settings;
+
+	auto add_shape = [&](const JPH::ShapeRefC& p_shape, const Transform3D& p_transform) {
+		shape_settings.AddShape(to_jolt(p_transform.origin), to_jolt(p_transform.basis), p_shape);
+	};
+
+	while (p_callable(add_shape)) {
+		// ...
+	}
+
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+
+	ERR_FAIL_COND_D_MSG(
+		shape_result.HasError(),
+		vformat(
+			"Failed to create compound shape with sub-shape count '%d'. "
+			"Jolt returned the following error: '%s'.",
+			(int32_t)shape_settings.mSubShapes.size(),
+			to_godot(shape_result.GetError())
+		)
+	);
+
+	return shape_result.Get();
+}

--- a/src/jolt_shape_instance_3d.cpp
+++ b/src/jolt_shape_instance_3d.cpp
@@ -2,73 +2,61 @@
 
 #include "jolt_shape_3d.hpp"
 
-bool JoltShapeInstance3D::try_build(
-	const JoltShapeInstance3D& p_shape,
-	uint64_t p_user_data,
-	Built& p_built_shape
-) {
-	if (p_shape.is_disabled()) {
+JoltShapeInstance3D::JoltShapeInstance3D(
+	JoltCollisionObject3D* p_parent,
+	JoltShape3D* p_shape,
+	const Transform3D& p_transform,
+	bool p_disabled
+)
+	: transform(p_transform)
+	, parent(p_parent)
+	, shape(p_shape)
+	, disabled(p_disabled) {
+	shape->add_owner(parent);
+}
+
+JoltShapeInstance3D::JoltShapeInstance3D(JoltShapeInstance3D&& p_other) noexcept {
+	*this = std::move(p_other);
+}
+
+JoltShapeInstance3D::~JoltShapeInstance3D() {
+	if (shape != nullptr) {
+		shape->remove_owner(parent);
+	}
+}
+
+bool JoltShapeInstance3D::try_build() {
+	ERR_FAIL_COND_D(is_disabled());
+
+	const JPH::ShapeRefC maybe_new_shape = shape->try_build();
+
+	if (maybe_new_shape == nullptr) {
+		jolt_ref = nullptr;
 		return false;
 	}
 
-	JPH::ShapeRefC jolt_ref = p_shape->try_build();
+	if (jolt_ref != nullptr) {
+		const auto* outer_shape = static_cast<const JPH::DecoratedShape*>(jolt_ref.GetPtr());
 
-	if (jolt_ref == nullptr) {
-		return false;
+		if (outer_shape->GetInnerShape() == maybe_new_shape) {
+			return true;
+		}
 	}
 
-	jolt_ref = JoltShape3D::with_user_data(jolt_ref, p_user_data);
-
-	p_built_shape.shape = &p_shape;
-	p_built_shape.jolt_ref = std::move(jolt_ref);
+	jolt_ref = JoltShape3D::with_user_data(maybe_new_shape, (uint64_t)id);
 
 	return true;
 }
 
-int32_t JoltShapeInstance3D::try_build(
-	const JoltShapeInstance3D* p_shapes,
-	int32_t p_count,
-	Built* p_built_shapes
-) {
-	Built* built_shapes_begin = p_built_shapes;
-	Built* built_shapes_end = built_shapes_begin;
-
-	for (int32_t i = 0; i < p_count; ++i) {
-		Built built_shape;
-		if (try_build(p_shapes[i], (uint64_t)i, built_shape)) {
-			*built_shapes_end++ = std::move(built_shape);
-		}
+JoltShapeInstance3D& JoltShapeInstance3D::operator=(JoltShapeInstance3D&& p_other) noexcept {
+	if (this != &p_other) {
+		transform = p_other.transform;
+		parent = std::exchange(p_other.parent, nullptr);
+		shape = std::exchange(p_other.shape, nullptr);
+		jolt_ref = std::move(p_other.jolt_ref);
+		id = p_other.id;
+		disabled = p_other.disabled;
 	}
 
-	return int32_t(built_shapes_end - built_shapes_begin);
-}
-
-JPH::ShapeRefC JoltShapeInstance3D::build_compound(const Built* p_built_shapes, int32_t p_count) {
-	JPH::StaticCompoundShapeSettings shape_settings;
-
-	for (int32_t i = 0; i < p_count; ++i) {
-		const Built& built_shape = p_built_shapes[i];
-		const JoltShapeInstance3D& shape = *built_shape.shape;
-		const JPH::ShapeRefC& jolt_ref = built_shape.jolt_ref;
-
-		shape_settings.AddShape(
-			to_jolt(shape.get_transform().origin),
-			to_jolt(shape.get_transform().basis),
-			jolt_ref
-		);
-	}
-
-	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-
-	ERR_FAIL_COND_D_MSG(
-		shape_result.HasError(),
-		vformat(
-			"Failed to create compound shape with sub-shape count '%d'. "
-			"Jolt returned the following error: '%s'.",
-			p_count,
-			to_godot(shape_result.GetError())
-		)
-	);
-
-	return shape_result.Get();
+	return *this;
 }

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -1,67 +1,61 @@
 #pragma once
 
+class JoltCollisionObject3D;
 class JoltShape3D;
 
 class JoltShapeInstance3D {
 public:
-	struct Built {
-		const JoltShapeInstance3D* shape = nullptr;
-		JPH::ShapeRefC jolt_ref;
-	};
+	JoltShapeInstance3D(
+		JoltCollisionObject3D* p_parent,
+		JoltShape3D* p_shape,
+		const Transform3D& p_transform,
+		bool p_disabled
+	);
 
-	JoltShapeInstance3D() = default;
+	JoltShapeInstance3D(const JoltShapeInstance3D& p_other) = delete;
 
-	JoltShapeInstance3D(JoltShape3D* p_shape, const Transform3D& p_transform, bool p_disabled)
-		: transform(p_transform)
-		, shape(p_shape)
-		, disabled(p_disabled) { }
+	JoltShapeInstance3D(JoltShapeInstance3D&& p_other) noexcept;
 
-	JoltShape3D* get() const { return shape; }
+	~JoltShapeInstance3D();
+
+	uint32_t get_id() const { return id; }
+
+	JoltShape3D* get_shape() const { return shape; }
+
+	JPH::ShapeRefC get_jolt_ref() const { return jolt_ref; }
 
 	const Transform3D& get_transform() const { return transform; }
 
 	void set_transform(const Transform3D& p_transform) { transform = p_transform; }
 
-	bool is_disabled() const { return disabled; }
+	bool is_built() const { return jolt_ref != nullptr; }
 
 	bool is_enabled() const { return !disabled; }
 
-	void set_disabled(bool p_disabled) { disabled = p_disabled; }
+	bool is_disabled() const { return disabled; }
 
-	JoltShape3D* operator->() const { return shape; }
+	void enable() { disabled = false; }
 
-	JoltShape3D& operator*() const { return *shape; }
+	void disable() { disabled = true; }
 
-	explicit operator JoltShape3D*() const { return shape; }
+	bool try_build();
 
-	bool operator==(const JoltShapeInstance3D& p_other) { return shape == p_other.shape; }
+	JoltShapeInstance3D& operator=(const JoltShapeInstance3D& p_other) = delete;
 
-	friend bool operator==(const JoltShapeInstance3D& p_lhs, JoltShape3D* p_rhs) {
-		return p_lhs.shape == p_rhs;
-	}
-
-	friend bool operator==(JoltShape3D* p_lhs, const JoltShapeInstance3D& p_rhs) {
-		return p_lhs == p_rhs.shape;
-	}
-
-	static bool try_build(
-		const JoltShapeInstance3D& p_shape,
-		uint64_t p_user_data,
-		Built& p_built_shape
-	);
-
-	static int32_t try_build(
-		const JoltShapeInstance3D* p_shapes,
-		int32_t p_count,
-		Built* p_built_shapes
-	);
-
-	static JPH::ShapeRefC build_compound(const Built* p_built_shapes, int32_t p_count);
+	JoltShapeInstance3D& operator=(JoltShapeInstance3D&& p_other) noexcept;
 
 private:
+	inline static uint32_t next_id = 1;
+
 	Transform3D transform;
 
+	JPH::ShapeRefC jolt_ref;
+
+	JoltCollisionObject3D* parent = nullptr;
+
 	JoltShape3D* shape = nullptr;
+
+	uint32_t id = next_id++;
 
 	bool disabled = false;
 };


### PR DESCRIPTION
This refactoring came out of needing a stable user data for shapes, as opposed to the shape index that was being stored there until now. Shape instances now store a globally unique ID in the user data instead. This means that we don't necessarily have to rebuild the `JoltOverrideUserDataShape` all the time, so shape instances now hold on to their `JPH::ShapeRefC`. This also means that we don't have to build shape instances into some intermediate structure, which cleaned up a fair few places.

Shape instances are now responsible for registering and unregistering their parent collision object with the shape, which leads to more straight-forward RAII semantics, instead of having to remember to call `add_owner`/`remove_owner` all the time. It does however burden the shape instances with needing a non-trivial move-assignment operator.

I moved the creation of compound shapes from `JoltShapeInstance3D` over to `JoltShape3D`, where the rest of the shape creation happens, in the form of `JoltShape3D::as_compound`. The multi-stage process of creating a compound shape demanded a somewhat awkward interface for said function, but I think it's a reasonable compromise in order to have most of the shape creation in one place.

I also removed the somewhat weird pointer-like interface on shape instances.