### PR TITLE
Lowered the number of iterations for contact impulses

### DIFF
--- a/src/jolt_contact_listener.cpp
+++ b/src/jolt_contact_listener.cpp
@@ -125,7 +125,9 @@ void JoltContactListener::update_contacts(
 		p_manifold,
 		collision,
 		p_settings.mCombinedFriction,
-		p_settings.mCombinedRestitution
+		p_settings.mCombinedRestitution,
+		1.0f,
+		5
 	);
 
 	for (JPH::uint i = 0; i < contact_count; ++i) {


### PR DESCRIPTION
Since this estimation only takes into account a single pair of bodies, I'll go ahead and conservatively lower this number from the default 10 to 5. There might be some more margin here that can be shaved off later if/when necessary.

I might end up exposing this in the project settings at some point.