### PR TITLE
Refactored creation of collision objects

### DIFF
--- a/src/jolt_area_3d.cpp
+++ b/src/jolt_area_3d.cpp
@@ -43,3 +43,11 @@ void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant
 void JoltArea3D::call_queries() {
 	// TOOD(mihe): Call `area_monitor_callback`
 }
+
+void JoltArea3D::create_in_space(bool p_lock) {
+	JPH::BodyCreationSettings settings = create_begin();
+
+	settings.mIsSensor = true;
+
+	create_end(settings, p_lock);
+}

--- a/src/jolt_area_3d.hpp
+++ b/src/jolt_area_3d.hpp
@@ -24,41 +24,17 @@ public:
 
 	void call_queries() override;
 
-	Vector3 get_initial_linear_velocity() const override { return {0, 0, 0}; }
-
-	Vector3 get_initial_angular_velocity() const override { return {0, 0, 0}; }
-
 	bool has_custom_center_of_mass() const override { return false; }
 
 	Vector3 get_center_of_mass_custom() const override { return {0, 0, 0}; }
 
 	bool get_initial_sleep_state() const override { return false; }
 
-	PhysicsServer3D::BodyMode get_mode() const override {
-		return PhysicsServer3D::BODY_MODE_KINEMATIC;
-	}
-
-	bool is_ccd_enabled() const override { return false; }
-
-	float get_mass() const override { return 1.0f; }
-
-	Vector3 get_inertia() const override { return {0, 0, 0}; }
-
-	float get_bounce() const override { return 0.0f; }
-
-	float get_friction() const override { return 1.0f; }
-
-	float get_gravity_scale() const override { return 1.0f; }
-
-	float get_linear_damp() const override { return 0.0f; }
-
-	float get_angular_damp() const override { return 0.0f; }
-
-	bool is_area() const override { return true; }
-
-	bool can_sleep() const override { return false; }
-
 private:
+	JPH::EMotionType get_motion_type() const override { return JPH::EMotionType::Kinematic; }
+
+	void create_in_space(bool p_lock = true) override;
+
 	Vector3 gravity_vector = {0, -1, 0};
 
 	float gravity = 9.81f;

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -32,15 +32,15 @@ public:
 
 	void set_sleep_state(bool p_enabled, bool p_lock = true);
 
-	bool can_sleep() const override { return allowed_sleep; }
+	bool can_sleep() const { return allowed_sleep; }
 
 	void set_can_sleep(bool p_enabled, bool p_lock = true);
 
 	Basis get_inverse_inertia_tensor(bool p_lock = true) const;
 
-	Vector3 get_initial_linear_velocity() const override { return initial_linear_velocity; }
+	Vector3 get_initial_linear_velocity() const { return initial_linear_velocity; }
 
-	Vector3 get_initial_angular_velocity() const override { return initial_angular_velocity; }
+	Vector3 get_initial_angular_velocity() const { return initial_angular_velocity; }
 
 	Vector3 get_linear_velocity(bool p_lock = true) const;
 
@@ -98,46 +98,52 @@ public:
 
 	JoltPhysicsDirectBodyState3D* get_direct_state();
 
-	PhysicsServer3D::BodyMode get_mode() const override { return mode; }
+	PhysicsServer3D::BodyMode get_mode() const { return mode; }
 
 	void set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock = true);
 
-	bool is_ccd_enabled() const override { return ccd_enabled; }
+	bool is_ccd_enabled() const { return ccd_enabled; }
 
 	void set_ccd_enabled(bool p_enable, bool p_lock = true);
 
-	float get_mass() const override { return mass; }
+	float get_mass() const { return mass; }
 
 	void set_mass(float p_mass, bool p_lock = true);
 
-	Vector3 get_inertia() const override { return inertia; }
+	Vector3 get_inertia() const { return inertia; }
 
 	void set_inertia(const Vector3& p_inertia, bool p_lock = true);
 
-	float get_bounce() const override { return bounce; }
+	float get_bounce() const { return bounce; }
 
 	void set_bounce(float p_bounce, bool p_lock = true);
 
