### PR TITLE
Added function that extracts scale from transform/basis

### DIFF
--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -104,21 +104,10 @@ JPH::ShapeRefC JoltShape3D::with_transform(
 		return shape;
 	}
 
-	const Vector3 scale_squared(
-		transform.basis.get_column(Vector3::AXIS_X).length_squared(),
-		transform.basis.get_column(Vector3::AXIS_Y).length_squared(),
-		transform.basis.get_column(Vector3::AXIS_Z).length_squared()
-	);
+	Vector3 scale(1.0f, 1.0f, 1.0f);
 
-	if (scale_squared != Vector3(1.0f, 1.0f, 1.0f)) {
-		const Vector3 scale(
-			Math::sqrt(scale_squared.x),
-			Math::sqrt(scale_squared.y),
-			Math::sqrt(scale_squared.z)
-		);
-
+	if (try_extract_scale(transform, scale)) {
 		shape = with_scale(shape, scale);
-		transform = transform.orthonormalized();
 	}
 
 	return with_basis_origin(shape, transform.basis, transform.origin);

--- a/src/misc/utility_functions.hpp
+++ b/src/misc/utility_functions.hpp
@@ -52,6 +52,40 @@ _FORCE_INLINE_ void memdelete_safely(TType*& p_ptr) {
 	}
 }
 
+_FORCE_INLINE_ bool try_extract_scale(Basis& p_basis, Vector3& p_scale) {
+	p_scale = Vector3(1.0f, 1.0f, 1.0f);
+
+	Vector3 x = p_basis.get_column(Vector3::AXIS_X);
+	Vector3 y = p_basis.get_column(Vector3::AXIS_Y);
+	Vector3 z = p_basis.get_column(Vector3::AXIS_Z);
+
+	const Vector3 scale_squared(x.length_squared(), y.length_squared(), z.length_squared());
+
+	if (p_scale == scale_squared) {
+		return false;
+	}
+
+	p_scale = Vector3(
+		Math::sqrt(scale_squared.x),
+		Math::sqrt(scale_squared.y),
+		Math::sqrt(scale_squared.z)
+	);
+
+	x /= p_scale.x;
+	y /= p_scale.y;
+	z /= p_scale.z;
+
+	p_basis.set_column(Vector3::AXIS_X, x);
+	p_basis.set_column(Vector3::AXIS_Y, y);
+	p_basis.set_column(Vector3::AXIS_Z, z);
+
+	return true;
+}
+
+_FORCE_INLINE_ bool try_extract_scale(Transform3D& p_transform, Vector3& p_scale) {
+	return try_extract_scale(p_transform.basis, p_scale);
+}
+
 inline double calculate_physics_step() {
 	// TODO(mihe): Replace these constants with the appropriate singleton calls once
 	// godotengine/godot-cpp#889 is fixed


### PR DESCRIPTION
A somewhat minor optimization as opposed to just doing `*.get_scale_abs()` and `*.orthonormalize()`, but since most of the shape-casts (in an upcoming PR) will have to extract/strip the scale from transforms, I figured this might worthwhile.