### PR TITLE
Added support for shape margins

### DIFF
--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -135,15 +135,12 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
-	const JPH::ShapeRefC jolt_shape = shape->try_build();
+	const JPH::ShapeRefC jolt_shape = shape->try_build((float)p_margin);
 	ERR_FAIL_NULL_D(jolt_shape);
 
 	Transform3D transform_com = p_transform.translated_local(shape->get_center_of_mass());
 	Vector3 scale(1.0f, 1.0f, 1.0f);
 	try_strip_scale(transform_com, scale);
-
-	JPH::CollideShapeSettings settings;
-	settings.mCollisionTolerance = max((float)p_margin, JPH::cDefaultCollisionTolerance);
 
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
@@ -154,7 +151,7 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 		jolt_shape,
 		to_jolt(scale),
 		to_jolt(transform_com),
-		settings,
+		JPH::CollideShapeSettings(),
 		to_jolt(transform_com.origin),
 		collector,
 		query_filter,
@@ -202,7 +199,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
-	const JPH::ShapeRefC jolt_shape = shape->try_build();
+	const JPH::ShapeRefC jolt_shape = shape->try_build((float)p_margin);
 	ERR_FAIL_NULL_D(jolt_shape);
 
 	Transform3D transform_com = p_transform.translated_local(shape->get_center_of_mass());
@@ -210,7 +207,6 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	try_strip_scale(transform_com, scale);
 
 	JPH::ShapeCastSettings settings;
-	settings.mCollisionTolerance = max((float)p_margin, JPH::cDefaultCollisionTolerance);
 	settings.mBackFaceModeConvex = JPH::EBackFaceMode::CollideWithBackFaces;
 
 	const Vector3& base_offset = transform_com.origin;
@@ -287,15 +283,12 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
-	const JPH::ShapeRefC jolt_shape = shape->try_build();
+	const JPH::ShapeRefC jolt_shape = shape->try_build((float)p_margin);
 	ERR_FAIL_NULL_D(jolt_shape);
 
 	Transform3D transform_com = p_transform.translated_local(shape->get_center_of_mass());
 	Vector3 scale(1.0f, 1.0f, 1.0f);
 	try_strip_scale(transform_com, scale);
-
-	JPH::CollideShapeSettings settings;
-	settings.mCollisionTolerance = max((float)p_margin, JPH::cDefaultCollisionTolerance);
 
 	const Vector3& base_offset = transform_com.origin;
 
@@ -308,7 +301,7 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 		jolt_shape,
 		to_jolt(scale),
 		to_jolt(transform_com),
-		settings,
+		JPH::CollideShapeSettings(),
 		to_jolt(base_offset),
 		collector,
 		query_filter,
@@ -347,15 +340,12 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
-	const JPH::ShapeRefC jolt_shape = shape->try_build();
+	const JPH::ShapeRefC jolt_shape = shape->try_build((float)p_margin);
 	ERR_FAIL_NULL_D(jolt_shape);
 
 	Transform3D transform_com = p_transform.translated_local(shape->get_center_of_mass());
 	Vector3 scale(1.0f, 1.0f, 1.0f);
 	try_strip_scale(transform_com, scale);
-
-	JPH::CollideShapeSettings settings;
-	settings.mCollisionTolerance = max((float)p_margin, JPH::cDefaultCollisionTolerance);
 
 	const Vector3& base_offset = transform_com.origin;
 
@@ -368,7 +358,7 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 		jolt_shape,
 		to_jolt(scale),
 		to_jolt(transform_com),
-		settings,
+		JPH::CollideShapeSettings(),
 		to_jolt(base_offset),
 		collector,
 		query_filter,

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -126,15 +126,18 @@ Variant JoltPhysicsServer3D::_shape_get_data(const RID& p_shape) const {
 	return shape->get_data();
 }
 
-void JoltPhysicsServer3D::_shape_set_margin(
-	[[maybe_unused]] const RID& p_shape,
-	[[maybe_unused]] double p_margin
-) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsServer3D::_shape_set_margin(const RID& p_shape, double p_margin) {
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL(shape);
+
+	shape->set_margin((float)p_margin);
 }
 