-	float get_friction() const override { return friction; }
+	float get_friction() const { return friction; }
 
 	void set_friction(float p_friction, bool p_lock = true);
 
-	float get_gravity_scale() const override { return gravity_scale; }
+	float get_gravity_scale() const { return gravity_scale; }
 
 	void set_gravity_scale(float p_scale, bool p_lock = true);
 
-	float get_linear_damp() const override { return linear_damp; }
+	float get_linear_damp() const { return linear_damp; }
 
 	void set_linear_damp(float p_damp, bool p_lock = true);
 
-	float get_angular_damp() const override { return angular_damp; }
+	float get_angular_damp() const { return angular_damp; }
 
 	void set_angular_damp(float p_damp, bool p_lock = true);
 
-	bool is_area() const override { return false; }
-
 private:
+	JPH::EMotionType get_motion_type() const override;
+
+	void create_in_space(bool p_lock = true) override;
+
 	void shapes_changed(bool p_lock) override;
+
+	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
+
+	JPH::MassProperties calculate_mass_properties(bool p_lock = true) const;
 
 	void mass_properties_changed(bool p_lock);
 

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -51,10 +51,6 @@ public:
 
 	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const;
 
-	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
-
-	JPH::MassProperties calculate_mass_properties(bool p_lock = true) const;
-
 	JPH::ShapeRefC try_build_shape();
 
 	void rebuild_shape(bool p_lock = true);
@@ -82,39 +78,27 @@ public:
 
 	virtual void call_queries() = 0;
 
-	virtual Vector3 get_initial_linear_velocity() const = 0;
-
-	virtual Vector3 get_initial_angular_velocity() const = 0;
-
+protected:
 	virtual bool has_custom_center_of_mass() const = 0;
 
 	virtual Vector3 get_center_of_mass_custom() const = 0;
 
 	virtual bool get_initial_sleep_state() const = 0;
 
-	virtual PhysicsServer3D::BodyMode get_mode() const = 0;
+	virtual JPH::EMotionType get_motion_type() const = 0;
 
-	virtual bool is_ccd_enabled() const = 0;
+	virtual void create_in_space(bool p_lock = true) = 0;
 
-	virtual float get_mass() const = 0;
+	JPH::BodyCreationSettings create_begin();
 
-	virtual Vector3 get_inertia() const = 0;
+	JPH::Body* create_end(const JPH::BodyCreationSettings& p_settings, bool p_lock = true);
 
-	virtual float get_bounce() const = 0;
+	void destroy_in_space(bool p_lock = true);
 
-	virtual float get_friction() const = 0;
+	void add_to_space(bool p_lock = true);
 
-	virtual float get_gravity_scale() const = 0;
+	void remove_from_space(bool p_lock = true);
 
-	virtual float get_linear_damp() const = 0;
-
-	virtual float get_angular_damp() const = 0;
-
-	virtual bool is_area() const = 0;
-
-	virtual bool can_sleep() const = 0;
-
-protected:
 	virtual void shapes_changed([[maybe_unused]] bool p_lock) { }
 
 	RID rid;

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -4,7 +4,6 @@
 
 class JoltArea3D;
 class JoltBody3D;
-class JoltCollisionObject3D;
 class JoltJoint3D;
 class JoltLayerMapper;
 class JoltPhysicsDirectSpaceState3D;
@@ -68,14 +67,6 @@ public:
 	Variant get_param(PhysicsServer3D::AreaParameter p_param) const;
 
 	void set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value);
-
-	void create_object(JoltCollisionObject3D* p_object, bool p_lock = true);
-
-	void add_object(JoltCollisionObject3D* p_object, bool p_lock = true);
-
-	void remove_object(JoltCollisionObject3D* p_object, bool p_lock = true);
-
-	void destroy_object(JoltCollisionObject3D* p_object, bool p_lock = true);
 
 	void add_joint(JoltJoint3D* p_joint);
 


### PR DESCRIPTION
This moves the creation/destruction and adding/removal of `JPH::Body` from `JoltSpace3D` to `JoltCollisionObject3D`, `JoltArea3D` and `JoltBody3D`. This removes the need for a lot of the virtual functions previously found in `JoltCollisionObject3D`.