### PR TITLE
Added support for the remaining body state methods

### DIFF
--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -219,6 +219,25 @@ void JoltBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
 	body->SetAllowSleeping(allowed_sleep);
 }
 
+Basis JoltBody3D::get_principal_inertia_axes(bool p_lock) const {
+	ERR_FAIL_NULL_D(space);
+
+	if (mode != PhysicsServer3D::BodyMode::BODY_MODE_RIGID) {
+		return {};
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	// TODO(mihe): See if there's some way of getting this directly from Jolt
+
+	Basis inertia_tensor = to_godot(jolt_shape->GetMassProperties().mInertia).basis;
+	const Basis principal_inertia_axes_local = inertia_tensor.diagonalize().transposed();
+	const Basis principal_inertia_axes = get_basis() * principal_inertia_axes_local;
+
+	return principal_inertia_axes;
+}
+
 Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 

--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -787,6 +787,24 @@ void JoltBody3D::set_angular_damp(float p_damp, bool p_lock) {
 	damp_changed(p_lock);
 }
 
+float JoltBody3D::get_total_linear_damp(bool p_lock) const {
+	ERR_FAIL_NULL_D(space);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return body->GetMotionPropertiesUnchecked()->GetLinearDamping();
+}
+
+float JoltBody3D::get_total_angular_damp(bool p_lock) const {
+	ERR_FAIL_NULL_D(space);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return body->GetMotionPropertiesUnchecked()->GetAngularDamping();
+}
+
 JPH::EMotionType JoltBody3D::get_motion_type() const {
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {

--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -238,6 +238,19 @@ Basis JoltBody3D::get_principal_inertia_axes(bool p_lock) const {
 	return principal_inertia_axes;
 }
 
+Vector3 JoltBody3D::get_inverse_inertia(bool p_lock) const {
+	ERR_FAIL_NULL_D(space);
+
+	if (mode != PhysicsServer3D::BodyMode::BODY_MODE_RIGID) {
+		return {};
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetMotionPropertiesUnchecked()->GetInverseInertiaDiagonal());
+}
+
 Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 

--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -261,7 +261,7 @@ Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	return to_godot(body->GetInverseInertia().GetQuaternion());
+	return to_godot(body->GetInverseInertia()).basis;
 }
 
 Vector3 JoltBody3D::get_linear_velocity(bool p_lock) const {

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -182,6 +182,8 @@ public:
 
 	void set_gravity_scale(float p_scale) { gravity_scale = p_scale; }
 
+	Vector3 get_gravity() const { return gravity; }
+
 	float get_linear_damp() const { return linear_damp; }
 
 	void set_linear_damp(float p_damp, bool p_lock = true);
@@ -266,6 +268,8 @@ private:
 	Vector3 constant_force;
 
 	Vector3 constant_torque;
+
+	Vector3 gravity;
 
 	Callable body_state_callback;
 

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -190,6 +190,10 @@ public:
 
 	void set_angular_damp(float p_damp, bool p_lock = true);
 
+	float get_total_linear_damp(bool p_lock = true) const;
+
+	float get_total_angular_damp(bool p_lock = true) const;
+
 	DampMode get_linear_damp_mode() const { return linear_damp_mode; }
 
 	void set_linear_damp_mode(DampMode p_mode) { linear_damp_mode = p_mode; }

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -64,6 +64,8 @@ public:
 
 	Basis get_principal_inertia_axes(bool p_lock = true) const;
 
+	Vector3 get_inverse_inertia(bool p_lock = true) const;
+
 	Basis get_inverse_inertia_tensor(bool p_lock = true) const;
 
 	Vector3 get_linear_velocity(bool p_lock = true) const;

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -62,6 +62,8 @@ public:
 
 	void set_can_sleep(bool p_enabled, bool p_lock = true);
 
+	Basis get_principal_inertia_axes(bool p_lock = true) const;
+
 	Basis get_inverse_inertia_tensor(bool p_lock = true) const;
 
 	Vector3 get_linear_velocity(bool p_lock = true) const;

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -12,11 +12,13 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_total_gravity() const {
 }
 
 double JoltPhysicsDirectBodyState3D::_get_total_angular_damp() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return (double)body->get_total_angular_damp();
 }
 
 double JoltPhysicsDirectBodyState3D::_get_total_linear_damp() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return (double)body->get_total_linear_damp();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -1,6 +1,7 @@
 #include "jolt_physics_direct_body_state_3d.hpp"
 
 #include "jolt_body_3d.hpp"
+#include "jolt_space_3d.hpp"
 
 JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D* p_body)
 	: body(p_body) { }
@@ -228,7 +229,11 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_contact_collider_velocity_at_position
 }
 
 double JoltPhysicsDirectBodyState3D::_get_step() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+
