### PR TITLE
Updated godot-cpp to 4.0-stable

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 27cdf763c7601400705adfc16a25a248ff47adc4
+	GIT_COMMIT d5f4e379948b69b131c1614ff971801477409988
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@27cdf763c7601400705adfc16a25a248ff47adc4 aka `4.0-rc6` to godot-jolt/godot-cpp@d5f4e379948b69b131c1614ff971801477409988 aka `4.0-stable` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/27cdf763c7601400705adfc16a25a248ff47adc4...d5f4e379948b69b131c1614ff971801477409988)).