### PR TITLE
Added support for axis-locking

### DIFF
--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -222,7 +222,7 @@ void JoltBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
 Basis JoltBody3D::get_principal_inertia_axes(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	if (mode != PhysicsServer3D::BodyMode::BODY_MODE_RIGID) {
+	if (is_static() || is_kinematic()) {
 		return {};
 	}
 
@@ -241,7 +241,7 @@ Basis JoltBody3D::get_principal_inertia_axes(bool p_lock) const {
 Vector3 JoltBody3D::get_inverse_inertia(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	if (mode != PhysicsServer3D::BodyMode::BODY_MODE_RIGID) {
+	if (is_static() || is_kinematic()) {
 		return {};
 	}
 
@@ -254,7 +254,7 @@ Vector3 JoltBody3D::get_inverse_inertia(bool p_lock) const {
 Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
-	if (mode != PhysicsServer3D::BodyMode::BODY_MODE_RIGID) {
+	if (is_static() || is_kinematic()) {
 		return {};
 	}
 
@@ -659,15 +659,6 @@ JoltPhysicsDirectBodyState3D* JoltBody3D::get_direct_state() {
 }
 
 void JoltBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
-	if (p_mode == PhysicsServer3D::BODY_MODE_RIGID_LINEAR) {
-		WARN_PRINT(
-			"Locking rotation is not supported by Godot Jolt. "
-			"Any such setting will be treated as disabled."
-		);
-
-		p_mode = PhysicsServer3D::BODY_MODE_RIGID;
-	}
-
 	if (p_mode == mode) {
 		return;
 	}
@@ -688,7 +679,8 @@ void JoltBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
 		case PhysicsServer3D::BODY_MODE_KINEMATIC: {
 			motion_type = JPH::EMotionType::Kinematic;
 		} break;
-		case PhysicsServer3D::BODY_MODE_RIGID: {
+		case PhysicsServer3D::BODY_MODE_RIGID:
+		case PhysicsServer3D::BODY_MODE_RIGID_LINEAR: {
 			motion_type = JPH::EMotionType::Dynamic;
 		} break;
 		default: {
@@ -856,6 +848,24 @@ float JoltBody3D::get_total_angular_damp(bool p_lock) const {
 	return body->GetMotionPropertiesUnchecked()->GetAngularDamping();
 }
 
+bool JoltBody3D::is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const {
+	return (locked_axes & (uint32_t)p_axis) != 0;
+}
+
+void JoltBody3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock_axis, bool p_lock) {
+	const uint32_t previous_locked_axes = locked_axes;
+
+	if (p_lock_axis) {
+		locked_axes |= (uint32_t)p_axis;
+	} else {
+		locked_axes &= ~(uint32_t)p_axis;
+	}
+
+	if (previous_locked_axes != locked_axes) {
+		axis_lock_changed(p_lock);
+	}
+}
+
 JPH::EMotionType JoltBody3D::get_motion_type() const {
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {
@@ -902,10 +912,18 @@ void JoltBody3D::create_in_space(bool p_lock) {
 	body->SetCollisionGroup(JPH::CollisionGroup(nullptr, group_id, sub_group_id));
 
 	areas_changed(p_lock);
+	axis_lock_changed(p_lock);
+}
+
+void JoltBody3D::destroy_in_space(bool p_lock) {
+	destroy_axes_constraint();
+
+	JoltCollisionObject3D::destroy_in_space(p_lock);
 }
 
 void JoltBody3D::mode_changed(bool p_lock) {
 	object_layer_changed(p_lock);
+	axis_lock_changed(p_lock);
 }
 
 void JoltBody3D::shapes_changed(bool p_lock) {
@@ -982,6 +1000,10 @@ void JoltBody3D::damp_changed(bool p_lock) {
 	motion_properties.SetAngularDamping(total_angular_damp);
 }
 
+void JoltBody3D::axis_lock_changed(bool p_lock) {
+	create_axes_constraint(p_lock);
+}
+
 JPH::MassProperties JoltBody3D::calculate_mass_properties(const JPH::Shape& p_shape) const {
 	const bool calculate_mass = mass <= 0;
 	const bool calculate_inertia = inertia.x <= 0 || inertia.y <= 0 || inertia.z <= 0;
@@ -1014,4 +1036,60 @@ void JoltBody3D::mass_properties_changed(bool p_lock) {
 	ERR_FAIL_COND(body.is_invalid());
 
 	body->GetMotionPropertiesUnchecked()->SetMassProperties(calculate_mass_properties());
+}
+
+void JoltBody3D::create_axes_constraint(bool p_lock) {
+	if (!space) {
+		return;
+	}
+
+	destroy_axes_constraint();
+
+	if (!are_axes_locked() && !is_rigid_linear()) {
+		return;
+	}
+
+	const JoltWritableBody3D jolt_body = space->write_body(jolt_id, p_lock);
+	ERR_FAIL_COND(jolt_body.is_invalid());
+
+	const Transform3D transform = get_transform(false);
+
+	JPH::SixDOFConstraintSettings constraint_settings;
+	constraint_settings.mPosition1 = jolt_body->GetCenterOfMassPosition();
+	constraint_settings.mPosition2 = constraint_settings.mPosition1;
+
+	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_LINEAR_X)) {
+		constraint_settings.MakeFixedAxis(JPH::SixDOFConstraintSettings::EAxis::TranslationX);
+	}
+
+	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_LINEAR_Y)) {
+		constraint_settings.MakeFixedAxis(JPH::SixDOFConstraintSettings::EAxis::TranslationY);
+	}
+
+	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_LINEAR_Z)) {
+		constraint_settings.MakeFixedAxis(JPH::SixDOFConstraintSettings::EAxis::TranslationZ);
+	}
+
+	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_ANGULAR_X) || is_rigid_linear()) {
+		constraint_settings.MakeFixedAxis(JPH::SixDOFConstraintSettings::EAxis::RotationX);
+	}
+
+	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_ANGULAR_Y) || is_rigid_linear()) {
+		constraint_settings.MakeFixedAxis(JPH::SixDOFConstraintSettings::EAxis::RotationY);
+	}
+
+	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_ANGULAR_Z) || is_rigid_linear()) {
+		constraint_settings.MakeFixedAxis(JPH::SixDOFConstraintSettings::EAxis::RotationZ);
+	}
+
+	axes_constraint = constraint_settings.Create(JPH::Body::sFixedToWorld, *jolt_body);
+
+	space->add_joint(axes_constraint);
+}
+
+void JoltBody3D::destroy_axes_constraint() {
+	if (space && axes_constraint) {
+		space->remove_joint(axes_constraint);
+		axes_constraint = nullptr;
+	}
 }