+	// TODO(mihe): Use `calculate_physics_step` instead (and remove `last_step` entirely) once
+	// godotengine/godot-cpp#889 has been fixed
+	return (double)body->get_space()->get_last_step();
 }
 
 void JoltPhysicsDirectBodyState3D::_integrate_forces() {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -43,7 +43,8 @@ double JoltPhysicsDirectBodyState3D::_get_inverse_mass() const {
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_inverse_inertia() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return body->get_inverse_inertia();
 }
 
 Basis JoltPhysicsDirectBodyState3D::_get_inverse_inertia_tensor() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -20,7 +20,8 @@ double JoltPhysicsDirectBodyState3D::_get_total_linear_damp() const {
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return body->get_center_of_mass();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass_local() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -59,9 +59,9 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_angular_velocity() const {
 	return body->get_angular_velocity();
 }
 
-void JoltPhysicsDirectBodyState3D::_set_angular_velocity([[maybe_unused]] const Vector3& p_velocity
-) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsDirectBodyState3D::_set_angular_velocity(const Vector3& p_velocity) {
+	ERR_FAIL_NULL(body);
+	return body->set_angular_velocity(p_velocity);
 }
 
 void JoltPhysicsDirectBodyState3D::_set_transform(const Transform3D& p_transform) {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -33,7 +33,8 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass_local() const {
 }
 
 Basis JoltPhysicsDirectBodyState3D::_get_principal_inertia_axes() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return body->get_principal_inertia_axes();
 }
 
 double JoltPhysicsDirectBodyState3D::_get_inverse_mass() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -1,6 +1,7 @@
 #include "jolt_physics_direct_body_state_3d.hpp"
 
 #include "jolt_body_3d.hpp"
+#include "jolt_physics_direct_space_state_3d.hpp"
 #include "jolt_space_3d.hpp"
 
 JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D* p_body)
@@ -241,5 +242,5 @@ void JoltPhysicsDirectBodyState3D::_integrate_forces() {
 }
 
 PhysicsDirectSpaceState3D* JoltPhysicsDirectBodyState3D::_get_space_state() {
-	ERR_FAIL_D_NOT_IMPL();
+	return body->get_space()->get_direct_state();
 }

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -64,8 +64,9 @@ void JoltPhysicsDirectBodyState3D::_set_angular_velocity([[maybe_unused]] const 
 	ERR_FAIL_NOT_IMPL();
 }
 
-void JoltPhysicsDirectBodyState3D::_set_transform([[maybe_unused]] const Transform3D& p_transform) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsDirectBodyState3D::_set_transform(const Transform3D& p_transform) {
+	ERR_FAIL_NULL(body);
+	return body->set_transform(p_transform);
 }
 
 Transform3D JoltPhysicsDirectBodyState3D::_get_transform() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -49,9 +49,9 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_linear_velocity() const {
 	return body->get_linear_velocity();
 }
 
-void JoltPhysicsDirectBodyState3D::_set_linear_velocity([[maybe_unused]] const Vector3& p_velocity
-) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsDirectBodyState3D::_set_linear_velocity(const Vector3& p_velocity) {
+	ERR_FAIL_NULL(body);
+	return body->set_linear_velocity(p_velocity);
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_angular_velocity() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -25,7 +25,8 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass() const {
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass_local() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return body->get_transform().xform_inv(body->get_center_of_mass());
 }
 
 Basis JoltPhysicsDirectBodyState3D::_get_principal_inertia_axes() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -37,7 +37,8 @@ Basis JoltPhysicsDirectBodyState3D::_get_principal_inertia_axes() const {
 }
 
 double JoltPhysicsDirectBodyState3D::_get_inverse_mass() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return 1.0 / body->get_mass();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_inverse_inertia() const {

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -8,7 +8,8 @@ JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D* p_body)
 	: body(p_body) { }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_total_gravity() const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_NULL_D(body);
+	return body->get_gravity();
 }
 
 double JoltPhysicsDirectBodyState3D::_get_total_angular_damp() const {

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -48,6 +48,8 @@ JoltSpace3D::~JoltSpace3D() {
 }
 
 void JoltSpace3D::step(float p_step) {
+	last_step = p_step;
+
 	pre_step(p_step);
 
 	physics_system->Update(p_step, 1, 1, temp_allocator, job_system);

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -72,6 +72,8 @@ public:
 
 	JoltArea3D* get_default_area() const { return default_area; }
 
+	float get_last_step() const { return last_step; }
+
 	void add_joint(JoltJoint3D* p_joint);
 
 	void remove_joint(JoltJoint3D* p_joint);
@@ -98,4 +100,6 @@ private:
 	JoltPhysicsDirectSpaceState3D* direct_state = nullptr;
 
 	JoltArea3D* default_area = nullptr;
+
+	float last_step = 0.0f;
 };


### PR DESCRIPTION
This PR adds support for the following methods (and matching properties) in [`PhysicsDirectBodyState3D`](https://docs.godotengine.org/en/latest/classes/class_physicsdirectbodystate3d.html):

- `get_step`
- `get_space_state`
- `set_transform`
- `set_linear_velocity`
- `set_angular_velocity`
- `get_center_of_mass`
- `get_center_of_mass_local`
- `get_total_gravity`
- `get_total_linear_damp`
- `get_total_angular_damp`
- `get_inverse_mass`
- `get_principal_inertia_axes`
- `get_inverse_inertia`