### PR TITLE
Fixed inability to scale shapes within a compound shape

### DIFF
--- a/src/jolt_shape_3d.inl
+++ b/src/jolt_shape_3d.inl
@@ -4,7 +4,13 @@ template<typename TCallable>
 JPH::ShapeRefC JoltShape3D::as_compound(TCallable&& p_callable) {
 	JPH::StaticCompoundShapeSettings shape_settings;
 
-	auto add_shape = [&](const JPH::Shape* p_shape, const Transform3D& p_transform) {
+	auto add_shape = [&](JPH::ShapeRefC p_shape, Transform3D p_transform) {
+		Vector3 scale(1.0f, 1.0f, 1.0f);
+
+		if (try_extract_scale(p_transform, scale)) {
+			p_shape = with_scale(p_shape, scale);
+		}
+
 		shape_settings.AddShape(to_jolt(p_transform.origin), to_jolt(p_transform.basis), p_shape);
 	};
 


### PR DESCRIPTION
Currently Jolt throws asserts due to it expecting normalized quaternions, so we fix that much in the same way we do with the root shape, by stripping the scale from the transform and wrapping the shape in a `JPH::ScaledShape` instead.