### PR TITLE
Added support for various physics server methods

### DIFF
--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -306,6 +306,25 @@ void JoltBody3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
 	body->GetMotionPropertiesUnchecked()->SetAngularVelocityClamped(to_jolt(p_velocity));
 }
 
+void JoltBody3D::set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock) {
+	const Vector3 axis = p_axis_velocity.normalized();
+
+	if (space) {
+		const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+		ERR_FAIL_COND(body.is_invalid());
+
+		Vector3 linear_velocity = get_linear_velocity(false);
+		linear_velocity -= axis * axis.dot(linear_velocity);
+		linear_velocity += p_axis_velocity;
+		set_linear_velocity(linear_velocity, false);
+	} else {
+		Vector3 linear_velocity = initial_linear_velocity;
+		linear_velocity -= axis * axis.dot(linear_velocity);
+		linear_velocity += p_axis_velocity;
+		initial_linear_velocity = linear_velocity;
+	}
+}
+
 void JoltBody3D::set_center_of_mass_custom(const Vector3& p_center_of_mass, bool p_lock) {
 	custom_center_of_mass = true;
 	center_of_mass_custom = p_center_of_mass;

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -76,6 +76,8 @@ public:
 
 	void set_angular_velocity(const Vector3& p_velocity, bool p_lock = true);
 
+	void set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock = true);
+
 	bool has_custom_center_of_mass() const override { return custom_center_of_mass; }
 
 	Vector3 get_center_of_mass_custom() const override { return center_of_mass_custom; }

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -257,6 +257,14 @@ int32_t JoltCollisionObject3D::find_shape_index(const JPH::SubShapeID& p_sub_sha
 	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
 }
 
