### PR TITLE
Updated godot-cpp to 4.0.1-stable

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT a1ae7959da3ce52951b3fed37a018960d03eb785
+	GIT_COMMIT f9f0200fac1c122dc477269e7e9ef981dc620bfc
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@a1ae7959da3ce52951b3fed37a018960d03eb785 aka `4.0-stable` to godot-jolt/godot-cpp@f9f0200fac1c122dc477269e7e9ef981dc620bfc aka `4.0.1-stable` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/a1ae7959da3ce52951b3fed37a018960d03eb785...f9f0200fac1c122dc477269e7e9ef981dc620bfc)).