### PR TITLE
Improved deinitialization of Jolt using `JPH::UnregisterTypes`

### DIFF
--- a/src/jolt_hooks.cpp
+++ b/src/jolt_hooks.cpp
@@ -68,5 +68,7 @@ void initialize_jolt_hooks() {
 }
 
 void deinitialize_jolt_hooks() {
+	JPH::UnregisterTypes();
+
 	delete_safely(JPH::Factory::sInstance);
 }


### PR DESCRIPTION
This shouldn't make much of a difference in practice, since all of Jolt's memory usage would've been wiped at library unload anyway, but it's the correct thing to do I guess.