### PR TITLE
Added server methods related to area collision layer/mask

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -360,11 +360,25 @@ void JoltPhysicsServer3D::_area_set_collision_mask(const RID& p_area, uint32_t p
 	area->set_collision_mask(p_mask);
 }
 
+uint32_t JoltPhysicsServer3D::_area_get_collision_mask(const RID& p_area) const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	return area->get_collision_mask();
+}
+
 void JoltPhysicsServer3D::_area_set_collision_layer(const RID& p_area, uint32_t p_layer) {
 	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_collision_layer(p_layer);
+}
+
+uint32_t JoltPhysicsServer3D::_area_get_collision_layer(const RID& p_area) const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	return area->get_collision_layer();
 }
 
 void JoltPhysicsServer3D::_area_set_monitorable(const RID& p_area, bool p_monitorable) {

--- a/src/jolt_physics_server_3d.hpp
+++ b/src/jolt_physics_server_3d.hpp
@@ -128,7 +128,11 @@ public:
 
 	void _area_set_collision_layer(const RID& p_area, uint32_t p_layer) override;
 
+	uint32_t _area_get_collision_layer(const RID& p_area) const override;
+
 	void _area_set_collision_mask(const RID& p_area, uint32_t p_mask) override;
+
+	uint32_t _area_get_collision_mask(const RID& p_area) const override;
 
 	void _area_set_monitorable(const RID& p_area, bool p_monitorable) override;
 


### PR DESCRIPTION
This adds overrides for, and implements, the getters for the collision mask and layer of areas.

These getters were added back at the end of September 2022, so they're not necessarily new, but I guess that must have been right after I added overrides of all the other server methods.