### PR TITLE
Added job system based on `WorkerThreadPool`

### DIFF
--- a/src/containers/free_list.hpp
+++ b/src/containers/free_list.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+template<typename TElement>
+class FreeList {
+	using Implementation = JPH::FixedSizeFreeList<TElement>;
+
+public:
+	explicit FreeList(int32_t p_max_elements) {
+		impl.Init((JPH::uint)p_max_elements, (JPH::uint)p_max_elements);
+	}
+
+	template<typename... TParams>
+	_FORCE_INLINE_ TElement* construct(TParams&&... p_params) {
+		const JPH::uint32 index = impl.ConstructObject(std::forward<TParams>(p_params)...);
+
+		if (index == Implementation::cInvalidObjectIndex) {
+			return nullptr;
+		}
+
+		return &impl.Get(index);
+	}
+
+	_FORCE_INLINE_ void destruct(TElement* p_value) { impl.DestructObject(p_value); }
+
+private:
+	Implementation impl;
+};

--- a/src/jolt_job_system.cpp
+++ b/src/jolt_job_system.cpp
@@ -1,0 +1,134 @@
+#include "jolt_job_system.hpp"
+
+namespace {
+
+constexpr int32_t GDJOLT_MAX_BARRIERS = 8;
+constexpr int32_t GDJOLT_MAX_JOBS = 2048;
+
+} // namespace
+
+JoltJobSystem::JoltJobSystem()
+	: JPH::JobSystemWithBarrier(GDJOLT_MAX_BARRIERS)
+	, jobs(GDJOLT_MAX_JOBS) {
+	singleton = this;
+}
+
+void JoltJobSystem::pre_step() {
+	// Nothing to do
+}
+
+void JoltJobSystem::post_step() {
+	while (Job* job = Job::pop_completed()) {
+		jobs.destruct(job);
+	}
+}
+
+JoltJobSystem::Job::Job(
+	const char* p_name,
+	JPH::ColorArg p_color,
+	JPH::JobSystem* p_job_system,
+	const JPH::JobSystem::JobFunction& p_job_function,
+	JPH::uint32 p_dependency_count
+)
+	: JPH::JobSystem::Job(p_name, p_color, p_job_system, p_job_function, p_dependency_count) { }
+
+JoltJobSystem::Job::~Job() {
+	if (task_id != -1) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(task_id);
+	}
+}
+
+void JoltJobSystem::Job::queue() {
+	AddRef();
+
+	// HACK(mihe): Ideally we would use Jolt's actual job name here, but I'd rather not incur the
+	// overhead of a memory allocation or thread-safe lookup every time we create/queue a task. So
+	// instead we use the same cached description for all of them.
+	static const String description("JoltPhysics3D");
+
+	task_id = WorkerThreadPool::get_singleton()->add_native_task(&execute, this, true, description);
+}
+
+void JoltJobSystem::Job::push_completed() {
+	Job* prev_head = nullptr;
+
+	do {
+		prev_head = completed_head;
+		completed_next = prev_head;
+	} while (!completed_head.compare_exchange_weak(prev_head, this));
+}
+
+JoltJobSystem::Job* JoltJobSystem::Job::pop_completed() {
+	Job* prev_head = nullptr;
+
+	do {
+		prev_head = completed_head;
+
+		if (prev_head == nullptr) {
+			return nullptr;
+		}
+	} while (!completed_head.compare_exchange_weak(prev_head, prev_head->completed_next));
+
+	return prev_head;
+}
+
+void JoltJobSystem::Job::execute(void* p_user_data) {
+	auto* job = static_cast<Job*>(p_user_data);
+
+	job->Execute();
+	job->Release();
+}
+
+int JoltJobSystem::GetMaxConcurrency() const {
+	// HACK(mihe): Ideally we would use `WorkerThreadPool::get_thread_count` here, but that method
+	// is unfortunately not exposed in the bindings.
+	return OS::get_singleton()->get_processor_count();
+}
+
+JPH::JobHandle JoltJobSystem::CreateJob(
+	const char* p_name,
+	JPH::ColorArg p_color,
+	const JPH::JobSystem::JobFunction& p_job_function,
+	JPH::uint32 p_dependency_count
+) {
+	Job* job = nullptr;
+
+	while (true) {
+		job = jobs.construct(p_name, p_color, this, p_job_function, p_dependency_count);
+
+		if (job != nullptr) {
+			break;
+		}
+
+		WARN_PRINT_ONCE(
+			"Job system exceed maximum number of jobs. "
+			"Waiting for jobs to become available. "
+			"Consider increasing maximum number of jobs."
+		);
+
+		OS::get_singleton()->delay_usec(100);
+	}
+
+	// This will increment the job's reference count, so must happen before we queue the job
+	JPH::JobHandle job_handle(job);
+
+	if (p_dependency_count == 0) {
+		QueueJob(job);
+	}
+
+	return job_handle;
+}
+
+void JoltJobSystem::QueueJob(JPH::JobSystem::Job* p_job) {
+	static_cast<Job*>(p_job)->queue();
+}
+
+void JoltJobSystem::QueueJobs(JPH::JobSystem::Job** p_jobs, JPH::uint p_job_count) {
+	for (JPH::uint i = 0; i < p_job_count; ++i) {
+		QueueJob(p_jobs[i]);
+	}
+}
+
+void JoltJobSystem::FreeJob(JPH::JobSystem::Job* p_job) {
+	static_cast<Job*>(p_job)->push_completed();
+}

