### PR TITLE
Added preliminary support for `body_test_motion`

### DIFF
--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -264,15 +264,6 @@ Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	return to_godot(body->GetInverseInertia()).basis;
 }
 
-Vector3 JoltBody3D::get_linear_velocity(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
-
-	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetMotionPropertiesUnchecked()->GetLinearVelocity());
-}
-
 void JoltBody3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
 	if (!space) {
 		initial_linear_velocity = p_velocity;
@@ -283,15 +274,6 @@ void JoltBody3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
 	ERR_FAIL_COND(body.is_invalid());
 
 	body->GetMotionPropertiesUnchecked()->SetLinearVelocityClamped(to_jolt(p_velocity));
-}
-
-Vector3 JoltBody3D::get_angular_velocity(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
-
-	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetMotionPropertiesUnchecked()->GetAngularVelocity());
 }
 
 void JoltBody3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -68,11 +68,7 @@ public:
 
 	Basis get_inverse_inertia_tensor(bool p_lock = true) const;
 
-	Vector3 get_linear_velocity(bool p_lock = true) const;
-
 	void set_linear_velocity(const Vector3& p_velocity, bool p_lock = true);
-
-	Vector3 get_angular_velocity(bool p_lock = true) const;
 
 	void set_angular_velocity(const Vector3& p_velocity, bool p_lock = true);
 

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -133,6 +133,24 @@ Vector3 JoltCollisionObject3D::get_center_of_mass(bool p_lock) const {
 	return to_godot(body->GetCenterOfMassPosition());
 }
 
+Vector3 JoltCollisionObject3D::get_linear_velocity(bool p_lock) const {
+	ERR_FAIL_NULL_D(space);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetLinearVelocity());
+}
+
+Vector3 JoltCollisionObject3D::get_angular_velocity(bool p_lock) const {
+	ERR_FAIL_NULL_D(space);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetAngularVelocity());
+}
+
 Vector3 JoltCollisionObject3D::get_velocity_at_position(const Vector3& p_position, bool p_lock)
 	const {
 	ERR_FAIL_NULL_D(space);

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -281,6 +281,16 @@ int32_t JoltCollisionObject3D::find_shape_index(const JPH::SubShapeID& p_sub_sha
 	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
 }
 
+JoltShape3D* JoltCollisionObject3D::find_shape(uint32_t p_shape_instance_id) const {
+	const int32_t shape_index = find_shape_index(p_shape_instance_id);
+	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
+}
+
+JoltShape3D* JoltCollisionObject3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
+	const int32_t shape_index = find_shape_index(p_sub_shape_id);
+	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
+}
+
 JoltShape3D* JoltCollisionObject3D::get_shape(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -53,6 +53,10 @@ public:
 
 	Vector3 get_center_of_mass(bool p_lock = true) const;
 
+	Vector3 get_linear_velocity(bool p_lock = true) const;
+
+	Vector3 get_angular_velocity(bool p_lock = true) const;
+
 	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const;
 
 	JPH::ShapeRefC try_build_shape();

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -86,6 +86,10 @@ public:
 
 	int32_t find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const;
 
+	JoltShape3D* find_shape(uint32_t p_shape_instance_id) const;
+
+	JoltShape3D* find_shape(const JPH::SubShapeID& p_sub_shape_id) const;
+
 	JoltShape3D* get_shape(int32_t p_index) const;
 
 	void set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock = true);

