### PR TITLE
Fixed broken area monitoring

### DIFF
--- a/src/jolt_layer_mapper.cpp
+++ b/src/jolt_layer_mapper.cpp
@@ -13,14 +13,19 @@ public:
 	constexpr JoltBroadPhaseLayerTable() {
 		using namespace JoltBroadPhaseLayer;
 
+		allow_collision(BODY_STATIC, BODY_DYNAMIC);
+
 		allow_collision(BODY_DYNAMIC, BODY_STATIC);
 		allow_collision(BODY_DYNAMIC, BODY_DYNAMIC);
+		allow_collision(BODY_DYNAMIC, AREA_DETECTABLE);
+		allow_collision(BODY_DYNAMIC, AREA_UNDETECTABLE);
 
 		allow_collision(AREA_DETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_DETECTABLE, AREA_DETECTABLE);
 		allow_collision(AREA_DETECTABLE, AREA_UNDETECTABLE);
 
 		allow_collision(AREA_UNDETECTABLE, BODY_DYNAMIC);
+		allow_collision(AREA_UNDETECTABLE, AREA_DETECTABLE);
 	}
 
 	constexpr void allow_collision(UnderlyingType p_layer1, UnderlyingType p_layer2) {


### PR DESCRIPTION
Apparently some last-minute changes to #193 had broken area monitoring.

Somehow I had managed convince myself that the results from `ShouldCollide` in `JPH::ObjectVsBroadPhaseLayerFilter` didn't need to be reciprocal, meaning I thought contacts would still be generated as long as (for example) objects in the `AREA_DETECTABLE` broad phase layer returned `true` when queried about the `BODY_DYNAMIC` broad phase layer, but not the other way around. This is apparently not true and these relationships do need to be reciprocal.