### PR TITLE
Added empty implementation of `WorldBoundaryShape3D`

### DIFF
--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -32,7 +32,10 @@ void JoltPhysicsServer3D::finish_statics() {
 }
 
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
-	ERR_FAIL_D_NOT_IMPL();
+	JoltShape3D* shape = memnew(JoltWorldBoundaryShape3D);
+	RID rid = shape_owner.make_rid(shape);
+	shape->set_rid(rid);
+	return rid;
 }
 
 RID JoltPhysicsServer3D::_separation_ray_shape_create() {

--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -175,6 +175,36 @@ JPH::ShapeRefC JoltShape3D::with_user_data(const JPH::Shape* p_shape, uint64_t p
 	return shape_result.Get();
 }
 
+Variant JoltWorldBoundaryShape3D::get_data() const {
+	return plane;
+}
+
+void JoltWorldBoundaryShape3D::set_data(const Variant& p_data) {
+	clear();
+
+	ERR_FAIL_COND(p_data.get_type() != Variant::PLANE);
+
+	const Plane new_plane = p_data;
+
+	if (new_plane == Plane()) {
+		return;
+	}
+
+	plane = new_plane;
+}
+
+void JoltWorldBoundaryShape3D::clear() {
+	jolt_ref = nullptr;
+	plane = Plane();
+}
+
+JPH::ShapeRefC JoltWorldBoundaryShape3D::build() const {
+	ERR_FAIL_D_MSG(
+		"WorldBoundaryShape3D is not supported by Godot Jolt. "
+		"Consider using one or more reasonably sized BoxShape3D instead."
+	);
+}
+
 Variant JoltSphereShape3D::get_data() const {
 	return radius;
 }

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -67,6 +67,24 @@ protected:
 	HashMap<JoltCollisionObject3D*, int32_t> ref_counts_by_owner;
 };
 
+class JoltWorldBoundaryShape3D final : public JoltShape3D {
+public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_WORLD_BOUNDARY; }
+
+	Variant get_data() const override;
+
+	void set_data(const Variant& p_data) override;
+
+	bool is_valid() const override { return plane != Plane(); }
+
+private:
+	void clear();
+
+	JPH::ShapeRefC build() const override;
+
+	Plane plane;
+};
+
 class JoltSphereShape3D final : public JoltShape3D {
 	ShapeType get_type() const override { return ShapeType::SHAPE_SPHERE; }
 


### PR DESCRIPTION
Since Jolt does not, and seemingly never will, support plane shapes (see jrouwe/JoltPhysics#126) for reasons that seem reasonable to me, I will opt to not support this shape type in Godot Jolt.

I took a crack at (somewhat naively) implementing a plane shape as a custom shape type, much in the same way that Bullet does it, and quickly ran into the precision problems mentioned in that issue.