### PR TITLE
Fixed issue where motion recovery inhibited rest info

### DIFF
--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -613,12 +613,23 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 
 		const float depth = hit.mPenetrationDepth + p_margin;
 
-		if (depth <= 0.0f) {
+		// HACK(mihe): An arbitrary number that's meant to prevent issues where recovery ends up
+		// being too great and thereby preventing `body_motion_collide` from actually hitting
+		// anything. Stems from godotengine/godot#52953.
+		const float magic_depth = p_margin * 0.05f;
+
+		if (depth <= magic_depth) {
 			break;
 		}
 
 		const Vector3 contact_normal = to_godot(-hit.mPenetrationAxis.Normalized());
-		const Vector3 recover_motion = contact_normal * depth;
+
+		// HACK(mihe): Another arbitrary number that's meant to prevent issues where recovery ends
+		// up being too great and thereby preventing `body_motion_collide` from actually hitting
+		// anything. Stems from godotengine/godot#46148.
+		const float magic_fraction = 0.4f;
+
+		const Vector3 recover_motion = contact_normal * (depth - magic_depth) * magic_fraction;
 
 		p_recover_motion += recover_motion;
 		p_transform_com.origin += recover_motion;


### PR DESCRIPTION
It seems that currently, in certain random cases, a `CharacterBody3D` can end up standing on solid ground while still having `move_and_slide` report no collision, because `body_motion_recovery` ends up pushing the body above the ground which leads to `body_motion_collision` hitting nothing.

Godot seemed to have solved this problem by using a couple of magic numbers that essentially just restrict how much recovery motion you're allowed to do. I had deliberately ignored these when implementing `body_test_motion` because I didn't understand their purpose, but it seems they were indeed necessary.

There might be some better way of solving this, but I figured it'd be best to try and align with Godot Physics as much as possible, given how fragile everything related to `body_test_motion` is.