### PR TITLE
Updated Jolt to 37a4137ef9

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -29,7 +29,7 @@ set(dev_definitions
 
 GodotJoltExternalLibrary_Add(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 9b9ca187190c55a21825b90537191f4071b127bc
+	GIT_COMMIT 37a4137ef901c747cdf604d920820461b3690cd1
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@9b9ca187190c55a21825b90537191f4071b127bc to godot-jolt/jolt@37a4137ef901c747cdf604d920820461b3690cd1 (see diff [here](https://github.com/godot-jolt/jolt/compare/9b9ca187190c55a21825b90537191f4071b127bc...37a4137ef901c747cdf604d920820461b3690cd1)).

This brings in the new helper function `JPH::EstimateCollisionResponse`, which is needed for calculating (somewhat) correct contact impulses.