### PR TITLE
Added support for `SeparationRayShape3D`

### DIFF
--- a/src/jolt_hooks.cpp
+++ b/src/jolt_hooks.cpp
@@ -2,6 +2,7 @@
 
 #include "jolt_empty_shape.hpp"
 #include "jolt_override_user_data_shape.hpp"
+#include "jolt_ray_shape.hpp"
 
 void* jolt_alloc(size_t p_size) {
 	return mi_malloc(p_size);
@@ -62,6 +63,7 @@ void initialize_jolt_hooks() {
 	JPH::RegisterTypes();
 
 	JoltEmptyShape::register_type();
+	JoltRayShape::register_type();
 	JoltOverrideUserDataShape::register_type();
 }
 

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -39,7 +39,10 @@ RID JoltPhysicsServer3D::_world_boundary_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_separation_ray_shape_create() {
-	ERR_FAIL_D_NOT_IMPL();
+	JoltShape3D* shape = memnew(JoltSeparationRayShape3D);
+	RID rid = shape_owner.make_rid(shape);
+	shape->set_rid(rid);
+	return rid;
 }
 
 RID JoltPhysicsServer3D::_sphere_shape_create() {

--- a/src/jolt_ray_shape.cpp
+++ b/src/jolt_ray_shape.cpp
@@ -1,0 +1,217 @@
+#include "jolt_ray_shape.hpp"
+
+#include "jolt_query_collectors.hpp"
+
+namespace {
+
+JPH::Shape* construct_ray() {
+	return new JoltRayShape();
+}
+
+void collide_ray_vs_shape(
+	const JPH::Shape* p_shape1,
+	const JPH::Shape* p_shape2,
+	JPH::Vec3Arg p_scale1,
+	JPH::Vec3Arg p_scale2,
+	JPH::Mat44Arg p_center_of_mass_transform1,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	const JPH::CollideShapeSettings& p_collide_shape_settings,
+	JPH::CollideShapeCollector& p_collector,
+	[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter
+) {
+	const auto* shape1 = static_cast<const JoltRayShape*>(p_shape1);
+
+	// TODO(mihe): This transform scale/inverse feels unnecessary and should be optimized
+
+	const JPH::Mat44 transform1 = p_center_of_mass_transform1 * JPH::Mat44::sScale(p_scale1);
+	const JPH::Mat44 transform2 = p_center_of_mass_transform2 * JPH::Mat44::sScale(p_scale2);
+	const JPH::Mat44 transform_inv2 = transform2.Inversed();
+
+	const JPH::Vec3 start = transform1.GetTranslation();
+	const JPH::Vec3 direction = transform1.GetAxisZ();
+	const JPH::Vec3 vector = direction * shape1->length;
+
+	const JPH::Vec3 local_start2 = transform_inv2 * start;
+	const JPH::Vec3 local_direction2 = transform_inv2.Multiply3x3(direction);
+	const JPH::Vec3 local_vector2 = transform_inv2.Multiply3x3(vector);
+
+	const JPH::RayCast ray_cast(local_start2, local_vector2);
+
+	JPH::RayCastSettings ray_cast_settings;
+	ray_cast_settings.mBackFaceMode = p_collide_shape_settings.mBackFaceMode;
+
+	// NOTE(mihe): Treating convex shapes as solid deviates from how these shapes behave in Godot
+	// Physics, where no collision is registered when fully enveloped by a convex shape. It's not
+	// clear to me whether the behavior of Godot Physics is desired or just the result of a simple
+	// implementation. I assume it's the latter, hence the deviation.
+	ray_cast_settings.mTreatConvexAsSolid = true;
+
+	JoltQueryCollectorClosest<JPH::CastRayCollector> collector;
+
+	p_shape2->CastRay(ray_cast, ray_cast_settings, p_sub_shape_id_creator2, collector);
+
+	if (!collector.had_hit()) {
+		return;
+	}
+
+	const JPH::RayCastResult& hit = collector.get_hit();
+
+	const JPH::Vec3 local_point2 = local_start2 + local_vector2 * hit.mFraction;
+	const JPH::Vec3 local_normal2 = shape1->slide_on_slope
+		? p_shape2->GetSurfaceNormal(hit.mSubShapeID2, local_point2)
+		: -local_direction2;
+
+	const JPH::Vec3 point_on_1 = start + vector;
+	const JPH::Vec3 point_on_2 = transform2 * local_point2;
+	const JPH::Vec3 normal = transform2.Multiply3x3(local_normal2);
+
+	const JPH::CollideShapeResult result(
+		point_on_1,
+		point_on_2,
+		-normal,
+		(point_on_1 - point_on_2).Length(),
+		p_sub_shape_id_creator1.GetID(),
+		p_sub_shape_id_creator2.GetID(),
+		JPH::TransformedShape::sGetBodyID(p_collector.GetContext())
+	);
+
+	// TODO(mihe): Implement face collecting
+
+	p_collector.AddHit(result);
+}
+
+void collide_noop(
+	[[maybe_unused]] const JPH::Shape* p_shape1,
+	[[maybe_unused]] const JPH::Shape* p_shape2,
+	[[maybe_unused]] JPH::Vec3Arg p_scale1,
+	[[maybe_unused]] JPH::Vec3Arg p_scale2,
+	[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform1,
+	[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform2,
+	[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	[[maybe_unused]] const JPH::CollideShapeSettings& p_collide_shape_settings,
+	[[maybe_unused]] JPH::CollideShapeCollector& p_collector,
+	[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter
+) { }
+
+void cast_noop(
+	[[maybe_unused]] const JPH::ShapeCast& p_shape_cast,
+	[[maybe_unused]] const JPH::ShapeCastSettings& p_shape_cast_settings,
+	[[maybe_unused]] const JPH::Shape* p_shape,
+	[[maybe_unused]] JPH::Vec3Arg p_scale,
+	[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter,
+	[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform2,
+	[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	[[maybe_unused]] JPH::CastShapeCollector& p_collector
+) { }
+
+} // namespace
+
+JPH::ShapeSettings::ShapeResult JoltRayShapeSettings::Create() const {
+	if (mCachedResult.IsEmpty()) {
+		new JoltRayShape(*this, mCachedResult);
+	}
+
+	return mCachedResult;
+}
+
+class JoltRayConvexSupport final : public JPH::ConvexShape::Support {
+public:
+	explicit JoltRayConvexSupport(float p_length)
+		: length(p_length) { }
+
+	JPH::Vec3 GetSupport(JPH::Vec3Arg p_direction) const override {
+		if (p_direction.GetZ() > 0.0f) {
+			return {0.0f, 0.0f, length};
+		} else {
+			return JPH::Vec3::sZero();
+		}
+	}
+
+	float GetConvexRadius() const override { return 0.0f; }
+
+private:
+	float length = 0.0f;
+};
+
+static_assert(sizeof(JoltRayConvexSupport) <= sizeof(JPH::ConvexShape::SupportBuffer));
+
+void JoltRayShape::register_type() {
+	JPH::ShapeFunctions& shape_functions =
+		JPH::ShapeFunctions::sGet(JPH::EShapeSubType::UserConvex1);
+
+	shape_functions.mConstruct = construct_ray;
+	shape_functions.mColor = JPH::Color::sDarkRed;
+
+	static constexpr JPH::EShapeSubType concrete_sub_types[] = {
+		JPH::EShapeSubType::Sphere,
+		JPH::EShapeSubType::Box,
+		JPH::EShapeSubType::Triangle,
+		JPH::EShapeSubType::Capsule,
+		JPH::EShapeSubType::TaperedCapsule,
+		JPH::EShapeSubType::Cylinder,
+		JPH::EShapeSubType::ConvexHull,
+		JPH::EShapeSubType::Mesh,
+		JPH::EShapeSubType::HeightField};
+
+	for (const JPH::EShapeSubType concrete_sub_type : concrete_sub_types) {
+		JPH::CollisionDispatch::sRegisterCollideShape(
+			JPH::EShapeSubType::UserConvex1,
+			concrete_sub_type,
+			collide_ray_vs_shape
+		);
+
+		JPH::CollisionDispatch::sRegisterCollideShape(
+			concrete_sub_type,
+			JPH::EShapeSubType::UserConvex1,
+			JPH::CollisionDispatch::sReversedCollideShape
+		);
+	}
+
+	JPH::CollisionDispatch::sRegisterCollideShape(
+		JPH::EShapeSubType::UserConvex1,
+		JPH::EShapeSubType::UserConvex1,
+		collide_noop
+	);
+
+	JPH::CollisionDispatch::sRegisterCastShape(
+		JPH::EShapeSubType::UserConvex1,
+		JPH::EShapeSubType::UserConvex1,
+		cast_noop
+	);
+}
+
+JPH::AABox JoltRayShape::GetLocalBounds() const {
+	return {JPH::Vec3::sZero(), JPH::Vec3(0.0f, 0.0f, length)};
+}
+
+#ifdef JPH_DEBUG_RENDERER
+
+void JoltRayShape::Draw(
+	JPH::DebugRenderer* p_renderer,
+	JPH::RMat44Arg p_center_of_mass_transform,
+	JPH::Vec3Arg p_scale,
+	JPH::ColorArg p_color,
+	bool p_use_material_colors,
+	[[maybe_unused]] bool p_draw_wireframe
+) const {
+	p_renderer->DrawArrow(
+		p_center_of_mass_transform.GetTranslation(),
+		p_center_of_mass_transform * JPH::Vec3(0, 0, length * p_scale.GetZ()),
+		p_use_material_colors ? GetMaterial()->GetDebugColor() : p_color,
+		0.1f
+	);
+}
+
+#endif // JPH_DEBUG_RENDERER
+
+const JPH::ConvexShape::Support* JoltRayShape::GetSupportFunction(
+	[[maybe_unused]] JPH::ConvexShape::ESupportMode p_mode,
+	JPH::ConvexShape::SupportBuffer& p_buffer,
+	JPH::Vec3Arg p_scale
+) const {
+	return new (&p_buffer) JoltRayConvexSupport(p_scale.GetZ() * length);
+}

--- a/src/jolt_ray_shape.hpp
+++ b/src/jolt_ray_shape.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+class JoltRayShapeSettings final : public JPH::ConvexShapeSettings {
+public:
+	JoltRayShapeSettings() = default;
+
+	JoltRayShapeSettings(
+		float p_length,
+		bool p_slide_on_slope,
+		const JPH::PhysicsMaterial* p_material = nullptr
+	)
+		: slide_on_slope(p_slide_on_slope)
+		, length(p_length)
+		, material(p_material) { }
+
+	JPH::ShapeSettings::ShapeResult Create() const override;
+
+	bool slide_on_slope = false;
+
+	float length = 1.0f;
+
+	JPH::RefConst<JPH::PhysicsMaterial> material;
+};
+
+class JoltRayShape final : public JPH::ConvexShape {
+public:
+	static void register_type();
+
+	JoltRayShape()
+		: JPH::ConvexShape(JPH::EShapeSubType::UserConvex1) { }
+
+	JoltRayShape(const JoltRayShapeSettings& p_settings, JPH::Shape::ShapeResult& p_result)
+		: JPH::ConvexShape(JPH::EShapeSubType::UserConvex1, p_settings, p_result)
+		, slide_on_slope(p_settings.slide_on_slope)
+		, length(p_settings.length)
+		, material(p_settings.material) {
+		if (!p_result.HasError()) {
+			p_result.Set(this);
+		}
+	}
+
+	JoltRayShape(
+		float p_length,
+		bool p_slide_on_slope,
+		const JPH::PhysicsMaterial* p_material = nullptr
+	)
+		: JPH::ConvexShape(JPH::EShapeSubType::UserConvex1)
+		, slide_on_slope(p_slide_on_slope)
+		, length(p_length)
+		, material(p_material) { }
+
+	JPH::AABox GetLocalBounds() const override;
+
+	float GetInnerRadius() const override { return 0.0f; }
+
+	JPH::MassProperties GetMassProperties() const override { return {}; }
+
+	JPH::Vec3 GetSurfaceNormal(
+		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,
+		[[maybe_unused]] JPH::Vec3Arg p_local_surface_position
+	) const override {
+		return JPH::Vec3::sAxisZ();
+	}
+
+	// clang-format off
+
+	void GetSubmergedVolume(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] const JPH::Plane& p_surface,
+		float& p_total_volume,
+		float& p_submerged_volume,
+		JPH::Vec3& p_center_of_buoyancy
+#ifdef JPH_DEBUG_RENDERER
+		, [[maybe_unused]] JPH::RVec3Arg p_base_offset
+#endif // JPH_DEBUG_RENDERER
+	) const override {
+		p_total_volume = 0.0f;
+		p_submerged_volume = 0.0f;
+		p_center_of_buoyancy = JPH::Vec3::sZero();
+	}
+
+	// clang-format on
+
+#ifdef JPH_DEBUG_RENDERER
+
+	void Draw(
+		JPH::DebugRenderer* p_renderer,
+		JPH::RMat44Arg p_center_of_mass_transform,
+		JPH::Vec3Arg p_scale,
+		JPH::ColorArg p_color,
+		bool p_use_material_colors,
+		bool p_draw_wireframe
+	) const override;
+
+#endif // JPH_DEBUG_RENDERER
+
+	bool CastRay(
+		[[maybe_unused]] const JPH::RayCast& p_ray,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::RayCastResult& p_hit
+	) const override {
+		return false;
+	}
+
+	void CastRay(
+		[[maybe_unused]] const JPH::RayCast& p_ray,
+		[[maybe_unused]] const JPH::RayCastSettings& p_ray_cast_settings,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::CastRayCollector& p_collector,
+		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
+	) const override { }
+
+	void CollidePoint(
+		[[maybe_unused]] JPH::Vec3Arg p_point,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::CollidePointCollector& p_collector,
+		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
+	) const override { }
+
+	JPH::Shape::Stats GetStats() const override { return {sizeof(*this), 0}; }
+
+	float GetVolume() const override { return 0.0f; }
+
+	const JPH::ConvexShape::Support* GetSupportFunction(
+		JPH::ConvexShape::ESupportMode p_mode,
+		JPH::ConvexShape::SupportBuffer& p_buffer,
+		JPH::Vec3Arg p_scale
+	) const override;
+
+	bool slide_on_slope = false;
+
+	float length = 0.0f;
+
+	JPH::RefConst<JPH::PhysicsMaterial> material;
+};

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -85,6 +85,26 @@ private:
 	Plane plane;
 };
 
+class JoltSeparationRayShape3D final : public JoltShape3D {
+public:
+	ShapeType get_type() const override { return ShapeType::SHAPE_SEPARATION_RAY; }
+
+	Variant get_data() const override;
+
+	void set_data(const Variant& p_data) override;
+
+	bool is_valid() const override { return length > 0.0f; }
+
+private:
+	void clear();
+
+	JPH::ShapeRefC build() const override;
+
+	float length = 0.0f;
+
+	bool slide_on_slope = false;
+};
+
 class JoltSphereShape3D final : public JoltShape3D {
 	ShapeType get_type() const override { return ShapeType::SHAPE_SPHERE; }
 


### PR DESCRIPTION
Note that this deviates slightly from the implementation in Godot Physics, where convex shapes are seemingly not treated as solid, meaning their implementation does not resolve collisions where the ray is fully enveloped by a convex shape, whereas this one will.