### PR TITLE
Updated Jolt to bc4fa997f1

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -29,7 +29,7 @@ set(dev_definitions
 
 GodotJoltExternalLibrary_Add(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 752f0c3e36c8bb324726496033cfbba45588207e
+	GIT_COMMIT bc4fa997f15f2953dc87ee5c1ba51ecf2077c287
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/examples/capsule.tscn
+++ b/examples/capsule.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=4 format=3 uid="uid://cpgec28ml0nss"]
+
+[ext_resource type="Material" uid="uid://ctm5wb05otmn4" path="res://scenes/common/materials/green.tres" id="1_4thlc"]
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_idxhg"]
+
+[sub_resource type="SeparationRayShape3D" id="SeparationRayShape3D_dmcex"]
+
+[node name="Capsule" type="RigidBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.56047, 5.62321, 0)
+
+[node name="Shape" type="CollisionShape3D" parent="."]
+shape = SubResource("CapsuleShape3D_idxhg")
+
+[node name="Mesh_Top" type="CSGSphere3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+radial_segments = 36
+rings = 18
+material = ExtResource("1_4thlc")
+
+[node name="Mesh_Middle" type="CSGCylinder3D" parent="."]
+height = 1.0
+sides = 36
+material = ExtResource("1_4thlc")
+
+[node name="Mesh_Bottom" type="CSGSphere3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
+radial_segments = 36
+rings = 18
+material = ExtResource("1_4thlc")
+
+[node name="Ray" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, -1.0876, 0)
+shape = SubResource("SeparationRayShape3D_dmcex")

--- a/examples/character.gd
+++ b/examples/character.gd
@@ -1,0 +1,48 @@
+extends CharacterBody3D
+
+
+const SPEED = 5.0
+const JUMP_VELOCITY = 4.5
+
+# Get the gravity from the project settings to be synced with RigidBody nodes.
+var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
+
+@onready
+var target_basis = $Arrow.global_transform.basis
+
+func _physics_process(delta: float):
+	# Add the gravity.
+	if not is_on_floor():
+		velocity.y -= gravity * delta
+
+	# Handle Jump.
+	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+		velocity.y = JUMP_VELOCITY
+
+	# Get the input direction and handle the movement/deceleration.
+	# As good practice, you should replace UI actions with custom gameplay actions.
+	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+
+	var arrow_material := $Arrow/Mesh_Shaft.material as StandardMaterial3D
+
+	if direction:
+		velocity.x = direction.x * SPEED
+		velocity.z = direction.z * SPEED
+		var y := up_direction
+		var z := -direction
+		var x := y.cross(z)
+		target_basis = Basis(x, y, z)
+		arrow_material.albedo_color.r = 1.0
+		arrow_material.albedo_color.g = 0.0
+		arrow_material.albedo_color.b = 0.0
+	else:
+		velocity.x = move_toward(velocity.x, 0, SPEED)
+		velocity.z = move_toward(velocity.z, 0, SPEED)
+		arrow_material.albedo_color.r = 0.43
+		arrow_material.albedo_color.g = 0.64
+		arrow_material.albedo_color.b = 0.0
+
+	$Arrow.global_transform.basis = $Arrow.global_transform.basis.slerp(target_basis, 30.0 * delta)
+
+	move_and_slide()

--- a/src/jolt_motion_filter_3d.cpp
+++ b/src/jolt_motion_filter_3d.cpp
@@ -56,21 +56,18 @@ bool JoltMotionFilter3D::ShouldCollideLocked(const JPH::Body& p_body) const {
 		!physics_server.body_test_motion_is_excluding_body(object->get_rid());
 }
 
-bool JoltMotionFilter3D::ShouldCollide([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2
+bool JoltMotionFilter3D::ShouldCollide(
+	[[maybe_unused]] const JPH::Shape* p_shape2,
+	[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2
 ) const {
 	return true;
 }
 
 bool JoltMotionFilter3D::ShouldCollide(
-	const JPH::SubShapeID& p_sub_shape_id1,
+	const JPH::Shape* p_shape1,
+	[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id1,
+	[[maybe_unused]] const JPH::Shape* p_shape2,
 	[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2
 ) const {
-	if (collide_separation_ray) {
-		return true;
-	}
-
-	const JoltShape3D* shape = body.find_shape(p_sub_shape_id1);
-	ERR_FAIL_NULL_V(shape, true);
-
-	return shape->get_type() != PhysicsServer3D::SHAPE_SEPARATION_RAY;
+	return collide_separation_ray || p_shape1->GetSubType() != JPH::EShapeSubType::UserConvex1;
 }

--- a/src/jolt_motion_filter_3d.hpp
+++ b/src/jolt_motion_filter_3d.hpp
@@ -19,10 +19,13 @@ public:
 
 	bool ShouldCollideLocked(const JPH::Body& p_body) const override;
 
-	bool ShouldCollide(const JPH::SubShapeID& p_sub_shape_id2) const override;
+	bool ShouldCollide(const JPH::Shape* p_shape2, const JPH::SubShapeID& p_sub_shape_id2)
+		const override;
 
 	bool ShouldCollide(
+		const JPH::Shape* p_shape1,
 		const JPH::SubShapeID& p_sub_shape_id1,
+		const JPH::Shape* p_shape2,
 		const JPH::SubShapeID& p_sub_shape_id2
 	) const override;
 


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@752f0c3e36c8bb324726496033cfbba45588207e to godot-jolt/jolt@bc4fa997f15f2953dc87ee5c1ba51ecf2077c287 (see diff [here](https://github.com/godot-jolt/jolt/compare/752f0c3e36c8bb324726496033cfbba45588207e...bc4fa997f15f2953dc87ee5c1ba51ecf2077c287)).

This brings in the revised `JPH::ShapeFilter`, which allows for discerning of compound shapes for the shape being cast during a shape-cast, which is needed for the `collide_separation_ray` parameter of `PhysicsServer3D.body_test_motion`.