### PR TITLE
Refactored shape-casting to use binary search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ if(MSVC)
 		PRIVATE /w44245 # Enable implicit conversion warning
 		PRIVATE /w44365 # Enable another implicit conversion warning
 		PRIVATE /w44800 # Enable another implicit conversion warning
+		PRIVATE /wd4324 # Disable structure padding warning
 		PRIVATE /EHsc # Enable exception handling
 		PRIVATE /GF # Enable string pooling
 		PRIVATE /Gy # Enable function-level linking

--- a/src/jolt_motion_filter_3d.cpp
+++ b/src/jolt_motion_filter_3d.cpp
@@ -3,6 +3,7 @@
 #include "jolt_body_3d.hpp"
 #include "jolt_broad_phase_layer.hpp"
 #include "jolt_collision_object_3d.hpp"
+#include "jolt_motion_shape.hpp"
 #include "jolt_physics_server_3d.hpp"
 #include "jolt_shape_3d.hpp"
 #include "jolt_space_3d.hpp"
@@ -69,5 +70,12 @@ bool JoltMotionFilter3D::ShouldCollide(
 	[[maybe_unused]] const JPH::Shape* p_shape2,
 	[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2
 ) const {
-	return collide_separation_ray || p_shape1->GetSubType() != JPH::EShapeSubType::UserConvex1;
+	if (collide_separation_ray) {
+		return true;
+	}
+
+	const auto* motion_shape1 = static_cast<const JoltMotionShape*>(p_shape1);
+	const JPH::ConvexShape& actual_shape1 = motion_shape1->get_inner_shape();
+
+	return actual_shape1.GetSubType() != JPH::EShapeSubType::UserConvex1;
 }

--- a/src/jolt_motion_shape.cpp
+++ b/src/jolt_motion_shape.cpp
@@ -1,0 +1,51 @@
+#include "jolt_motion_shape.hpp"
+
+namespace {
+
+class JoltMotionConvexSupport final : public JPH::ConvexShape::Support {
+public:
+	JoltMotionConvexSupport(JPH::Vec3Arg p_motion, const JPH::ConvexShape::Support* p_inner_support)
+		: motion(p_motion)
+		, inner_support(p_inner_support) { }
+
+	JPH::Vec3 GetSupport(JPH::Vec3Arg p_direction) const override {
+		JPH::Vec3 support = inner_support->GetSupport(p_direction);
+
+		if (p_direction.Dot(motion) > 0) {
+			support += motion;
+		}
+
+		return support;
+	}
+
+	float GetConvexRadius() const override { return inner_support->GetConvexRadius(); }
+
+private:
+	JPH::Vec3 motion = JPH::Vec3::sZero();
+
+	const JPH::ConvexShape::Support* inner_support = nullptr;
+};
+
+} // namespace
+
+JPH::AABox JoltMotionShape::GetLocalBounds() const {
+	JPH::AABox aabb = inner_shape.GetLocalBounds();
+
+	JPH::AABox aabb_translated = aabb;
+	aabb_translated.Translate(motion);
+
+	aabb.Encapsulate(aabb_translated);
+
+	return aabb;
+}
+
+const JPH::ConvexShape::Support* JoltMotionShape::GetSupportFunction(
+	JPH::ConvexShape::ESupportMode p_mode,
+	JPH::ConvexShape::SupportBuffer& p_buffer,
+	JPH::Vec3Arg p_scale
+) const {
+	return new (&p_buffer) JoltMotionConvexSupport(
+		motion,
+		inner_shape.GetSupportFunction(p_mode, inner_support_buffer, p_scale)
+	);
+}

--- a/src/jolt_motion_shape.hpp
+++ b/src/jolt_motion_shape.hpp
@@ -1,0 +1,204 @@
+#pragma once
+
+class JoltMotionShape final : public JPH::ConvexShape {
+public:
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+	explicit JoltMotionShape(const JPH::ConvexShape& p_shape)
+		: JPH::ConvexShape(JPH::EShapeSubType::UserConvex2)
+		, inner_shape(p_shape) { }
+
+	bool MustBeStatic() const override { return false; }
+
+	JPH::Vec3 GetCenterOfMass() const override { ERR_FAIL_D_NOT_IMPL(); }
+
+	JPH::AABox GetLocalBounds() const override;
+
+	JPH::uint GetSubShapeIDBitsRecursive() const override { ERR_FAIL_D_NOT_IMPL(); }
+
+	JPH::AABox GetWorldSpaceBounds(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	float GetInnerRadius() const override { ERR_FAIL_D_NOT_IMPL(); }
+
+	JPH::MassProperties GetMassProperties() const override { ERR_FAIL_D_NOT_IMPL(); }
+
+	const JPH::PhysicsMaterial* GetMaterial([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	JPH::Vec3 GetSurfaceNormal(
+		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,
+		[[maybe_unused]] JPH::Vec3Arg p_local_surface_position
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	void GetSupportingFace(
+		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,
+		[[maybe_unused]] JPH::Vec3Arg p_direction,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Shape::SupportingFace& p_vertices
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	JPH::uint64 GetSubShapeUserData([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	JPH::TransformedShape GetSubShapeTransformedShape(
+		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,
+		[[maybe_unused]] JPH::Vec3Arg p_position_com,
+		[[maybe_unused]] JPH::QuatArg p_rotation,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::SubShapeID& p_remainder
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	// clang-format off
+
+	void GetSubmergedVolume(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] const JPH::Plane& p_surface,
+		[[maybe_unused]] float& p_total_volume,
+		[[maybe_unused]] float& p_submerged_volume,
+		[[maybe_unused]] JPH::Vec3& p_center_of_buoyancy
+#ifdef JPH_DEBUG_RENDERER
+		, [[maybe_unused]] JPH::RVec3Arg p_base_offset
+#endif // JPH_DEBUG_RENDERER
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	// clang-format on
+
+	const JPH::ConvexShape::Support* GetSupportFunction(
+		JPH::ConvexShape::ESupportMode p_mode,
+		JPH::ConvexShape::SupportBuffer& p_buffer,
+		JPH::Vec3Arg p_scale
+	) const override;
+
+#ifdef JPH_DEBUG_RENDERER
+	void Draw(
+		[[maybe_unused]] JPH::DebugRenderer* p_renderer,
+		[[maybe_unused]] JPH::RMat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::ColorArg p_color,
+		[[maybe_unused]] bool p_use_material_colors,
+		[[maybe_unused]] bool p_draw_wireframe
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	void DrawGetSupportFunction(
+		[[maybe_unused]] JPH::DebugRenderer* p_renderer,
+		[[maybe_unused]] JPH::RMat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::ColorArg p_color,
+		[[maybe_unused]] bool p_draw_support_direction
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	void DrawGetSupportingFace(
+		[[maybe_unused]] JPH::DebugRenderer* p_renderer,
+		[[maybe_unused]] JPH::RMat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+#endif // JPH_DEBUG_RENDERER
+
+	bool CastRay(
+		[[maybe_unused]] const JPH::RayCast& p_ray,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::RayCastResult& p_hit
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	void CastRay(
+		[[maybe_unused]] const JPH::RayCast& p_ray,
+		[[maybe_unused]] const JPH::RayCastSettings& p_ray_cast_settings,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::CastRayCollector& p_collector,
+		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	void CollidePoint(
+		[[maybe_unused]] JPH::Vec3Arg p_point,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::CollidePointCollector& p_collector,
+		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	void CollectTransformedShapes(
+		[[maybe_unused]] const JPH::AABox& p_box,
+		[[maybe_unused]] JPH::Vec3Arg p_position_com,
+		[[maybe_unused]] JPH::QuatArg p_rotation,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		[[maybe_unused]] JPH::TransformedShapeCollector& p_collector,
+		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	void TransformShape(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::TransformedShapeCollector& p_collector
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	void GetTrianglesStart(
+		[[maybe_unused]] GetTrianglesContext& p_context,
+		[[maybe_unused]] const JPH::AABox& p_box,
+		[[maybe_unused]] JPH::Vec3Arg p_position_com,
+		[[maybe_unused]] JPH::QuatArg p_rotation,
+		[[maybe_unused]] JPH::Vec3Arg p_scale
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
+	int GetTrianglesNext(
+		[[maybe_unused]] GetTrianglesContext& p_context,
+		[[maybe_unused]] int p_max_triangles_requested,
+		[[maybe_unused]] JPH::Float3* p_triangle_vertices,
+		[[maybe_unused]] const JPH::PhysicsMaterial** p_materials = nullptr
+	) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	JPH::Shape::Stats GetStats() const override { return {sizeof(*this), 0}; }
+
+	float GetVolume() const override { ERR_FAIL_D_NOT_IMPL(); }
+
+	bool IsValidScale([[maybe_unused]] JPH::Vec3Arg p_scale) const override {
+		ERR_FAIL_D_NOT_IMPL();
+	}
+
+	const JPH::ConvexShape& get_inner_shape() const { return inner_shape; }
+
+	void set_motion(JPH::Vec3Arg p_motion) { motion = p_motion; }
+
+private:
+	mutable JPH::ConvexShape::SupportBuffer inner_support_buffer;
+
+	JPH::Vec3 motion = JPH::Vec3::sZero();
+
+	const JPH::ConvexShape& inner_shape;
+};

--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -4,6 +4,7 @@
 #include "jolt_body_3d.hpp"
 #include "jolt_collision_object_3d.hpp"
 #include "jolt_motion_filter_3d.hpp"
+#include "jolt_motion_shape.hpp"
 #include "jolt_physics_server_3d.hpp"
 #include "jolt_query_collectors.hpp"
 #include "jolt_query_filter_3d.hpp"
@@ -195,76 +196,33 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	float* p_closest_unsafe,
 	PhysicsServer3DExtensionShapeRestInfo* p_info
 ) {
+	// HACK(mihe): This rest info parameter doesn't seem to be used anywhere within Godot, and isn't
+	// exposed in the bindings, so this will be unsupported until anyone actually needs it
+	ERR_FAIL_COND_D_MSG(
+		p_info != nullptr,
+		"Providing rest info as part of a shape-cast is not supported by Godot Jolt."
+	);
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
-	const JPH::ShapeRefC jolt_shape = shape->try_build((float)p_margin);
-	ERR_FAIL_NULL_D(jolt_shape);
-
-	const Vector3 center_of_mass = to_godot(jolt_shape->GetCenterOfMass());
-	Transform3D transform_com = p_transform.translated_local(center_of_mass);
-	Vector3 scale(1.0f, 1.0f, 1.0f);
-	try_strip_scale(transform_com, scale);
-
-	JPH::ShapeCastSettings settings;
-	settings.mBackFaceModeConvex = JPH::EBackFaceMode::CollideWithBackFaces;
-	settings.mUseShrunkenShapeAndConvexRadius = true;
-
-	const Vector3& base_offset = transform_com.origin;
-
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	JoltQueryCollectorClosest<JPH::CastShapeCollector> collector;
-
-	space->get_narrow_phase_query().CastShape(
-		JPH::RShapeCast(jolt_shape, to_jolt(scale), to_jolt(transform_com), to_jolt(p_motion)),
-		settings,
-		to_jolt(base_offset),
-		collector,
+	return cast_motion(
+		*shape,
+		p_margin,
+		p_transform,
+		p_motion,
 		query_filter,
 		query_filter,
-		query_filter
+		query_filter,
+		JPH::ShapeFilter(),
+		*p_closest_safe,
+		*p_closest_unsafe
 	);
-
-	if (!collector.had_hit()) {
-		return false;
-	}
-
-	const JPH::ShapeCastResult& hit = collector.get_hit();
-
-	if (p_info != nullptr) {
-		const JoltReadableBody3D body = space->read_body(hit.mBodyID2);
-		const JoltCollisionObject3D* object = body.as_object();
-		ERR_FAIL_NULL_D(object);
-
-		const int32_t shape_index = object->find_shape_index(hit.mSubShapeID2);
-		ERR_FAIL_COND_D(shape_index == -1);
-
-		const Vector3 hit_point = base_offset + to_godot(hit.mContactPointOn2);
-
-		p_info->point = hit_point;
-		p_info->normal = to_godot(-hit.mPenetrationAxis.Normalized());
-		p_info->rid = object->get_rid();
-		p_info->collider_id = object->get_instance_id();
-		p_info->shape = shape_index;
-		p_info->linear_velocity = object->get_velocity_at_position(hit_point, false);
-	}
-
-	const float small_number = 0.000001f;
-	const float motion_length = p_motion.length();
-	const float nudge_epsilon = max(small_number * motion_length, small_number);
-	const float nudge_safe = settings.mCollisionTolerance + nudge_epsilon;
-	const float nudge_unsafe = nudge_safe + shape->get_margin();
-	const float nudge_fraction_safe = max(nudge_safe / motion_length, FLT_EPSILON);
-	const float nudge_fraction_unsafe = max(nudge_unsafe / motion_length, FLT_EPSILON);
-
-	*p_closest_safe = max(hit.mFraction - nudge_fraction_safe, 0.0f);
-	*p_closest_unsafe = min(hit.mFraction + nudge_fraction_unsafe, 1.0f);
-
-	return true;
 }
 
 bool JoltPhysicsDirectSpaceState3D::_collide_shape(
@@ -502,32 +460,23 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	bool p_collide_separation_ray,
 	PhysicsServer3DExtensionMotionResult* p_result
 ) const {
-	const JPH::Shape* jolt_shape = p_body.get_jolt_shape();
-
-	const Vector3 center_of_mass = to_godot(jolt_shape->GetCenterOfMass());
-	Transform3D transform_com = p_transform.translated_local(center_of_mass);
+	Transform3D transform = p_transform;
 	Vector3 scale(1.0f, 1.0f, 1.0f);
-	try_strip_scale(transform_com, scale);
+	try_strip_scale(transform, scale);
 
 	const Vector3 motion_direction = p_motion.normalized();
 
 	Vector3 recover_motion;
 
-	const bool recovered = body_motion_recover(
-		p_body,
-		transform_com,
-		scale,
-		motion_direction,
-		p_margin,
-		recover_motion
-	);
+	const bool recovered =
+		body_motion_recover(p_body, transform, scale, motion_direction, p_margin, recover_motion);
 
 	float safe_fraction = 1.0f;
 	float unsafe_fraction = 1.0f;
 
 	const bool hit = body_motion_cast(
 		p_body,
-		transform_com,
+		transform,
 		scale,
 		p_motion,
 		p_collide_separation_ray,
@@ -540,7 +489,7 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	if (hit || (recovered /* && p_recovery_as_collision */)) {
 		collided = body_motion_collide(
 			p_body,
-			transform_com.translated(p_motion * unsafe_fraction),
+			transform.translated(p_motion * unsafe_fraction),
 			scale,
 			motion_direction,
 			p_margin,
@@ -570,15 +519,189 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	return collided;
 }
 
+bool JoltPhysicsDirectSpaceState3D::cast_motion(
+	JoltShape3D& p_shape,
+	double p_margin,
+	const Transform3D& p_transform,
+	const Vector3& p_motion,
+	const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter,
+	const JPH::ObjectLayerFilter& p_object_layer_filter,
+	const JPH::BodyFilter& p_body_filter,
+	const JPH::ShapeFilter& p_shape_filter,
+	float& p_closest_safe,
+	float& p_closest_unsafe
+) const {
+	const JPH::ShapeRefC jolt_shape = p_shape.try_build((float)p_margin);
+	ERR_FAIL_NULL_D(jolt_shape);
+
+	const Vector3 center_of_mass = to_godot(jolt_shape->GetCenterOfMass());
+	Transform3D transform_com = p_transform.translated_local(center_of_mass);
+	Vector3 scale(1.0f, 1.0f, 1.0f);
+	try_strip_scale(transform_com, scale);
+
+	return cast_motion(
+		*jolt_shape,
+		transform_com,
+		scale,
+		p_motion,
+		p_broad_phase_layer_filter,
+		p_object_layer_filter,
+		p_body_filter,
+		p_shape_filter,
+		p_closest_safe,
+		p_closest_unsafe
+	);
+}
+
+bool JoltPhysicsDirectSpaceState3D::cast_motion(
+	const JPH::Shape& p_jolt_shape,
+	const Transform3D& p_transform_com,
+	const Vector3& p_scale,
+	const Vector3& p_motion,
+	const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter,
+	const JPH::ObjectLayerFilter& p_object_layer_filter,
+	const JPH::BodyFilter& p_body_filter,
+	const JPH::ShapeFilter& p_shape_filter,
+	float& p_closest_safe,
+	float& p_closest_unsafe
+) const {
+	ERR_FAIL_COND_D_MSG(
+		p_jolt_shape.GetType() != JPH::EShapeType::Convex,
+		"Shape-casting with non-convex shapes is not supported by Godot Jolt."
+	);
+
+	p_closest_safe = 1.0f;
+	p_closest_unsafe = 1.0f;
+
+	const float motion_length = p_motion.length();
+
+	if (motion_length == 0.0f) {
+		return false;
+	}
+
+	const JPH::Mat44 transform_com = to_jolt(p_transform_com);
+	const JPH::Vec3 scale = to_jolt(p_scale);
+	const JPH::Vec3 motion = to_jolt(p_motion);
+	const JPH::Vec3 motion_local = transform_com.Multiply3x3Transposed(motion);
+
+	JPH::AABox aabb = p_jolt_shape.GetWorldSpaceBounds(transform_com, scale);
+	JPH::AABox aabb_translated = aabb;
+	aabb_translated.Translate(motion);
+	aabb.Encapsulate(aabb_translated);
+
+	JoltQueryCollectorAnyMulti<JPH::CollideShapeBodyCollector, 2048> aabb_collector;
+
+	space->get_broad_phase_query()
+		.CollideAABox(aabb, aabb_collector, p_broad_phase_layer_filter, p_object_layer_filter);
+
+	if (!aabb_collector.had_hit()) {
+		return false;
+	}
+
+	JoltMotionShape motion_shape(static_cast<const JPH::ConvexShape&>(p_jolt_shape));
+
+	JoltQueryCollectorAny<JPH::CollideShapeCollector> collide_collector;
+
+	auto collides = [&](const JPH::Body& p_other_body, float p_fraction) {
+		motion_shape.set_motion(motion_local * p_fraction);
+
+		const JPH::TransformedShape other_shape = p_other_body.GetTransformedShape();
+
+		collide_collector.reset();
+
+		JPH::CollisionDispatch::sCollideShapeVsShape(
+			&motion_shape,
+			other_shape.mShape,
+			scale,
+			other_shape.GetShapeScale(),
+			transform_com,
+			other_shape.GetCenterOfMassTransform(),
+			JPH::SubShapeIDCreator(),
+			JPH::SubShapeIDCreator(),
+			JPH::CollideShapeSettings(),
+			collide_collector,
+			p_shape_filter
+		);
+
+		return collide_collector.had_hit();
+	};
+
+	// Figure out the number of steps we need in our binary search in order to achieve millimeter
+	// precision, within reason. Derived from `2^-step_count * motion_length = 0.001`.
+	const int32_t step_count = clamp(int32_t(logf(1000.0f * motion_length) / Math_LN2), 4, 16);
+
+	bool collided = false;
+
+	for (int32_t i = 0; i < aabb_collector.get_hit_count(); ++i) {
+		const JPH::BodyID other_jolt_id = aabb_collector.get_hit(i);
+
+		if (!p_body_filter.ShouldCollide(other_jolt_id)) {
+			continue;
+		}
+
+		const JoltReadableBody3D other_jolt_body = space->read_body(other_jolt_id);
+
+		if (!p_body_filter.ShouldCollideLocked(*other_jolt_body)) {
+			continue;
+		}
+
+		if (!collides(*other_jolt_body, 1.0f)) {
+			continue;
+		}
+
+		if (collides(*other_jolt_body, 0.0f)) {
+			continue;
+		}
+
+		float lo = 0.0f;
+		float hi = 1.0f;
+		float coeff = 0.5f;
+
+		for (int j = 0; j < step_count; ++j) {
+			const float fraction = lo + (hi - lo) * coeff;
+
+			if (collides(*other_jolt_body, fraction)) {
+				collided = true;
+
+				hi = fraction;
+
+				if (j == 0 || lo > 0.0f) {
+					coeff = 0.5f;
+				} else {
+					coeff = 0.25f;
+				}
+			} else {
+				lo = fraction;
+
+				if (j == 0 || hi < 1.0f) {
+					coeff = 0.5f;
+				} else {
+					coeff = 0.75f;
+				}
+			}
+		}
+
+		if (lo < p_closest_safe) {
+			p_closest_safe = lo;
+			p_closest_unsafe = hi;
+		}
+	}
+
+	return collided;
+}
+
 bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 	const JoltBody3D& p_body,
-	Transform3D& p_transform_com,
+	Transform3D& p_transform,
 	const Vector3& p_scale,
 	const Vector3& p_direction,
 	float p_margin,
 	Vector3& p_recover_motion
 ) const {
 	const JPH::Shape* jolt_shape = p_body.get_jolt_shape();
+
+	const Vector3 center_of_mass = to_godot(jolt_shape->GetCenterOfMass());
+	const Transform3D transform_com = p_transform.translated_local(center_of_mass);
 
 	JPH::CollideShapeSettings settings;
 	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
@@ -595,9 +718,9 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 		space->get_narrow_phase_query().CollideShape(
 			jolt_shape,
 			to_jolt(p_scale),
-			to_jolt(p_transform_com),
+			to_jolt(transform_com),
 			settings,
-			to_jolt(p_transform_com.origin),
+			to_jolt(transform_com.origin),
 			collector,
 			motion_filter,
 			motion_filter,
@@ -632,7 +755,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 		const Vector3 recover_motion = contact_normal * (depth - magic_depth) * magic_fraction;
 
 		p_recover_motion += recover_motion;
-		p_transform_com.origin += recover_motion;
+		p_transform.origin += recover_motion;
 
 		recovered = true;
 	}
@@ -642,67 +765,62 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 
 bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
 	const JoltBody3D& p_body,
-	const Transform3D& p_transform_com,
+	const Transform3D& p_transform,
 	const Vector3& p_scale,
 	const Vector3& p_motion,
 	bool p_collide_separation_ray,
 	float& p_safe_fraction,
 	float& p_unsafe_fraction
 ) const {
-	const JPH::Shape* jolt_shape = p_body.get_jolt_shape();
-
-	const float motion_length = p_motion.length();
-	const Vector3 direction = motion_length != 0.0f ? p_motion / motion_length : p_motion;
-
-	JPH::ShapeCastSettings settings;
-	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
-	settings.mActiveEdgeMovementDirection = to_jolt(direction);
-	settings.mBackFaceModeConvex = JPH::EBackFaceMode::CollideWithBackFaces;
-	settings.mUseShrunkenShapeAndConvexRadius = true;
-
 	const JoltMotionFilter3D motion_filter(p_body, p_collide_separation_ray);
 
-	JoltQueryCollectorClosest<JPH::CastShapeCollector> collector;
+	bool collided = false;
 
-	space->get_narrow_phase_query().CastShape(
-		JPH::RShapeCast(jolt_shape, to_jolt(p_scale), to_jolt(p_transform_com), to_jolt(p_motion)),
-		settings,
-		to_jolt(p_transform_com.origin),
-		collector,
-		motion_filter,
-		motion_filter,
-		motion_filter,
-		motion_filter
-	);
+	for (int32_t i = 0; i < p_body.get_shape_count(); ++i) {
+		if (p_body.is_shape_disabled(i)) {
+			continue;
+		}
 
-	if (!collector.had_hit()) {
-		p_safe_fraction = 1.0f;
-		p_unsafe_fraction = 1.0f;
+		JoltShape3D* shape = p_body.get_shape(i);
 
-		return false;
+		if (!shape->is_convex()) {
+			continue;
+		}
+
+		const JPH::ShapeRefC jolt_shape = shape->try_build();
+
+		const Vector3 shape_com = to_godot(jolt_shape->GetCenterOfMass());
+		const Transform3D shape_transform = p_body.get_shape_transform(i);
+		Transform3D shape_transform_com = shape_transform.translated_local(shape_com);
+		Vector3 shape_scale;
+		try_strip_scale(shape_transform_com, shape_scale);
+
+		float shape_safe_fraction = 1.0f;
+		float shape_unsafe_fraction = 1.0f;
+
+		collided |= cast_motion(
+			*jolt_shape,
+			p_transform * shape_transform_com,
+			p_scale * shape_scale,
+			p_motion,
+			motion_filter,
+			motion_filter,
+			motion_filter,
+			motion_filter,
+			shape_safe_fraction,
+			shape_unsafe_fraction
+		);
+
+		p_safe_fraction = min(p_safe_fraction, shape_safe_fraction);
+		p_unsafe_fraction = min(p_unsafe_fraction, shape_unsafe_fraction);
 	}
 
-	const JPH::ShapeCastResult& hit = collector.get_hit();
-
-	const JoltShape3D* shape = p_body.find_shape(hit.mSubShapeID1);
-	ERR_FAIL_NULL_D(shape);
-
-	const float small_number = 0.000001f;
-	const float nudge_epsilon = max(small_number * motion_length, small_number);
-	const float nudge_safe = settings.mCollisionTolerance + nudge_epsilon;
-	const float nudge_unsafe = nudge_safe + shape->get_margin();
-	const float nudge_fraction_safe = max(nudge_safe / motion_length, FLT_EPSILON);
-	const float nudge_fraction_unsafe = max(nudge_unsafe / motion_length, FLT_EPSILON);
-
-	p_safe_fraction = max(hit.mFraction - nudge_fraction_safe, 0.0f);
-	p_unsafe_fraction = min(hit.mFraction + nudge_fraction_unsafe, 1.0f);
-
-	return true;
+	return collided;
 }
 
 bool JoltPhysicsDirectSpaceState3D::body_motion_collide(
 	const JoltBody3D& p_body,
-	const Transform3D& p_transform_com,
+	const Transform3D& p_transform,
 	const Vector3& p_scale,
 	const Vector3& p_direction,
 	float p_margin,
@@ -712,12 +830,15 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_collide(
 ) const {
 	const JPH::Shape* jolt_shape = p_body.get_jolt_shape();
 
+	const Vector3 center_of_mass = to_godot(jolt_shape->GetCenterOfMass());
+	const Transform3D transform_com = p_transform.translated_local(center_of_mass);
+
 	JPH::CollideShapeSettings settings;
 	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
 	settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
 	settings.mMaxSeparationDistance = p_margin;
 
-	const Vector3& base_offset = p_transform_com.origin;
+	const Vector3& base_offset = transform_com.origin;
 
 	const JoltMotionFilter3D motion_filter(p_body);
 
@@ -726,7 +847,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_collide(
 	space->get_narrow_phase_query().CollideShape(
 		jolt_shape,
 		to_jolt(p_scale),
-		to_jolt(p_transform_com),
+		to_jolt(transform_com),
 		settings,
 		to_jolt(base_offset),
 		collector,

--- a/src/jolt_physics_direct_space_state_3d.hpp
+++ b/src/jolt_physics_direct_space_state_3d.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 class JoltBody3D;
+class JoltShape3D;
 class JoltSpace3D;
 
 class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3DExtension {
@@ -100,9 +101,35 @@ public:
 	JoltSpace3D& get_space() const { return *space; }
 
 private:
+	bool cast_motion(
+		JoltShape3D& p_shape,
+		double p_margin,
+		const Transform3D& p_transform,
+		const Vector3& p_motion,
+		const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter,
+		const JPH::ObjectLayerFilter& p_object_layer_filter,
+		const JPH::BodyFilter& p_body_filter,
+		const JPH::ShapeFilter& p_shape_filter,
+		float& p_closest_safe,
+		float& p_closest_unsafe
+	) const;
+
+	bool cast_motion(
+		const JPH::Shape& p_jolt_shape,
+		const Transform3D& p_transform_com,
+		const Vector3& p_scale,
+		const Vector3& p_motion,
+		const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter,
+		const JPH::ObjectLayerFilter& p_object_layer_filter,
+		const JPH::BodyFilter& p_body_filter,
+		const JPH::ShapeFilter& p_shape_filter,
+		float& p_closest_safe,
+		float& p_closest_unsafe
+	) const;
+
 	bool body_motion_recover(
 		const JoltBody3D& p_body,
-		Transform3D& p_transform_com,
+		Transform3D& p_transform,
 		const Vector3& p_scale,
 		const Vector3& p_direction,
 		float p_margin,
@@ -111,7 +138,7 @@ private:
 
 	bool body_motion_cast(
 		const JoltBody3D& p_body,
-		const Transform3D& p_transform_com,
+		const Transform3D& p_transform,
 		const Vector3& p_scale,
 		const Vector3& p_motion,
 		bool p_collide_separation_ray,
@@ -121,7 +148,7 @@ private:
 
 	bool body_motion_collide(
 		const JoltBody3D& p_body,
-		const Transform3D& p_transform_com,
+		const Transform3D& p_transform,
 		const Vector3& p_scale,
 		const Vector3& p_direction,
 		float p_margin,

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -20,6 +20,8 @@ public:
 
 	virtual ShapeType get_type() const = 0;
 
+	virtual bool is_convex() const = 0;
+
 	virtual Variant get_data() const = 0;
 
 	virtual void set_data(const Variant& p_data) = 0;
@@ -75,6 +77,8 @@ class JoltWorldBoundaryShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_WORLD_BOUNDARY; }
 
+	bool is_convex() const override { return false; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -98,6 +102,8 @@ private:
 class JoltSeparationRayShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_SEPARATION_RAY; }
+
+	bool is_convex() const override { return true; }
 
 	Variant get_data() const override;
 
@@ -124,6 +130,8 @@ private:
 class JoltSphereShape3D final : public JoltShape3D {
 	ShapeType get_type() const override { return ShapeType::SHAPE_SPHERE; }
 
+	bool is_convex() const override { return true; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -147,6 +155,8 @@ private:
 class JoltBoxShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_BOX; }
+
+	bool is_convex() const override { return true; }
 
 	Variant get_data() const override;
 
@@ -174,6 +184,8 @@ class JoltCapsuleShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CAPSULE; }
 
+	bool is_convex() const override { return true; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -199,6 +211,8 @@ private:
 class JoltCylinderShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CYLINDER; }
+
+	bool is_convex() const override { return true; }
 
 	Variant get_data() const override;
 
@@ -228,6 +242,8 @@ class JoltConvexPolygonShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CONVEX_POLYGON; }
 
+	bool is_convex() const override { return true; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -254,6 +270,8 @@ class JoltConcavePolygonShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CONCAVE_POLYGON; }
 
+	bool is_convex() const override { return false; }
+
 	Variant get_data() const override;
 
 	void set_data(const Variant& p_data) override;
@@ -279,6 +297,8 @@ private:
 class JoltHeightMapShape3D final : public JoltShape3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_HEIGHTMAP; }
+
+	bool is_convex() const override { return false; }
 
 	Variant get_data() const override;
 

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -220,6 +220,10 @@ const JPH::BodyLockInterface& JoltSpace3D::get_lock_iface(bool p_locked) const {
 	}
 }
 
+const JPH::BroadPhaseQuery& JoltSpace3D::get_broad_phase_query() const {
+	return physics_system->GetBroadPhaseQuery();
+}
+
 const JPH::NarrowPhaseQuery& JoltSpace3D::get_narrow_phase_query(bool p_locked) const {
 	if (p_locked && body_accessor.not_acquired()) {
 		return physics_system->GetNarrowPhaseQuery();

--- a/src/jolt_space_3d.hpp
+++ b/src/jolt_space_3d.hpp
@@ -35,6 +35,8 @@ public:
 
 	const JPH::BodyLockInterface& get_lock_iface(bool p_locked = true) const;
 
+	const JPH::BroadPhaseQuery& get_broad_phase_query() const;
+
 	const JPH::NarrowPhaseQuery& get_narrow_phase_query(bool p_locked = true) const;
 
 	JPH::ObjectLayer map_to_object_layer(

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -52,6 +52,7 @@
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyID.h>
 #include <Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h>
+#include <Jolt/Physics/Collision/BroadPhase/BroadPhaseQuery.h>
 #include <Jolt/Physics/Collision/CastResult.h>
 #include <Jolt/Physics/Collision/CollidePointResult.h>
 #include <Jolt/Physics/Collision/CollideShape.h>


### PR DESCRIPTION
This PR replaces the implementation of `cast_motion` and `body_motion_cast`, which previously relied on Jolt's `CastShape`, with a `CollideShape`-powered binary search.

It ended up being too difficult to iron out all the issues that came with trying to shoehorn Jolt's `CastShape` into the safe/unsafe fraction that Godot's `cast_motion` outputs, so I caved in and implemented the same binary search that Godot Physics uses.

I'll probably expose a more suitable shape-casting method, that uses `CastShape`, later down the road.