### PR TITLE
Fixed seemingly ignored transformations in `_integrate_forces`

### DIFF
--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -102,4 +102,6 @@ private:
 	JoltArea3D* default_area = nullptr;
 
 	float last_step = 0.0f;
+
+	bool has_stepped = false;
 };


### PR DESCRIPTION
There was a slight bug in #212 where `set_transform` wouldn't work on the first call of `_integrate_forces`. This turned out to be because `flush_queries` happens before `physics_process`, where things like `NOTIFICATION_ENTER_WORLD` gets flushed, which sets the transform of the body to its initial state.