### PR TITLE
Added bounds-checking to containers

### DIFF
--- a/src/hash_map.hpp
+++ b/src/hash_map.hpp
@@ -38,9 +38,17 @@ public:
 
 	_FORCE_INLINE_ void clear() { storage.clear(); }
 
-	_FORCE_INLINE_ TValue& get(const TKey& p_key) { return storage.at(p_key); }
+	_FORCE_INLINE_ TValue& get(const TKey& p_key) {
+		auto iter = storage.find(p_key);
+		CRASH_COND(iter == end());
+		return iter->second;
+	}
 
-	_FORCE_INLINE_ const TValue& get(const TKey& p_key) const { return storage.at(p_key); }
+	_FORCE_INLINE_ const TValue& get(const TKey& p_key) const {
+		auto iter = storage.find(p_key);
+		CRASH_COND(iter == end());
+		return iter->second;
+	}
 
 	_FORCE_INLINE_ const TValue* getptr(const TKey& p_key) const {
 		auto iter = storage.find(p_key);

--- a/src/local_vector.hpp
+++ b/src/local_vector.hpp
@@ -145,9 +145,13 @@ public:
 
 	_FORCE_INLINE_ ConstIterator cend() const { return storage.cend(); }
 
-	_FORCE_INLINE_ TElement& operator[](int32_t p_index) { return storage[(size_t)p_index]; }
+	_FORCE_INLINE_ TElement& operator[](int32_t p_index) {
+		CRASH_BAD_INDEX(p_index, size());
+		return storage[(size_t)p_index];
+	}
 
 	_FORCE_INLINE_ const TElement& operator[](int32_t p_index) const {
+		CRASH_BAD_INDEX(p_index, size());
 		return storage[(size_t)p_index];
 	}
 


### PR DESCRIPTION
`HashMap::get` was technically already doing it through `std::unordered_map::at`, but I figured this mimicked the Godot equivalent better with `CRASH_*` rather than throwing an exception.