### PR TITLE
Added explicit non-support for various server methods

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -665,11 +665,14 @@ void JoltPhysicsServer3D::_body_set_user_flags(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] uint32_t p_flags
 ) {
-	ERR_FAIL_NOT_IMPL();
+	WARN_PRINT(
+		"Body user flags are not supported by Godot Jolt. "
+		"Any such value will be ignored."
+	);
 }
 
 uint32_t JoltPhysicsServer3D::_body_get_user_flags([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_D_NOT_IMPL();
+	return 0;
 }
 
 void JoltPhysicsServer3D::_body_set_param(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -899,13 +899,16 @@ void JoltPhysicsServer3D::_body_set_contacts_reported_depth_threshold(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_threshold
 ) {
-	ERR_FAIL_NOT_IMPL();
+	WARN_PRINT(
+		"Per-body contact depth threshold is not supported by Godot Jolt. "
+		"Any such value will be ignored."
+	);
 }
 
 double JoltPhysicsServer3D::_body_get_contacts_reported_depth_threshold(
 	[[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_NOT_IMPL();
+	return 0.0;
 }
 
 void JoltPhysicsServer3D::_body_set_omit_force_integration(

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -197,16 +197,16 @@ void JoltPhysicsServer3D::_space_set_debug_contacts(
 	[[maybe_unused]] const RID& p_space,
 	[[maybe_unused]] int32_t p_max_contacts
 ) {
-	ERR_FAIL_NOT_IMPL();
+	WARN_PRINT("Contact debugging is not supported by Godot Jolt.");
 }
 
 PackedVector3Array JoltPhysicsServer3D::_space_get_contacts([[maybe_unused]] const RID& p_space
 ) const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_D_MSG("Contact debugging is not supported by Godot Jolt.");
 }
 
 int32_t JoltPhysicsServer3D::_space_get_contact_count([[maybe_unused]] const RID& p_space) const {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_D_MSG("Contact debugging is not supported by Godot Jolt.");
 }
 
 RID JoltPhysicsServer3D::_area_create() {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -89,7 +89,7 @@ RID JoltPhysicsServer3D::_heightmap_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_custom_shape_create() {
-	ERR_FAIL_D_NOT_IMPL();
+	ERR_FAIL_D_MSG("Custom shapes are not supported by Godot Jolt.");
 }
 
 void JoltPhysicsServer3D::_shape_set_data(const RID& p_shape, const Variant& p_data) {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -169,18 +169,21 @@ bool JoltPhysicsServer3D::_space_is_active(const RID& p_space) const {
 }
 
 void JoltPhysicsServer3D::_space_set_param(
-	[[maybe_unused]] const RID& p_space,
-	[[maybe_unused]] SpaceParameter p_param,
-	[[maybe_unused]] double p_value
+	const RID& p_space,
+	SpaceParameter p_param,
+	double p_value
 ) {
-	ERR_FAIL_NOT_IMPL();
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+
+	space->set_param(p_param, p_value);
 }
 
-double JoltPhysicsServer3D::_space_get_param(
-	[[maybe_unused]] const RID& p_space,
-	[[maybe_unused]] SpaceParameter p_param
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+double JoltPhysicsServer3D::_space_get_param(const RID& p_space, SpaceParameter p_param) const {
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL_D(space);
+
+	return space->get_param(p_param);
 }
 
 PhysicsDirectSpaceState3D* JoltPhysicsServer3D::_space_get_direct_state(const RID& p_space) {

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -16,6 +16,15 @@ constexpr uint32_t GDJOLT_BODY_MUTEX_COUNT = 0; // 0 = default
 constexpr uint32_t GDJOLT_MAX_BODY_PAIRS = 65536;
 constexpr uint32_t GDJOLT_MAX_CONTACT_CONSTRAINTS = 8192;
 
+constexpr double GDJOLT_SPACE_CONTACT_RECYCLE_RADIUS = 0.01;
+constexpr double GDJOLT_SPACE_CONTACT_MAX_SEPARATION = 0.05;
+constexpr double GDJOLT_SPACE_CONTACT_MAX_ALLOWED_PENETRATION = 0.01;
+constexpr double GDJOLT_SPACE_CONTACT_DEFAULT_BIAS = 0.8;
+constexpr double GDJOLT_SPACE_SLEEP_THRESHOLD_LINEAR = 0.1;
+constexpr double GDJOLT_SPACE_SLEEP_THRESHOLD_ANGULAR = 8.0 * Math_PI / 180;
+constexpr double GDJOLT_SPACE_TIME_BEFORE_SLEEP = 0.5;
+constexpr double GDJOLT_SPACE_SOLVER_ITERATIONS = 8;
+
 } // namespace
 
 JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
@@ -90,6 +99,97 @@ void JoltSpace3D::call_queries() {
 	}
 
 	body_accessor.release();
+}
+
+double JoltSpace3D::get_param(PhysicsServer3D::SpaceParameter p_param) const {
+	switch (p_param) {
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: {
+			return GDJOLT_SPACE_CONTACT_RECYCLE_RADIUS;
+		}
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_MAX_SEPARATION: {
+			return GDJOLT_SPACE_CONTACT_MAX_SEPARATION;
+		}
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION: {
+			return GDJOLT_SPACE_CONTACT_MAX_ALLOWED_PENETRATION;
+		}
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_DEFAULT_BIAS: {
+			return GDJOLT_SPACE_CONTACT_DEFAULT_BIAS;
+		}
+		case PhysicsServer3D::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: {
+			return GDJOLT_SPACE_SLEEP_THRESHOLD_LINEAR;
+		}
+		case PhysicsServer3D::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: {
+			return GDJOLT_SPACE_SLEEP_THRESHOLD_ANGULAR;
+		}
+		case PhysicsServer3D::SPACE_PARAM_BODY_TIME_TO_SLEEP: {
+			return GDJOLT_SPACE_TIME_BEFORE_SLEEP;
+		}
+		case PhysicsServer3D::SPACE_PARAM_SOLVER_ITERATIONS: {
+			return GDJOLT_SPACE_SOLVER_ITERATIONS;
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled space parameter: '%d'", p_param));
+		}
+	}
+}
+
+void JoltSpace3D::set_param(
+	PhysicsServer3D::SpaceParameter p_param,
+	[[maybe_unused]] double p_value
+) {
+	switch (p_param) {
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_RECYCLE_RADIUS: {
+			WARN_PRINT(
+				"Space-specific contact recycle radius is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_MAX_SEPARATION: {
+			WARN_PRINT(
+				"Space-specific contact max separation is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION: {
+			WARN_PRINT(
+				"Space-specific contact max allowed penetration is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_CONTACT_DEFAULT_BIAS: {
+			WARN_PRINT(
+				"Space-specific contact default bias is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD: {
+			WARN_PRINT(
+				"Space-specific linear velocity sleep threshold is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD: {
+			WARN_PRINT(
+				"Space-specific angular velocity sleep threshold is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_BODY_TIME_TO_SLEEP: {
+			WARN_PRINT(
+				"Space-specific body sleep time is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		case PhysicsServer3D::SPACE_PARAM_SOLVER_ITERATIONS: {
+			WARN_PRINT(
+				"Space-specific solver iterations is not supported by Godot Jolt. "
+				"Any such value will be ignored."
+			);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled space parameter: '%d'", p_param));
+		} break;
+	}
 }
 
 JPH::BodyInterface& JoltSpace3D::get_body_iface(bool p_locked) {

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -23,6 +23,10 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
+	double get_param(PhysicsServer3D::SpaceParameter p_param) const;
+
+	void set_param(PhysicsServer3D::SpaceParameter p_param, double p_value);
+
 	JPH::PhysicsSystem& get_physics_system() const { return *physics_system; }
 
 	JPH::BodyInterface& get_body_iface(bool p_locked = true);


### PR DESCRIPTION
This PR adds error/warning messages to indicate that certain (mostly minor) features are not supported by Godot Jolt. These consist of the following:

- Custom shapes
    - Not supported by Godot Physics either
- Body user flags
    - Not supported by Godot Physics either
- Contact depth threshold
   - Not supported by Godot Physics either
- Contact debugging
    - Only relevant for `dev_build=yes` builds of the engine, so I assume it's meant to be a developer tool
- Per-space physics parameters
    - Most of them don't line up with what Jolt expects
    - `SPACE_PARAM_BODY_TIME_TO_SLEEP` could probably be supported, but I'll hold off until someone requests it