### PR TITLE
Updated godot-cpp to a1ae7959da (4.0-stable)

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT d5f4e379948b69b131c1614ff971801477409988
+	GIT_COMMIT a1ae7959da3ce52951b3fed37a018960d03eb785
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@d5f4e379948b69b131c1614ff971801477409988 aka `4.0-stable` to godot-jolt/godot-cpp@a1ae7959da3ce52951b3fed37a018960d03eb785 aka `4.0-stable` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/d5f4e379948b69b131c1614ff971801477409988...a1ae7959da3ce52951b3fed37a018960d03eb785)).

This fixes a problem with the bindings of `PhysicsServer3DExtensionMotionCollision` and `PhysicsServer3DExtensionMotionResult`, where certain members were missing, leading to a mismatch of struct layouts between the engine and the extension.