--- a/src/jolt_job_system.hpp
+++ b/src/jolt_job_system.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+class JoltJobSystem final : public JPH::JobSystemWithBarrier {
+public:
+	JoltJobSystem();
+
+	static JoltJobSystem* get_singleton() { return singleton; }
+
+	void pre_step();
+
+	void post_step();
+
+private:
+	class Job : public JPH::JobSystem::Job {
+	public:
+		Job(const char* p_name,
+			JPH::ColorArg p_color,
+			JPH::JobSystem* p_job_system,
+			const JPH::JobSystem::JobFunction& p_job_function,
+			JPH::uint32 p_dependency_count);
+
+		Job(const Job& p_other) = delete;
+
+		Job(Job&& p_other) = delete;
+
+		~Job();
+
+		void queue();
+
+		void push_completed();
+
+		static Job* pop_completed();
+
+		Job& operator=(const Job& p_other) = delete;
+
+		Job& operator=(Job&& p_other) = delete;
+
+	private:
+		static void execute(void* p_user_data);
+
+		inline static std::atomic<Job*> completed_head = nullptr;
+
+		std::atomic<Job*> completed_next = nullptr;
+
+		int64_t task_id = -1;
+	};
+
+	int GetMaxConcurrency() const override;
+
+	JPH::JobHandle CreateJob(
+		const char* p_name,
+		JPH::ColorArg p_color,
+		const JPH::JobSystem::JobFunction& p_job_function,
+		JPH::uint32 p_dependency_count = 0
+	) override;
+
+	void QueueJob(JPH::JobSystem::Job* p_job) override;
+
+	void QueueJobs(JPH::JobSystem::Job** p_jobs, JPH::uint p_job_count) override;
+
+	void FreeJob(JPH::JobSystem::Job* p_job) override;
+
+	inline static JoltJobSystem* singleton = nullptr;
+
+	FreeList<Job> jobs;
+};

--- a/src/jolt_physics_server_3d.hpp
+++ b/src/jolt_physics_server_3d.hpp
@@ -2,6 +2,7 @@
 
 class JoltArea3D;
 class JoltBody3D;
+class JoltJobSystem;
 class JoltJoint3D;
 class JoltShape3D;
 class JoltSpace3D;
@@ -12,11 +13,6 @@ class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
 protected:
 	// NOLINTNEXTLINE(readability-identifier-naming)
 	static void _bind_methods() { }
-
-private:
-	static void init_statics();
-
-	static void finish_statics();
 
 public:
 	RID _world_boundary_shape_create() override;
@@ -572,13 +568,11 @@ public:
 	JoltJoint3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
 
 private:
-	inline static int32_t server_count;
-
-	inline static JPH::JobSystem* job_system;
-
 	bool active = true;
 
 	bool flushing_queries = false;
+
+	JoltJobSystem* job_system = nullptr;
 
 	HashSet<JoltSpace3D*> active_spaces;
 

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -16,6 +16,7 @@
 #include <godot_cpp/classes/geometry_instance3d.hpp>
 #include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/physics_direct_body_state3d_extension.hpp>
 #include <godot_cpp/classes/physics_direct_space_state3d_extension.hpp>
 #include <godot_cpp/classes/physics_server3d_extension.hpp>
@@ -28,6 +29,7 @@
 #include <godot_cpp/classes/rendering_server.hpp>
 #include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/classes/worker_thread_pool.hpp>
 #include <godot_cpp/classes/world3d.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
@@ -46,7 +48,7 @@
 #include <Jolt/Core/Factory.h>
 #include <Jolt/Core/FixedSizeFreeList.h>
 #include <Jolt/Core/IssueReporting.h>
-#include <Jolt/Core/JobSystemThreadPool.h>
+#include <Jolt/Core/JobSystemWithBarrier.h>
 #include <Jolt/Core/TempAllocator.h>
 #include <Jolt/Geometry/ConvexSupport.h>
 #include <Jolt/Geometry/GJKClosestPoint.h>

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -44,6 +44,7 @@
 #include <Jolt/Jolt.h>
 
 #include <Jolt/Core/Factory.h>
+#include <Jolt/Core/FixedSizeFreeList.h>
 #include <Jolt/Core/IssueReporting.h>
 #include <Jolt/Core/JobSystemThreadPool.h>
 #include <Jolt/Core/TempAllocator.h>
@@ -111,6 +112,7 @@ using namespace godot;
 #pragma warning(pop)
 #endif // _MSC_VER
 
+#include "containers/free_list.hpp"
 #include "containers/hash_map.hpp"
 #include "containers/hash_set.hpp"
 #include "containers/inline_vector.hpp"


### PR DESCRIPTION
This replaces Jolt's reference job system implementation (`JPH::JobSystemThreadPool`) with one powered by Godot's `WorkerThreadPool` instead, which should hopefully interact better with the rest of the engine and lessen any potential contention.