### PR TITLE
Added support for contact debugging

### DIFF
--- a/src/jolt_contact_listener.cpp
+++ b/src/jolt_contact_listener.cpp
@@ -22,7 +22,10 @@ void JoltContactListener::listen_for(JoltCollisionObject3D* p_object) {
 
 void JoltContactListener::pre_step() {
 	listening_for.clear();
+
+#ifdef DEBUG_ENABLED
 	debug_contact_count = 0;
+#endif // DEBUG_ENABLED
 }
 
 void JoltContactListener::post_step() {

--- a/src/jolt_contact_listener.cpp
+++ b/src/jolt_contact_listener.cpp
@@ -38,7 +38,7 @@ void JoltContactListener::OnContactAdded(
 	const JPH::ContactManifold& p_manifold,
 	JPH::ContactSettings& p_settings
 ) {
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	add_debug_contacts(p_manifold);
 #endif // DEBUG_ENABLED
 
@@ -64,7 +64,7 @@ void JoltContactListener::OnContactPersisted(
 	const JPH::ContactManifold& p_manifold,
 	JPH::ContactSettings& p_settings
 ) {
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	add_debug_contacts(p_manifold);
 #endif // DEBUG_ENABLED
 
@@ -323,7 +323,7 @@ void JoltContactListener::flush_area_exits() {
 	area_exits.clear();
 }
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 
 void JoltContactListener::add_debug_contacts(const JPH::ContactManifold& p_manifold) {
 	const int64_t max_count = debug_contacts.size();

--- a/src/jolt_contact_listener.hpp
+++ b/src/jolt_contact_listener.hpp
@@ -62,6 +62,16 @@ public:
 
 	void post_step();
 
+#if DEBUG_ENABLED
+	const PackedVector3Array& get_debug_contacts() const { return debug_contacts; }
+
+	int32_t get_debug_contact_count() const { return debug_contact_count; }
+
+	int32_t get_max_debug_contacts() const { return (int32_t)debug_contacts.size(); }
+
+	void set_max_debug_contacts(int32_t p_count) { debug_contacts.resize(p_count); }
+#endif // DEBUG_ENABLED
+
 private:
 	void OnContactAdded(
 		const JPH::Body& p_body1,
@@ -96,6 +106,10 @@ private:
 
 	void flush_area_exits();
 
+#if DEBUG_ENABLED
+	void add_debug_contacts(const JPH::ContactManifold& p_manifold);
+#endif // DEBUG_ENABLED
+
 	JoltSpace3D* space = nullptr;
 
 	Mutex write_mutex;
@@ -109,4 +123,10 @@ private:
 	Overlaps area_enters;
 
 	Overlaps area_exits;
+
+#if DEBUG_ENABLED
+	PackedVector3Array debug_contacts;
+
+	std::atomic<int32_t> debug_contact_count;
+#endif // DEBUG_ENABLED
 };

--- a/src/jolt_contact_listener.hpp
+++ b/src/jolt_contact_listener.hpp
@@ -62,7 +62,7 @@ public:
 
 	void post_step();
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	const PackedVector3Array& get_debug_contacts() const { return debug_contacts; }
 
 	int32_t get_debug_contact_count() const { return debug_contact_count; }
@@ -106,7 +106,7 @@ private:
 
 	void flush_area_exits();
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	void add_debug_contacts(const JPH::ContactManifold& p_manifold);
 #endif // DEBUG_ENABLED
 
@@ -124,7 +124,7 @@ private:
 
 	Overlaps area_exits;
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	PackedVector3Array debug_contacts;
 
 	std::atomic<int32_t> debug_contact_count;

--- a/src/jolt_contact_listener.hpp
+++ b/src/jolt_contact_listener.hpp
@@ -127,6 +127,6 @@ private:
 #ifdef DEBUG_ENABLED
 	PackedVector3Array debug_contacts;
 
-	std::atomic<int32_t> debug_contact_count;
+	std::atomic<int32_t> debug_contact_count = 0;
 #endif // DEBUG_ENABLED
 };

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -197,16 +197,35 @@ void JoltPhysicsServer3D::_space_set_debug_contacts(
 	[[maybe_unused]] const RID& p_space,
 	[[maybe_unused]] int32_t p_max_contacts
 ) {
-	WARN_PRINT("Contact debugging is not supported by Godot Jolt.");
+#if DEBUG_ENABLED
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+
+	space->set_max_debug_contacts(p_max_contacts);
+#endif // DEBUG_ENABLED
 }
 
 PackedVector3Array JoltPhysicsServer3D::_space_get_contacts([[maybe_unused]] const RID& p_space
 ) const {
-	ERR_FAIL_D_MSG("Contact debugging is not supported by Godot Jolt.");
+#if DEBUG_ENABLED
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL_D(space);
+
+	return space->get_debug_contacts();
+#else // DEBUG_ENABLED
+	return {};
+#endif // DEBUG_ENABLED
 }
 
 int32_t JoltPhysicsServer3D::_space_get_contact_count([[maybe_unused]] const RID& p_space) const {
-	ERR_FAIL_D_MSG("Contact debugging is not supported by Godot Jolt.");
+#if DEBUG_ENABLED
+	JoltSpace3D* space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL_D(space);
+
+	return space->get_debug_contact_count();
+#else // DEBUG_ENABLED
+	return 0;
+#endif // DEBUG_ENABLED
 }
 
 RID JoltPhysicsServer3D::_area_create() {

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -197,7 +197,7 @@ void JoltPhysicsServer3D::_space_set_debug_contacts(
 	[[maybe_unused]] const RID& p_space,
 	[[maybe_unused]] int32_t p_max_contacts
 ) {
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
@@ -207,7 +207,7 @@ void JoltPhysicsServer3D::_space_set_debug_contacts(
 
 PackedVector3Array JoltPhysicsServer3D::_space_get_contacts([[maybe_unused]] const RID& p_space
 ) const {
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_D(space);
 
@@ -218,7 +218,7 @@ PackedVector3Array JoltPhysicsServer3D::_space_get_contacts([[maybe_unused]] con
 }
 
 int32_t JoltPhysicsServer3D::_space_get_contact_count([[maybe_unused]] const RID& p_space) const {
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_D(space);
 

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -304,6 +304,26 @@ void JoltSpace3D::remove_joint(JoltJoint3D* p_joint) {
 	remove_joint(p_joint->get_jolt_ref());
 }
 
+#if DEBUG_ENABLED
+
+const PackedVector3Array& JoltSpace3D::get_debug_contacts() const {
+	return contact_listener->get_debug_contacts();
+}
+
+int32_t JoltSpace3D::get_debug_contact_count() const {
+	return contact_listener->get_debug_contact_count();
+}
+
+int32_t JoltSpace3D::get_max_debug_contacts() const {
+	return contact_listener->get_max_debug_contacts();
+}
+
+void JoltSpace3D::set_max_debug_contacts(int32_t p_count) {
+	contact_listener->set_max_debug_contacts(p_count);
+}
+
+#endif // DEBUG_ENABLED
+
 void JoltSpace3D::pre_step(float p_step) {
 	body_accessor.acquire_all(true);
 

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -304,7 +304,7 @@ void JoltSpace3D::remove_joint(JoltJoint3D* p_joint) {
 	remove_joint(p_joint->get_jolt_ref());
 }
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 
 const PackedVector3Array& JoltSpace3D::get_debug_contacts() const {
 	return contact_listener->get_debug_contacts();

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -86,6 +86,16 @@ public:
 
 	void remove_joint(JoltJoint3D* p_joint);
 
+#if DEBUG_ENABLED
+	const PackedVector3Array& get_debug_contacts() const;
+
+	int32_t get_debug_contact_count() const;
+
+	int32_t get_max_debug_contacts() const;
+
+	void set_max_debug_contacts(int32_t p_count);
+#endif // DEBUG_ENABLED
+
 private:
 	void pre_step(float p_step);
 

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -86,7 +86,7 @@ public:
 
 	void remove_joint(JoltJoint3D* p_joint);
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	const PackedVector3Array& get_debug_contacts() const;
 
 	int32_t get_debug_contact_count() const;

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -89,6 +89,7 @@
 #include <mimalloc.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
This PR adds support for contact debugging, which is available through the [`debug_collisions_hint`](https://docs.godotengine.org/en/latest/classes/class_scenetree.html#class-scenetree-property-debug-collisions-hint) property on `SceneTree`.

Apparently I had mistaken `DEBUG_ENABLED` for `DEV_ENABLED` when I declared this as unsupported in #215. I was unaware of the above mentioned property and thought this was purely a developer feature for `dev_build` builds of the engine.