### PR TITLE
Fixed broken `collider` in ray-cast results

### DIFF
--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -7,6 +7,24 @@
 
 JoltCollisionObject3D::~JoltCollisionObject3D() = default;
 
+void* JoltCollisionObject3D::get_instance() const {
+	return internal::gde_interface->object_get_instance_from_id(instance_id);
+}
+
+Object* JoltCollisionObject3D::get_instance_unsafe() const {
+	// HACK(mihe): This is being deliberately and incorrectly cast to a godot-cpp `Object` when in
+	// reality it's a Godot `Object`. This is meant to be used in places where an `Object` is
+	// returned through a parameter, such as in `PhysicsServer3DExtensionRayResult`, because
+	// godot-cpp is unable to do the necessary unwrapping of the instance bindings in such cases.
+	//
+	// Dereferencing this pointer from the extension will lead to bad things.
+	return static_cast<Object*>(get_instance());
+}
+
+Object* JoltCollisionObject3D::get_instance_wrapped() const {
+	return ObjectDB::get_instance(instance_id);
+}
+
 void JoltCollisionObject3D::set_space(JoltSpace3D* p_space, bool p_lock) {
 	if (space == p_space) {
 		return;

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -21,6 +21,12 @@ public:
 
 	void set_jolt_id(JPH::BodyID p_jolt_id) { jolt_id = p_jolt_id; }
 
+	void* get_instance() const;
+
+	Object* get_instance_unsafe() const;
+
+	Object* get_instance_wrapped() const;
+
 	JoltSpace3D* get_space() const { return space; }
 
 	void set_space(JoltSpace3D* p_space, bool p_lock = true);

--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -133,7 +133,7 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	p_result->normal = to_godot(normal);
 	p_result->rid = object->get_rid();
 	p_result->collider_id = object_id;
-	p_result->collider = ObjectDB::get_instance(object_id);
+	p_result->collider = object->get_instance_unsafe();
 	p_result->shape = shape_index;
 
 	return true;


### PR DESCRIPTION
Apparently godot-cpp has some trouble with unwrapping the instance bindings for objects when they're returned through a parameter (like `PhysicsServer3DExtensionRayResult`), which means that objects that are returned from `ObjectDB::get_instance` can't/shouldn't pass through there, so I worked around it by instead fetching the actual engine object instance using GDExtension's `object_get_instance_from_id` function and then dirty-casting it to `Object*`.