### PR TITLE
Refactored handling of body/shape scale

### DIFF
--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -41,7 +41,7 @@ public:
 
 	Transform3D get_transform(bool p_lock = true) const;
 
-	void set_transform(const Transform3D& p_transform, bool p_lock = true);
+	void set_transform(Transform3D p_transform, bool p_lock = true);
 
 	Basis get_basis(bool p_lock = true) const;
 
@@ -96,7 +96,9 @@ public:
 
 	Transform3D get_shape_transform(int32_t p_index) const;
 
-	void set_shape_transform(int32_t p_index, const Transform3D& p_transform, bool p_lock = true);
+	Vector3 get_shape_scale(int32_t p_index) const;
+
+	void set_shape_transform(int32_t p_index, Transform3D p_transform, bool p_lock = true);
 
 	bool is_shape_disabled(int32_t p_index) const;
 

--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -789,11 +789,10 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
 
 		const JPH::ShapeRefC jolt_shape = shape->try_build();
 
+		const Transform3D& shape_transform = p_body.get_shape_transform(i);
+		const Vector3& shape_scale = p_body.get_shape_scale(i);
 		const Vector3 shape_com = to_godot(jolt_shape->GetCenterOfMass());
-		const Transform3D shape_transform = p_body.get_shape_transform(i);
-		Transform3D shape_transform_com = shape_transform.translated_local(shape_com);
-		Vector3 shape_scale;
-		try_strip_scale(shape_transform_com, shape_scale);
+		const Transform3D shape_transform_com = shape_transform.translated_local(shape_com);
 
 		float shape_safe_fraction = 1.0f;
 		float shape_unsafe_fraction = 1.0f;

--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -98,24 +98,22 @@ JPH::ShapeRefC JoltShape3D::with_basis_origin(
 
 JPH::ShapeRefC JoltShape3D::with_transform(
 	const JPH::Shape* p_shape,
-	const Transform3D& p_transform
+	const Transform3D& p_transform,
+	const Vector3& p_scale
 ) {
 	ERR_FAIL_NULL_D(p_shape);
 
 	JPH::ShapeRefC shape = p_shape;
-	Transform3D transform = p_transform;
 
-	if (transform == Transform3D()) {
-		return shape;
+	if (p_scale != Vector3(1.0f, 1.0f, 1.0f)) {
+		shape = with_scale(shape, p_scale);
 	}
 
-	Vector3 scale(1.0f, 1.0f, 1.0f);
-
-	if (try_strip_scale(transform, scale)) {
-		shape = with_scale(shape, scale);
+	if (p_transform != Transform3D()) {
+		shape = with_basis_origin(shape, p_transform.basis, p_transform.origin);
 	}
 
-	return with_basis_origin(shape, transform.basis, transform.origin);
+	return shape;
 }
 
 JPH::ShapeRefC JoltShape3D::with_center_of_mass_offset(

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -46,7 +46,11 @@ public:
 		const Vector3& p_origin
 	);
 
-	static JPH::ShapeRefC with_transform(const JPH::Shape* p_shape, const Transform3D& p_transform);
+	static JPH::ShapeRefC with_transform(
+		const JPH::Shape* p_shape,
+		const Transform3D& p_transform,
+		const Vector3& p_scale
+	);
 
 	static JPH::ShapeRefC with_center_of_mass_offset(
 		const JPH::Shape* p_shape,

--- a/src/jolt_shape_3d.inl
+++ b/src/jolt_shape_3d.inl
@@ -4,11 +4,11 @@ template<typename TCallable>
 JPH::ShapeRefC JoltShape3D::as_compound(TCallable&& p_callable) {
 	JPH::StaticCompoundShapeSettings shape_settings;
 
-	auto add_shape = [&](JPH::ShapeRefC p_shape, Transform3D p_transform) {
-		Vector3 scale(1.0f, 1.0f, 1.0f);
-
-		if (try_strip_scale(p_transform, scale)) {
-			p_shape = with_scale(p_shape, scale);
+	auto add_shape = [&](JPH::ShapeRefC p_shape,
+						 const Transform3D& p_transform,
+						 const Vector3& p_scale) {
+		if (p_scale != Vector3(1.0f, 1.0f, 1.0f)) {
+			p_shape = with_scale(p_shape, p_scale);
 		}
 
 		shape_settings.AddShape(to_jolt(p_transform.origin), to_jolt(p_transform.basis), p_shape);

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -28,6 +28,10 @@ public:
 
 	void set_transform(const Transform3D& p_transform) { transform = p_transform; }
 
+	const Vector3& get_scale() const { return scale; }
+
+	void set_scale(const Vector3& p_scale) { scale = p_scale; }
+
 	bool is_built() const { return jolt_ref != nullptr; }
 
 	bool is_enabled() const { return !disabled; }
@@ -48,6 +52,8 @@ private:
 	inline static uint32_t next_id = 1;
 
 	Transform3D transform;
+
+	Vector3 scale;
 
 	JPH::ShapeRefC jolt_ref;
 


### PR DESCRIPTION
This changes the way scaling is dealt with in regards to physics bodies (like `RigidBody3D`) and collision shapes.

Until now, scaling a physics body such as `RigidBody3D` has resulted in Jolt throwing an assert about its rotation not being normalized, since Jolt requires that scale always be separate from the transform. I "solved" this by simply discarding the body scale altogether, which lines up with the way Godot Physics seems to deal with it. Regardless of what physics server you're using Godot will add a node configuration warning to your physics body if you apply any scaling to it, saying that the physics engine will override the scaling, by presumably resetting it to identity, so it seemed appropriate to deal with it in this way.

As for scaling collision shapes, that worked just fine previously to the best of my knowledge, but the scaling was stripped/normalized every time we rebuilt its underlying `JPH::Shape`. Now instead we store the scale separately in the shape instance and only strip/normalize it when the shape's transform is being set.