--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -1052,8 +1052,6 @@ void JoltBody3D::create_axes_constraint(bool p_lock) {
 	const JoltWritableBody3D jolt_body = space->write_body(jolt_id, p_lock);
 	ERR_FAIL_COND(jolt_body.is_invalid());
 
-	const Transform3D transform = get_transform(false);
-
 	JPH::SixDOFConstraintSettings constraint_settings;
 	constraint_settings.mPosition1 = jolt_body->GetCenterOfMassPosition();
 	constraint_settings.mPosition2 = constraint_settings.mPosition1;

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -162,7 +162,11 @@ public:
 
 	bool is_kinematic() const { return mode == PhysicsServer3D::BODY_MODE_KINEMATIC; }
 
-	bool is_rigid() const { return mode == PhysicsServer3D::BODY_MODE_RIGID; }
+	bool is_rigid_free() const { return mode == PhysicsServer3D::BODY_MODE_RIGID; }
+
+	bool is_rigid_linear() const { return mode == PhysicsServer3D::BODY_MODE_RIGID_LINEAR; }
+
+	bool is_rigid() const { return is_rigid_free() || is_rigid_linear(); }
 
 	bool is_ccd_enabled() const { return ccd_enabled; }
 
@@ -210,12 +214,20 @@ public:
 
 	void set_angular_damp_mode(DampMode p_mode) { angular_damp_mode = p_mode; }
 
+	bool is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const;
+
+	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock_axis, bool p_lock = true);
+
+	bool are_axes_locked() const { return locked_axes != 0; }
+
 private:
 	bool get_initial_sleep_state() const override { return initial_sleep_state; }
 
 	JPH::EMotionType get_motion_type() const override;
 
 	void create_in_space(bool p_lock = true) override;
