### PR TITLE
Updated godot-cpp to 4.0-rc4

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT fc79e1b9acb5bc3cc035dbb4f4d4ac1e9d15e7fe
+	GIT_COMMIT 3093fa8a6e8a194be1d34b81b6740dbb1abf689c
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@fc79e1b9acb5bc3cc035dbb4f4d4ac1e9d15e7fe aka `4.0-rc3` to godot-jolt/godot-cpp@3093fa8a6e8a194be1d34b81b6740dbb1abf689c aka `4.0-rc4` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/fc79e1b9acb5bc3cc035dbb4f4d4ac1e9d15e7fe...3093fa8a6e8a194be1d34b81b6740dbb1abf689c)).