### PR TITLE
Updated godot-cpp to 4.0-rc2

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 40e679fd6acde90ee087b201fb1024cd9509547b
+	GIT_COMMIT 234024cfcf58fe57b4c6d58be72ee11673d48634
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@40e679fd6acde90ee087b201fb1024cd9509547b aka `4.0-rc1` to godot-jolt/godot-cpp@234024cfcf58fe57b4c6d58be72ee11673d48634 aka `4.0-rc2` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/40e679fd6acde90ee087b201fb1024cd9509547b...234024cfcf58fe57b4c6d58be72ee11673d48634)).