+void JoltCollisionObject3D::set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock) {
+	ERR_FAIL_INDEX(p_index, shapes.size());
+
+	shapes[p_index] = JoltShapeInstance3D(this, p_shape);
+
+	rebuild_shape(p_lock);
+}
+
 void JoltCollisionObject3D::set_shape_transform(
 	int32_t p_index,
 	const Transform3D& p_transform,

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -245,6 +245,12 @@ void JoltCollisionObject3D::remove_shape(int32_t p_index, bool p_lock) {
 	rebuild_shape(p_lock);
 }
 
+void JoltCollisionObject3D::clear_shapes(bool p_lock) {
+	shapes.clear();
+
+	rebuild_shape(p_lock);
+}
+
 int32_t JoltCollisionObject3D::find_shape_index(uint32_t p_shape_instance_id) const {
 	return shapes.find_if([&](const JoltShapeInstance3D& p_shape) {
 		return p_shape.get_id() == p_shape_instance_id;

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -271,6 +271,12 @@ void JoltCollisionObject3D::set_shape(int32_t p_index, JoltShape3D* p_shape, boo
 	rebuild_shape(p_lock);
 }
 
+Transform3D JoltCollisionObject3D::get_shape_transform(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_transform();
+}
+
 void JoltCollisionObject3D::set_shape_transform(
 	int32_t p_index,
 	const Transform3D& p_transform,

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -257,6 +257,12 @@ int32_t JoltCollisionObject3D::find_shape_index(const JPH::SubShapeID& p_sub_sha
 	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
 }
 
+JoltShape3D* JoltCollisionObject3D::get_shape(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_shape();
+}
+
 void JoltCollisionObject3D::set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -74,6 +74,8 @@ public:
 
 	void remove_shape(int32_t p_index, bool p_lock = true);
 
+	int32_t get_shape_count() const { return shapes.size(); }
+
 	int32_t find_shape_index(uint32_t p_shape_instance_id) const;
 
 	int32_t find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const;

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -78,6 +78,8 @@ public:
 
 	int32_t find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const;
 
+	void set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock = true);
+
 	void set_shape_transform(int32_t p_index, const Transform3D& p_transform, bool p_lock = true);
 
 	void set_shape_disabled(int32_t p_index, bool p_disabled, bool p_lock = true);

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -84,6 +84,8 @@ public:
 
 	void set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock = true);
 
+	Transform3D get_shape_transform(int32_t p_index) const;
+
 	void set_shape_transform(int32_t p_index, const Transform3D& p_transform, bool p_lock = true);
 
 	void set_shape_disabled(int32_t p_index, bool p_disabled, bool p_lock = true);

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -80,6 +80,8 @@ public:
 
 	int32_t find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const;
 
+	JoltShape3D* get_shape(int32_t p_index) const;
+
 	void set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock = true);
 
 	void set_shape_transform(int32_t p_index, const Transform3D& p_transform, bool p_lock = true);

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -74,6 +74,8 @@ public:
 
 	void remove_shape(int32_t p_index, bool p_lock = true);
 
+	void clear_shapes(bool p_lock = true);
+
 	int32_t get_shape_count() const { return shapes.size(); }
 
 	int32_t find_shape_index(uint32_t p_shape_instance_id) const;

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -312,8 +312,11 @@ void JoltPhysicsServer3D::_area_remove_shape(const RID& p_area, int32_t p_shape_
 	area->remove_shape(p_shape_idx);
 }
 
-void JoltPhysicsServer3D::_area_clear_shapes([[maybe_unused]] const RID& p_area) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsServer3D::_area_clear_shapes(const RID& p_area) {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL(area);
+
+	area->clear_shapes();
 }
 
 void JoltPhysicsServer3D::_area_set_shape_disabled(
@@ -557,8 +560,11 @@ void JoltPhysicsServer3D::_body_remove_shape(const RID& p_body, int32_t p_shape_
 	body->remove_shape((int32_t)p_shape_idx);
 }
 
-void JoltPhysicsServer3D::_body_clear_shapes([[maybe_unused]] const RID& p_body) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsServer3D::_body_clear_shapes(const RID& p_body) {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->clear_shapes();
 }
 
 void JoltPhysicsServer3D::_body_set_shape_disabled(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -256,11 +256,17 @@ void JoltPhysicsServer3D::_area_add_shape(
 }
 
 void JoltPhysicsServer3D::_area_set_shape(
-	[[maybe_unused]] const RID& p_area,
-	[[maybe_unused]] int32_t p_shape_idx,
-	[[maybe_unused]] const RID& p_shape
+	const RID& p_area,
+	int32_t p_shape_idx,
+	const RID& p_shape
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL(area);
+
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL(shape);
+
+	area->set_shape(p_shape_idx, shape);
 }
 
 void JoltPhysicsServer3D::_area_set_shape_transform(
@@ -488,11 +494,17 @@ void JoltPhysicsServer3D::_body_add_shape(
 }
 
 void JoltPhysicsServer3D::_body_set_shape(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] int32_t p_shape_idx,
-	[[maybe_unused]] const RID& p_shape
+	const RID& p_body,
+	int32_t p_shape_idx,
+	const RID& p_shape
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL(shape);
+
+	body->set_shape(p_shape_idx, shape);
 }
 
 void JoltPhysicsServer3D::_body_set_shape_transform(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -280,8 +280,11 @@ void JoltPhysicsServer3D::_area_set_shape_transform(
 	area->set_shape_transform(p_shape_idx, p_transform);
 }
 
-int32_t JoltPhysicsServer3D::_area_get_shape_count([[maybe_unused]] const RID& p_area) const {
-	ERR_FAIL_D_NOT_IMPL();
+int32_t JoltPhysicsServer3D::_area_get_shape_count(const RID& p_area) const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	return area->get_shape_count();
 }
 
 RID JoltPhysicsServer3D::_area_get_shape(
@@ -518,8 +521,11 @@ void JoltPhysicsServer3D::_body_set_shape_transform(
 	body->set_shape_transform(p_shape_idx, p_transform);
 }
 
-int32_t JoltPhysicsServer3D::_body_get_shape_count([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_D_NOT_IMPL();
+int32_t JoltPhysicsServer3D::_body_get_shape_count(const RID& p_body) const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	return body->get_shape_count();
 }
 
 RID JoltPhysicsServer3D::_body_get_shape(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -106,9 +106,11 @@ void JoltPhysicsServer3D::_shape_set_custom_solver_bias(
 	ERR_FAIL_NOT_IMPL();
 }
 
-PhysicsServer3D::ShapeType JoltPhysicsServer3D::_shape_get_type([[maybe_unused]] const RID& p_shape
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+PhysicsServer3D::ShapeType JoltPhysicsServer3D::_shape_get_type(const RID& p_shape) const {
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL_D(shape);
+
+	return shape->get_type();
 }
 
 Variant JoltPhysicsServer3D::_shape_get_data(const RID& p_shape) const {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -486,9 +486,11 @@ void JoltPhysicsServer3D::_body_set_mode(const RID& p_body, BodyMode p_mode) {
 	body->set_mode(p_mode);
 }
 
-PhysicsServer3D::BodyMode JoltPhysicsServer3D::_body_get_mode([[maybe_unused]] const RID& p_body
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+PhysicsServer3D::BodyMode JoltPhysicsServer3D::_body_get_mode(const RID& p_body) const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	return body->get_mode();
 }
 
 void JoltPhysicsServer3D::_body_add_shape(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -227,8 +227,17 @@ void JoltPhysicsServer3D::_area_set_space(const RID& p_area, const RID& p_space)
 	area->set_space(space);
 }
 
-RID JoltPhysicsServer3D::_area_get_space([[maybe_unused]] const RID& p_area) const {
-	ERR_FAIL_D_NOT_IMPL();
+RID JoltPhysicsServer3D::_area_get_space(const RID& p_area) const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	JoltSpace3D* space = area->get_space();
+
+	if (space == nullptr) {
+		return {};
+	}
+
+	return space->get_rid();
 }
 
 void JoltPhysicsServer3D::_area_add_shape(
@@ -438,8 +447,17 @@ void JoltPhysicsServer3D::_body_set_space(const RID& p_body, const RID& p_space)
 	body->set_space(space);
 }
 
-RID JoltPhysicsServer3D::_body_get_space([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_D_NOT_IMPL();
+RID JoltPhysicsServer3D::_body_get_space(const RID& p_body) const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	JoltSpace3D* space = body->get_space();
+
+	if (space == nullptr) {
+		return {};
+	}
+
+	return space->get_rid();
 }
 
 void JoltPhysicsServer3D::_body_set_mode(const RID& p_body, BodyMode p_mode) {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -287,11 +287,14 @@ int32_t JoltPhysicsServer3D::_area_get_shape_count(const RID& p_area) const {
 	return area->get_shape_count();
 }
 
-RID JoltPhysicsServer3D::_area_get_shape(
-	[[maybe_unused]] const RID& p_area,
-	[[maybe_unused]] int32_t p_shape_idx
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+RID JoltPhysicsServer3D::_area_get_shape(const RID& p_area, int32_t p_shape_idx) const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	JoltShape3D* shape = area->get_shape(p_shape_idx);
+	ERR_FAIL_NULL_D(shape);
+
+	return shape->get_rid();
 }
 
 Transform3D JoltPhysicsServer3D::_area_get_shape_transform(
@@ -528,11 +531,14 @@ int32_t JoltPhysicsServer3D::_body_get_shape_count(const RID& p_body) const {
 	return body->get_shape_count();
 }
 
-RID JoltPhysicsServer3D::_body_get_shape(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] int32_t p_shape_idx
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+RID JoltPhysicsServer3D::_body_get_shape(const RID& p_body, int32_t p_shape_idx) const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	JoltShape3D* shape = body->get_shape(p_shape_idx);
+	ERR_FAIL_NULL_D(shape);
+
+	return shape->get_rid();
 }
 
 Transform3D JoltPhysicsServer3D::_body_get_shape_transform(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -297,11 +297,12 @@ RID JoltPhysicsServer3D::_area_get_shape(const RID& p_area, int32_t p_shape_idx)
 	return shape->get_rid();
 }
 
-Transform3D JoltPhysicsServer3D::_area_get_shape_transform(
-	[[maybe_unused]] const RID& p_area,
-	[[maybe_unused]] int32_t p_shape_idx
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+Transform3D JoltPhysicsServer3D::_area_get_shape_transform(const RID& p_area, int32_t p_shape_idx)
+	const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	return area->get_shape_transform(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_area_remove_shape(const RID& p_area, int32_t p_shape_idx) {
@@ -541,11 +542,12 @@ RID JoltPhysicsServer3D::_body_get_shape(const RID& p_body, int32_t p_shape_idx)
 	return shape->get_rid();
 }
 
-Transform3D JoltPhysicsServer3D::_body_get_shape_transform(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] int32_t p_shape_idx
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+Transform3D JoltPhysicsServer3D::_body_get_shape_transform(const RID& p_body, int32_t p_shape_idx)
+	const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	return body->get_shape_transform(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_body_remove_shape(const RID& p_body, int32_t p_shape_idx) {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -954,10 +954,11 @@ bool JoltPhysicsServer3D::_body_test_motion(
 	ERR_FAIL_D_NOT_IMPL();
 }
 
-PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(
-	[[maybe_unused]] const RID& p_body
-) {
-	ERR_FAIL_D_NOT_IMPL();
+PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(const RID& p_body) {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	return body->get_direct_state();
 }
 
 RID JoltPhysicsServer3D::_soft_body_create() {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -376,8 +376,11 @@ Variant JoltPhysicsServer3D::_area_get_param(const RID& p_area, AreaParameter p_
 	return area->get_param(p_param);
 }
 
-Transform3D JoltPhysicsServer3D::_area_get_transform([[maybe_unused]] const RID& p_area) const {
-	ERR_FAIL_D_NOT_IMPL();
+Transform3D JoltPhysicsServer3D::_area_get_transform(const RID& p_area) const {
+	JoltArea3D* area = area_owner.get_or_null(p_area);
+	ERR_FAIL_NULL_D(area);
+
+	return area->get_transform();
 }
 
 void JoltPhysicsServer3D::_area_set_collision_mask(const RID& p_area, uint32_t p_mask) {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -819,10 +819,13 @@ Vector3 JoltPhysicsServer3D::_body_get_constant_torque(const RID& p_body) const 
 }
 
 void JoltPhysicsServer3D::_body_set_axis_velocity(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] const Vector3& p_axis_velocity
+	const RID& p_body,
+	const Vector3& p_axis_velocity
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_axis_velocity(p_axis_velocity);
 }
 
 void JoltPhysicsServer3D::_body_set_axis_lock(

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -4,6 +4,8 @@ class JoltCollisionObject3D;
 
 class JoltShape3D {
 public:
+	using ShapeType = PhysicsServer3D::ShapeType;
+
 	virtual ~JoltShape3D() = 0;
 
 	RID get_rid() const { return rid; }
@@ -15,6 +17,8 @@ public:
 	void remove_owner(JoltCollisionObject3D* p_owner);
 
 	void remove_self(bool p_lock = true);
+
+	virtual ShapeType get_type() const = 0;
 
 	virtual Variant get_data() const = 0;
 
@@ -64,6 +68,8 @@ protected:
 };
 
 class JoltSphereShape3D final : public JoltShape3D {
+	ShapeType get_type() const override { return ShapeType::SHAPE_SPHERE; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -80,6 +86,8 @@ private:
 
 class JoltBoxShape3D final : public JoltShape3D {
 public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_BOX; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -96,6 +104,8 @@ private:
 
 class JoltCapsuleShape3D final : public JoltShape3D {
 public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_CAPSULE; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -114,6 +124,8 @@ private:
 
 class JoltCylinderShape3D final : public JoltShape3D {
 public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_CYLINDER; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -132,6 +144,8 @@ private:
 
 class JoltConvexPolygonShape3D final : public JoltShape3D {
 public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_CONVEX_POLYGON; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -148,6 +162,8 @@ private:
 
 class JoltConcavePolygonShape3D final : public JoltShape3D {
 public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_CONCAVE_POLYGON; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -166,6 +182,8 @@ private:
 
 class JoltHeightMapShape3D final : public JoltShape3D {
 public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_HEIGHTMAP; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -8,8 +8,8 @@ public:
 	JoltShapeInstance3D(
 		JoltCollisionObject3D* p_parent,
 		JoltShape3D* p_shape,
-		const Transform3D& p_transform,
-		bool p_disabled
+		const Transform3D& p_transform = {},
+		bool p_disabled = false
 	);
 
 	JoltShapeInstance3D(const JoltShapeInstance3D& p_other) = delete;


### PR DESCRIPTION
This PR adds support for the following methods in [`PhysicsServer3D`](https://docs.godotengine.org/en/latest/classes/class_physicsserver3d.html):

- `area_clear_shapes`
- `area_get_shape_count`
- `area_get_shape_transform`
- `area_get_shape`
- `area_get_space`
- `area_get_transform`
- `area_set_shape`
- `body_clear_shapes`
- `body_get_direct_state`
- `body_get_mode`
- `body_get_shape_count`
- `body_get_shape_transform`
- `body_get_shape`
- `body_get_space`
- `body_set_axis_velocity`
- `body_set_shape`
- `shape_get_type`