--- a/src/jolt_motion_filter_3d.cpp
+++ b/src/jolt_motion_filter_3d.cpp
@@ -1,0 +1,76 @@
+#include "jolt_motion_filter_3d.hpp"
+
+#include "jolt_body_3d.hpp"
+#include "jolt_broad_phase_layer.hpp"
+#include "jolt_collision_object_3d.hpp"
+#include "jolt_physics_server_3d.hpp"
+#include "jolt_shape_3d.hpp"
+#include "jolt_space_3d.hpp"
+
+JoltMotionFilter3D::JoltMotionFilter3D(const JoltBody3D& p_body, bool p_collide_separation_ray)
+	: physics_server(*static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton()))
+	, body(p_body)
+	, collide_separation_ray(p_collide_separation_ray) { }
+
+bool JoltMotionFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const {
+	const auto broad_phase_layer = (JPH::BroadPhaseLayer::Type)p_broad_phase_layer;
+
+	switch (broad_phase_layer) {
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC:
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_DYNAMIC: {
+			return true;
+		} break;
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::AREA_DETECTABLE:
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::AREA_UNDETECTABLE: {
+			return false;
+		} break;
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled broad phase layer: '%d'", broad_phase_layer));
+		}
+	}
+}
+
+bool JoltMotionFilter3D::ShouldCollide(JPH::ObjectLayer p_object_layer) const {
+	JPH::BroadPhaseLayer object_broad_phase_layer = {};
+	uint32_t object_collision_layer = 0;
+	uint32_t object_collision_mask = 0;
+
+	body.get_space()->map_from_object_layer(
+		p_object_layer,
+		object_broad_phase_layer,
+		object_collision_layer,
+		object_collision_mask
+	);
+
+	return (body.get_collision_mask() & object_collision_layer) != 0;
+}
+
+bool JoltMotionFilter3D::ShouldCollide(const JPH::BodyID& p_body_id) const {
+	return p_body_id != body.get_jolt_id();
+}
+
+bool JoltMotionFilter3D::ShouldCollideLocked(const JPH::Body& p_body) const {
+	auto* object = reinterpret_cast<JoltCollisionObject3D*>(p_body.GetUserData());
+
+	return !physics_server.body_test_motion_is_excluding_object(object->get_instance_id()) &&
+		!physics_server.body_test_motion_is_excluding_body(object->get_rid());
+}
+
+bool JoltMotionFilter3D::ShouldCollide([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2
+) const {
+	return true;
+}
+
+bool JoltMotionFilter3D::ShouldCollide(
+	const JPH::SubShapeID& p_sub_shape_id1,
+	[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2
+) const {
+	if (collide_separation_ray) {
+		return true;
+	}
+
+	const JoltShape3D* shape = body.find_shape(p_sub_shape_id1);
+	ERR_FAIL_NULL_V(shape, true);
+
+	return shape->get_type() != PhysicsServer3D::SHAPE_SEPARATION_RAY;
+}

--- a/src/jolt_motion_filter_3d.hpp
+++ b/src/jolt_motion_filter_3d.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+class JoltPhysicsServer3D;
+class JoltBody3D;
+
+class JoltMotionFilter3D final
+	: public JPH::BroadPhaseLayerFilter
+	, public JPH::ObjectLayerFilter
+	, public JPH::BodyFilter
+	, public JPH::ShapeFilter {
+public:
+	JoltMotionFilter3D(const JoltBody3D& p_body, bool p_collide_separation_ray);
+
+	bool ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const override;
+
+	bool ShouldCollide(JPH::ObjectLayer p_object_layer) const override;
+
+	bool ShouldCollide(const JPH::BodyID& p_body_id) const override;
+
+	bool ShouldCollideLocked(const JPH::Body& p_body) const override;
+
+	bool ShouldCollide(const JPH::SubShapeID& p_sub_shape_id2) const override;
+
+	bool ShouldCollide(
+		const JPH::SubShapeID& p_sub_shape_id1,
+		const JPH::SubShapeID& p_sub_shape_id2
+	) const override;
+
+private:
+	const JoltPhysicsServer3D& physics_server;
+
+	const JoltBody3D& body;
+
+	bool collide_separation_ray = false;
+};

--- a/src/jolt_physics_direct_space_state_3d.hpp
+++ b/src/jolt_physics_direct_space_state_3d.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+class JoltBody3D;
 class JoltSpace3D;
 
 class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3DExtension {
@@ -86,8 +87,49 @@ public:
 	Vector3 _get_closest_point_to_object_volume(const RID& p_object, const Vector3& p_point)
 		const override;
 
+	bool test_body_motion(
+		const JoltBody3D& p_body,
+		const Transform3D& p_transform,
+		const Vector3& p_motion,
+		float p_margin,
+		int32_t p_max_collisions,
+		bool p_collide_separation_ray,
+		PhysicsServer3DExtensionMotionResult* p_result
+	) const;
+
 	JoltSpace3D& get_space() const { return *space; }
 
 private:
+	bool body_motion_recover(
+		const JoltBody3D& p_body,
+		Transform3D& p_transform_com,
+		const Vector3& p_scale,
+		float p_margin,
+		bool p_collide_separation_ray,
+		Vector3& p_recover_motion
+	) const;
+
+	bool body_motion_cast(
+		const JoltBody3D& p_body,
+		const Transform3D& p_transform_com,
+		const Vector3& p_scale,
+		float p_margin,
+		const Vector3& p_motion,
+		bool p_collide_separation_ray,
+		float& p_safe_fraction,
+		float& p_unsafe_fraction
+	) const;
+
+	bool body_motion_collide(
+		const JoltBody3D& p_body,
+		const Transform3D& p_transform_com,
+		const Vector3& p_scale,
+		float p_margin,
+		int32_t p_max_collisions,
+		bool p_collide_separation_ray,
+		PhysicsServer3DExtensionMotionCollision* p_collisions,
+		int32_t& p_collision_count
+	) const;
+
 	JoltSpace3D* space = nullptr;
 };

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -971,15 +971,29 @@ void JoltPhysicsServer3D::_body_set_ray_pickable(const RID& p_body, bool p_enabl
 }
 
 bool JoltPhysicsServer3D::_body_test_motion(
-	[[maybe_unused]] const RID& p_body,
-	[[maybe_unused]] const Transform3D& p_from,
-	[[maybe_unused]] const Vector3& p_motion,
-	[[maybe_unused]] double p_margin,
-	[[maybe_unused]] int32_t p_max_collisions,
-	[[maybe_unused]] bool p_collide_separation_ray,
-	[[maybe_unused]] PhysicsServer3DExtensionMotionResult* p_result
+	const RID& p_body,
+	const Transform3D& p_from,
+	const Vector3& p_motion,
+	double p_margin,
+	int32_t p_max_collisions,
+	bool p_collide_separation_ray,
+	PhysicsServer3DExtensionMotionResult* p_result
 ) const {
-	ERR_FAIL_D_NOT_IMPL();
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	JoltSpace3D* space = body->get_space();
+	ERR_FAIL_NULL_D(space);
+
+	return space->get_direct_state()->test_body_motion(
+		*body,
+		p_from,
+		p_motion,
+		(float)p_margin,
+		p_max_collisions,
+		p_collide_separation_ray,
+		p_result
+	);
 }
 
 PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(const RID& p_body) {


### PR DESCRIPTION
This adds preliminary (somewhat broken) support for the [`body_test_motion`](https://docs.godotengine.org/en/latest/classes/class_physicsserver3d.html#class-physicsserver3d-method-body-test-motion) method on `PhysicsServer3D`, which is what powers methods like `PhysicsBody3D.move_and_collide` and `PhysicsBody3D.test_move`, which in turn powers `CharacterBody3D`.

The caveats here are as follows:

1. The `recovery_as_collision` parameter that gets passed to the above mentioned methods is not currently exposed to GDExtension, so this will always be treated as `true` currently, to cater to the needs of `CharacterBody3D`.
2. More work needs to be done with collision tolerances and how the `margin` parameter is incorporated into them, because you can currently get stuck randomly as you're walking up certain slopes, especially at distances far from the world origin.