### PR TITLE
Fixed incorrect `get_velocity_at_local_position`

### DIFF
--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -129,16 +129,14 @@ Vector3 JoltCollisionObject3D::get_center_of_mass(bool p_lock) const {
 	return to_godot(body->GetCenterOfMassPosition());
 }
 
-Vector3 JoltCollisionObject3D::get_velocity_at_local_position(
-	const Vector3& p_position,
-	bool p_lock
-) const {
+Vector3 JoltCollisionObject3D::get_velocity_at_position(const Vector3& p_position, bool p_lock)
+	const {
 	ERR_FAIL_NULL_D(space);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	return to_godot(body->GetPointVelocity(body->GetWorldTransform() * to_jolt(p_position)));
+	return to_godot(body->GetPointVelocity(to_jolt(p_position)));
 }
 
 JPH::MassProperties JoltCollisionObject3D::calculate_mass_properties(const JPH::Shape& p_shape

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -49,7 +49,7 @@ public:
 
 	Vector3 get_center_of_mass(bool p_lock = true) const;
 
-	Vector3 get_velocity_at_local_position(const Vector3& p_position, bool p_lock = true) const;
+	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const;
 
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -75,7 +75,7 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_velocity_at_local_position(
 	const Vector3& p_local_position
 ) const {
 	ERR_FAIL_NULL_D(body);
-	return body->get_velocity_at_local_position(p_local_position);
+	return body->get_velocity_at_position(body->get_position() + p_local_position);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_central_impulse(const Vector3& p_impulse) {


### PR DESCRIPTION
It turns out "local" means "relative" (in world-space) in this context and not "local-space" like I thought.