### PR TITLE
Updated godot-cpp to 576431062f (4.0.1-stable)

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT f9f0200fac1c122dc477269e7e9ef981dc620bfc
+	GIT_COMMIT 576431062f94ba19c43fc6733d03681090a89699
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@f9f0200fac1c122dc477269e7e9ef981dc620bfc aka `4.0.1-stable` to godot-jolt/godot-cpp@576431062f94ba19c43fc6733d03681090a89699 aka `4.0.1-stable` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/f9f0200fac1c122dc477269e7e9ef981dc620bfc...576431062f94ba19c43fc6733d03681090a89699)).

This introduces a (somewhat hacky) fix to a long-standing problem in godot-cpp where you weren't able to use many of the singleton classes because their engine counterpart would outlive the extension library. Once the engine counterpart got destroyed it would try and call the library-provided callback to also destroy the instance bindings, at which point the library would already be unloaded, leading to a use-after-free. See godotengine/godot-cpp#889 for more details.

Thankfully the `free_callback` is being [conditionally invoked](https://github.com/godotengine/godot/blob/cacf49999e3fb37281d66cc591ca8bebc5712d4d/core/object/object.cpp#L1816-L1818), so I changed the `get_singleton` method in the generated singleton classes to pass `nullptr` as its `free_callback` and then instead clean up its instance binding at library unload using a `static` ad-hoc `struct` variable.

I also took the opportunity to optimize the method bodies for the generated classes, which were previously creating `StringName` variables on every single call that were only meant to be passed into a `static` variable once, meaning they were being created for no reason most of the time.