### PR TITLE
Added `as` helper to `JoltAccessibleBody3D`

### DIFF
--- a/src/jolt_body_accessor_3d.hpp
+++ b/src/jolt_body_accessor_3d.hpp
@@ -145,6 +145,15 @@ public:
 
 	bool is_invalid() const { return body == nullptr; }
 
+	template<typename TType>
+	TType* as() const {
+		if (body != nullptr) {
+			return reinterpret_cast<TType*>(body->GetUserData());
+		} else {
+			return nullptr;
+		}
+	}
+
 	TBody* operator->() const { return body; }
 
 	TBody& operator*() const { return *body; }

--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -121,12 +121,12 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	const JPH::SubShapeID& subshape_id = collector.mHit.mSubShapeID2;
 
 	const JoltReadableBody3D body = space->read_body(body_id);
-	ERR_FAIL_COND_D(body.is_invalid());
+	const auto* object = body.as<JoltCollisionObject3D>();
+	ERR_FAIL_NULL_D(object);
 
 	const JPH::Vec3 position = ray.GetPointOnRay(collector.mHit.mFraction);
 	const JPH::Vec3 normal = body->GetWorldSpaceSurfaceNormal(subshape_id, position);
 
-	auto* object = reinterpret_cast<JoltCollisionObject3D*>(body->GetUserData());
 	const auto object_id = (uint64_t)object->get_instance_id();
 
 	const JPH::Shape& shape = *body->GetShape();


### PR DESCRIPTION
This can save a line here or there, by not having to extract and cast the user data.