-double JoltPhysicsServer3D::_shape_get_margin([[maybe_unused]] const RID& p_shape) const {
-	ERR_FAIL_D_NOT_IMPL();
+double JoltPhysicsServer3D::_shape_get_margin(const RID& p_shape) const {
+	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL_D(shape);
+
+	return (double)shape->get_margin();
 }
 
 double JoltPhysicsServer3D::_shape_get_custom_solver_bias([[maybe_unused]] const RID& p_shape

--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -185,13 +185,17 @@ void JoltWorldBoundaryShape3D::set_data(const Variant& p_data) {
 
 	ERR_FAIL_COND(p_data.get_type() != Variant::PLANE);
 
-	const Plane new_plane = p_data;
+	set_data((Plane)p_data);
+}
 
-	if (new_plane == Plane()) {
+void JoltWorldBoundaryShape3D::set_data(Plane p_plane) {
+	clear();
+
+	if (p_plane == Plane()) {
 		return;
 	}
 
-	plane = new_plane;
+	plane = p_plane;
 }
 
 void JoltWorldBoundaryShape3D::clear() {
@@ -226,17 +230,20 @@ void JoltSeparationRayShape3D::set_data(const Variant& p_data) {
 	const Variant maybe_slide_on_slope = data.get("slide_on_slope", {});
 	ERR_FAIL_COND(maybe_slide_on_slope.get_type() != Variant::BOOL);
 
-	const float new_length = maybe_length;
-	const bool new_slide_on_slope = maybe_slide_on_slope;
+	set_data((float)maybe_length, (bool)maybe_slide_on_slope);
+}
+
+void JoltSeparationRayShape3D::set_data(float p_length, bool p_slide_on_slope) {
+	clear();
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid.
-	if (new_length == 0.0f) {
+	if (p_length == 0.0f) {
 		return;
 	}
 
-	length = new_length;
-	slide_on_slope = new_slide_on_slope;
+	length = p_length;
+	slide_on_slope = p_slide_on_slope;
 }
 
 void JoltSeparationRayShape3D::clear() {
@@ -271,15 +278,19 @@ void JoltSphereShape3D::set_data(const Variant& p_data) {
 
 	ERR_FAIL_COND(p_data.get_type() != Variant::FLOAT);
 
-	const float new_radius = p_data;
+	set_data((float)p_data);
+}
+
+void JoltSphereShape3D::set_data(float p_radius) {
+	clear();
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid.
-	if (new_radius <= 0.0f) {
+	if (p_radius <= 0.0f) {
 		return;
 	}
 
-	radius = new_radius;
+	radius = p_radius;
 }
 
 void JoltSphereShape3D::clear() {
@@ -313,8 +324,13 @@ void JoltBoxShape3D::set_data(const Variant& p_data) {
 
 	ERR_FAIL_COND(p_data.get_type() != Variant::VECTOR3);
 
-	const Vector3 new_half_extents = p_data;
-	const float shortest_axis = new_half_extents[new_half_extents.min_axis_index()];
+	set_data((Vector3)p_data);
+}
+
+void JoltBoxShape3D::set_data(Vector3 p_half_extents) {
+	clear();
+
+	const float shortest_axis = p_half_extents[p_half_extents.min_axis_index()];
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid. We also treat any extents smaller than or equal to the convex
@@ -323,7 +339,7 @@ void JoltBoxShape3D::set_data(const Variant& p_data) {
 		return;
 	}
 
-	half_extents = new_half_extents;
+	half_extents = p_half_extents;
 }
 
 void JoltBoxShape3D::clear() {
@@ -368,29 +384,32 @@ void JoltCapsuleShape3D::set_data(const Variant& p_data) {
 	const Variant maybe_radius = data.get("radius", {});
 	ERR_FAIL_COND(maybe_radius.get_type() != Variant::FLOAT);
 
-	const float new_height = maybe_height;
-	const float new_radius = maybe_radius;
+	set_data((float)maybe_height, (float)maybe_radius);
+}
+
+void JoltCapsuleShape3D::set_data(float p_height, float p_radius) {
+	clear();
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid.
-	if (new_height <= 0.0f || new_radius <= 0.0f) {
+	if (p_height <= 0.0f || p_radius <= 0.0f) {
 		return;
 	}
 
-	const float half_height = new_height / 2.0f;
+	const float half_height = p_height / 2.0f;
 
 	ERR_FAIL_COND_MSG(
-		half_height < new_radius,
+		half_height < p_radius,
 		vformat(
 			"Failed to set shape data for capsule shape with height '%f' and radius '%f'. "
 			"Half height must be equal to or greater than radius.",
-			new_height,
-			new_radius
+			p_height,
+			p_radius
 		)
 	);
 
-	height = new_height;
-	radius = new_radius;
+	height = p_height;
+	radius = p_radius;
 }
 
 void JoltCapsuleShape3D::clear() {
@@ -440,18 +459,21 @@ void JoltCylinderShape3D::set_data(const Variant& p_data) {
 	const Variant maybe_radius = data.get("radius", {});
 	ERR_FAIL_COND(maybe_radius.get_type() != Variant::FLOAT);
 
-	const float new_height = maybe_height;
-	const float new_radius = maybe_radius;
+	set_data((float)maybe_height, (float)maybe_radius);
+}
+
+void JoltCylinderShape3D::set_data(float p_height, float p_radius) {
+	clear();
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid. We also treat any extents smaller than the convex radius as
 	// zero-sized, otherwise Jolt will report an error.
-	if (new_height < GDJOLT_CONVEX_RADIUS || new_radius < GDJOLT_CONVEX_RADIUS) {
+	if (p_height < GDJOLT_CONVEX_RADIUS || p_radius < GDJOLT_CONVEX_RADIUS) {
 		return;
 	}
 
-	height = new_height;
-	radius = new_radius;
+	height = p_height;
+	radius = p_radius;
 }
 
 void JoltCylinderShape3D::clear() {
@@ -489,16 +511,19 @@ void JoltConvexPolygonShape3D::set_data(const Variant& p_data) {
 
 	ERR_FAIL_COND(p_data.get_type() != Variant::PACKED_VECTOR3_ARRAY);
 
-	PackedVector3Array new_vertices = p_data;
-	const int64_t vertex_count = new_vertices.size();
+	set_data((PackedVector3Array)p_data);
+}
+
+void JoltConvexPolygonShape3D::set_data(PackedVector3Array p_vertices) {
+	clear();
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid.
-	if (vertex_count < 3) {
+	if (p_vertices.size() < 3) {
 		return;
 	}
 
-	vertices = std::move(new_vertices);
+	vertices = std::move(p_vertices);
 }
 
 void JoltConvexPolygonShape3D::clear() {
@@ -555,10 +580,13 @@ void JoltConcavePolygonShape3D::set_data(const Variant& p_data) {
 	const Variant maybe_backface_collision = data.get("backface_collision", {});
 	ERR_FAIL_COND(maybe_backface_collision.get_type() != Variant::BOOL);
 
-	PackedVector3Array new_faces = maybe_faces;
-	const bool new_backface_collision = maybe_backface_collision;
+	set_data((PackedVector3Array)maybe_faces, (bool)maybe_backface_collision);
+}
 
-	const auto vertex_count = (size_t)new_faces.size();
+void JoltConcavePolygonShape3D::set_data(PackedVector3Array p_faces, bool p_backface_collision) {
+	clear();
+
+	const auto vertex_count = (size_t)p_faces.size();
 
 	// Godot seems to be forgiving about zero-sized shapes, so we try to mimick that by silently
 	// letting these remain invalid.
@@ -580,8 +608,8 @@ void JoltConcavePolygonShape3D::set_data(const Variant& p_data) {
 		return;
 	}
 
-	faces = std::move(new_faces);
-	backface_collision = new_backface_collision;
+	faces = std::move(p_faces);
+	backface_collision = p_backface_collision;
 }
 
 void JoltConcavePolygonShape3D::clear() {
@@ -660,11 +688,17 @@ void JoltHeightMapShape3D::set_data(const Variant& p_data) {
 	const Variant maybe_depth = data.get("depth", {});
 	ERR_FAIL_COND(maybe_depth.get_type() != Variant::INT);
 
-	const PackedFloat32Array new_heights = maybe_heights;
-	const int32_t new_width = maybe_width;
-	const int32_t new_depth = maybe_depth;
+	set_data((PackedFloat32Array)maybe_heights, (int32_t)maybe_width, (int32_t)maybe_depth);
+}
 
-	const auto height_count = (int32_t)new_heights.size();
+void JoltHeightMapShape3D::set_data(
+	PackedFloat32Array p_heights,
+	int32_t p_width,
+	int32_t p_depth
+) {
+	clear();
+
+	const auto height_count = (int32_t)p_heights.size();
 
 	if (height_count == 0) {
 		return;
@@ -674,34 +708,34 @@ void JoltHeightMapShape3D::set_data(const Variant& p_data) {
 	// its default state. Since Jolt doesn't support non-square height maps, and it's unlikely that
 	// anyone would actually want a height map of such small dimensions, we silently let this remain
 	// invalid in order to not display an error every single time we create a shape of this type.
-	if (new_width <= 2 || new_depth <= 2) {
+	if (p_width <= 2 || p_depth <= 2) {
 		return;
 	}
 
 	ERR_FAIL_COND_MSG(
-		height_count != new_width * new_depth,
+		height_count != p_width * p_depth,
 		vformat(
 			"Failed to set shape data for height map shape with width '%d', depth '%d' and height "
 			"count '%d'. Height count must be equal to width multiplied by depth.",
-			new_width,
-			new_depth,
+			p_width,
+			p_depth,
 			height_count
 		)
 	);
 
 	ERR_FAIL_COND_MSG(
-		new_width != new_depth,
+		p_width != p_depth,
 		vformat(
 			"Failed to set shape data for height map shape with width '%d', depth '%d' and height "
 			"count '%d'. Height maps with differing width and depth are not supported by Godot "
 			"Jolt.",
-			new_width,
-			new_depth,
+			p_width,
+			p_depth,
 			height_count
 		)
 	);
 
-	const auto sample_count = (JPH::uint32)new_width;
+	const auto sample_count = (JPH::uint32)p_width;
 
 	ERR_FAIL_COND_MSG(
 		!is_power_of_2(sample_count),
@@ -709,15 +743,15 @@ void JoltHeightMapShape3D::set_data(const Variant& p_data) {
 			"Failed to set shape data for height map shape with width '%d', depth '%d' and height "
 			"count '%d'. Height maps with a width/depth that is not a power of two are not "
 			"supported by Godot Jolt.",
-			new_width,
-			new_depth,
+			p_width,
+			p_depth,
 			height_count
 		)
 	);
 
-	heights = new_heights;
-	width = new_width;
-	depth = new_depth;
+	heights = std::move(p_heights);
+	width = p_width;
+	depth = p_depth;
 }
 
 void JoltHeightMapShape3D::clear() {

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -24,6 +24,10 @@ public:
 
 	virtual void set_data(const Variant& p_data) = 0;
 
+	virtual float get_margin() const = 0;
+
+	virtual void set_margin(float p_margin) = 0;
+
 	virtual bool is_valid() const = 0;
 
 	JPH::ShapeRefC try_build();
@@ -77,6 +81,10 @@ public:
 
 	void set_data(Plane p_plane);
 
+	float get_margin() const override { return 0.0f; }
+
+	void set_margin([[maybe_unused]] float p_margin) override { }
+
 	bool is_valid() const override { return plane != Plane(); }
 
 private:
@@ -96,6 +104,10 @@ public:
 	void set_data(const Variant& p_data) override;
 
 	void set_data(float p_length, bool p_slide_on_slope);
+
+	float get_margin() const override { return 0.0f; }
+
+	void set_margin([[maybe_unused]] float p_margin) override { }
 
 	bool is_valid() const override { return length > 0.0f; }
 
@@ -118,6 +130,10 @@ class JoltSphereShape3D final : public JoltShape3D {
 
 	void set_data(float p_radius);
 
+	float get_margin() const override { return 0.0f; }
+
+	void set_margin([[maybe_unused]] float p_margin) override { }
+
 	bool is_valid() const override { return radius > 0; }
 
 private:
@@ -138,6 +154,10 @@ public:
 
 	void set_data(Vector3 p_half_extents);
 
+	float get_margin() const override { return margin; }
+
+	void set_margin(float p_margin) override;
+
 	bool is_valid() const override { return half_extents.x > 0; }
 
 private:
@@ -146,6 +166,8 @@ private:
 	JPH::ShapeRefC build() const override;
 
 	Vector3 half_extents;
+
+	float margin = 0.04f;
 };
 
 class JoltCapsuleShape3D final : public JoltShape3D {
@@ -157,6 +179,10 @@ public:
 	void set_data(const Variant& p_data) override;
 
 	void set_data(float p_height, float p_radius);
+
+	float get_margin() const override { return 0.0f; }
+
+	void set_margin([[maybe_unused]] float p_margin) override { }
 
 	bool is_valid() const override { return radius > 0; }
 
@@ -180,6 +206,10 @@ public:
 
 	void set_data(float p_height, float p_radius);
 
+	float get_margin() const override { return margin; }
+
+	void set_margin(float p_margin) override;
+
 	bool is_valid() const override { return radius > 0; }
 
 private:
@@ -190,6 +220,8 @@ private:
 	float height = 0.0f;
 
 	float radius = 0.0f;
+
+	float margin = 0.04f;
 };
 
 class JoltConvexPolygonShape3D final : public JoltShape3D {
@@ -202,6 +234,10 @@ public:
 
 	void set_data(PackedVector3Array p_vertices);
 
+	float get_margin() const override { return margin; }
+
+	void set_margin(float p_margin) override;
+
 	bool is_valid() const override { return !vertices.is_empty(); }
 
 private:
@@ -210,6 +246,8 @@ private:
 	JPH::ShapeRefC build() const override;
 
 	PackedVector3Array vertices;
+
+	float margin = 0.04f;
 };
 
 class JoltConcavePolygonShape3D final : public JoltShape3D {
@@ -221,6 +259,10 @@ public:
 	void set_data(const Variant& p_data) override;
 
 	void set_data(PackedVector3Array p_faces, bool p_backface_collision);
+
+	float get_margin() const override { return 0.0f; }
+
+	void set_margin([[maybe_unused]] float p_margin) override { }
 
 	bool is_valid() const override { return !faces.is_empty(); }
 
@@ -243,6 +285,10 @@ public:
 	void set_data(const Variant& p_data) override;
 
 	void set_data(PackedFloat32Array p_heights, int32_t p_width, int32_t p_depth);
+
+	float get_margin() const override { return 0.0f; }
+
+	void set_margin([[maybe_unused]] float p_margin) override { }
 
 	bool is_valid() const override { return width > 0; }
 

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -30,7 +30,7 @@ public:
 
 	virtual bool is_valid() const = 0;
 
-	JPH::ShapeRefC try_build();
+	JPH::ShapeRefC try_build(float p_extra_margin = 0.0f);
 
 	const JPH::Shape* get_jolt_ref() const { return jolt_ref; }
 
@@ -62,7 +62,7 @@ public:
 	static JPH::ShapeRefC as_compound(TCallable&& p_callable);
 
 protected:
-	virtual JPH::ShapeRefC build() const = 0;
+	virtual JPH::ShapeRefC build(float p_extra_margin) const = 0;
 
 	RID rid;
 
@@ -90,7 +90,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	Plane plane;
 };
@@ -114,7 +114,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	float length = 0.0f;
 
@@ -139,7 +139,7 @@ class JoltSphereShape3D final : public JoltShape3D {
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	float radius = 0.0f;
 };
@@ -163,7 +163,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	Vector3 half_extents;
 
@@ -189,7 +189,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	float height = 0.0f;
 
@@ -215,7 +215,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	float height = 0.0f;
 
@@ -243,7 +243,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	PackedVector3Array vertices;
 
@@ -269,7 +269,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	PackedVector3Array faces;
 
@@ -295,7 +295,7 @@ public:
 private:
 	void clear();
 
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC build(float p_extra_margin) const override;
 
 	PackedFloat32Array heights;
 

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -75,6 +75,8 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	void set_data(Plane p_plane);
+
 	bool is_valid() const override { return plane != Plane(); }
 
 private:
@@ -92,6 +94,8 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	void set_data(float p_length, bool p_slide_on_slope);
 
 	bool is_valid() const override { return length > 0.0f; }
 
@@ -112,6 +116,8 @@ class JoltSphereShape3D final : public JoltShape3D {
 
 	void set_data(const Variant& p_data) override;
 
+	void set_data(float p_radius);
+
 	bool is_valid() const override { return radius > 0; }
 
 private:
@@ -130,6 +136,8 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	void set_data(Vector3 p_half_extents);
+
 	bool is_valid() const override { return half_extents.x > 0; }
 
 private:
@@ -147,6 +155,8 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	void set_data(float p_height, float p_radius);
 
 	bool is_valid() const override { return radius > 0; }
 
@@ -168,6 +178,8 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	void set_data(float p_height, float p_radius);
+
 	bool is_valid() const override { return radius > 0; }
 
 private:
@@ -188,6 +200,8 @@ public:
 
 	void set_data(const Variant& p_data) override;
 
+	void set_data(PackedVector3Array p_vertices);
+
 	bool is_valid() const override { return !vertices.is_empty(); }
 
 private:
@@ -205,6 +219,8 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	void set_data(PackedVector3Array p_faces, bool p_backface_collision);
 
 	bool is_valid() const override { return !faces.is_empty(); }
 
@@ -225,6 +241,8 @@ public:
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
+
+	void set_data(PackedFloat32Array p_heights, int32_t p_width, int32_t p_depth);
 
 	bool is_valid() const override { return width > 0; }
 


### PR DESCRIPTION
This PR adds support for the "Margin" property on `BoxShape3D`, `CylinderShape3D` and `ConvexPolygonShape3D`. Any other shapes are either not convex or not applicable, in which case the margin will be a no-op.

This PR also fixes the `margin` parameter on physics queries involving shapes, like `cast_motion`. This previously relied on Jolt's GJK collision tolerance to achieve this, which was probably not a good use of that parameter, and also wouldn't have worked for anything but convex-versus-convex collisions.