+
+	void destroy_in_space(bool p_lock = true) override;
 
 	void mode_changed(bool p_lock = true);
 
@@ -225,11 +237,17 @@ private:
 
 	void damp_changed(bool p_lock = true);
 
+	void axis_lock_changed(bool p_lock = true);
+
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 
 	JPH::MassProperties calculate_mass_properties() const;
 
 	void mass_properties_changed(bool p_lock);
+
+	void create_axes_constraint(bool p_lock = true);
+
+	void destroy_axes_constraint();
 
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
 
@@ -259,6 +277,8 @@ private:
 
 	bool custom_center_of_mass = false;
 
+	uint32_t locked_axes = 0;
+
 	int32_t contact_count = 0;
 
 	LocalVector<Contact> contacts;
@@ -284,4 +304,6 @@ private:
 	Variant force_integration_userdata;
 
 	JoltPhysicsDirectBodyState3D* direct_state = nullptr;
+
+	JPH::Ref<JPH::Constraint> axes_constraint;
 };

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -119,7 +119,7 @@ protected:
 
 	JPH::Body* create_end(const JPH::BodyCreationSettings& p_settings, bool p_lock = true);
 
-	void destroy_in_space(bool p_lock = true);
+	virtual void destroy_in_space(bool p_lock = true);
 
 	void add_to_space(bool p_lock = true);
 

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -834,24 +834,18 @@ void JoltPhysicsServer3D::_body_set_axis_velocity(
 	body->set_axis_velocity(p_axis_velocity);
 }
 
-void JoltPhysicsServer3D::_body_set_axis_lock(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] BodyAxis p_axis,
-	bool p_lock
-) {
-	if (p_lock) {
-		WARN_PRINT(
-			"Axis lock is not supported by Godot Jolt. "
-			"Any such setting will be treated as disabled."
-		);
-	}
+void JoltPhysicsServer3D::_body_set_axis_lock(const RID& p_body, BodyAxis p_axis, bool p_lock) {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_axis_lock(p_axis, p_lock);
 }
 
-bool JoltPhysicsServer3D::_body_is_axis_locked(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] BodyAxis p_axis
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+bool JoltPhysicsServer3D::_body_is_axis_locked(const RID& p_body, BodyAxis p_axis) const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	return body->is_axis_locked(p_axis);
 }
 
 void JoltPhysicsServer3D::_body_add_collision_exception(

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -288,12 +288,20 @@ JoltPhysicsDirectSpaceState3D* JoltSpace3D::get_direct_state() {
 	return direct_state;
 }
 
+void JoltSpace3D::add_joint(JPH::Constraint* p_jolt_ref) {
+	physics_system->AddConstraint(p_jolt_ref);
+}
+
 void JoltSpace3D::add_joint(JoltJoint3D* p_joint) {
-	physics_system->AddConstraint(p_joint->get_jolt_ref());
+	add_joint(p_joint->get_jolt_ref());
+}
+
+void JoltSpace3D::remove_joint(JPH::Constraint* p_jolt_ref) {
+	physics_system->RemoveConstraint(p_jolt_ref);
 }
 
 void JoltSpace3D::remove_joint(JoltJoint3D* p_joint) {
-	physics_system->RemoveConstraint(p_joint->get_jolt_ref());
+	remove_joint(p_joint->get_jolt_ref());
 }
 
 void JoltSpace3D::pre_step(float p_step) {

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -78,7 +78,11 @@ public:
 
 	float get_last_step() const { return last_step; }
 
+	void add_joint(JPH::Constraint* p_jolt_ref);
+
 	void add_joint(JoltJoint3D* p_joint);
+
+	void remove_joint(JPH::Constraint* p_jolt_ref);
 
 	void remove_joint(JoltJoint3D* p_joint);
 


### PR DESCRIPTION
This PR adds support for the "Axis Lock" property on [`PhysicsBody3D`](https://docs.godotengine.org/en/latest/classes/class_physicsbody3d.html) as well as the "Lock Rotation" property on [`RigidBody3D`](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html).