### PR TITLE
Changed clang-format penalties

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,15 +112,15 @@ SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 1
 
 # Penalties
-# PenaltyBreakAssignment: 2
+PenaltyBreakAssignment: 1000000
 PenaltyBreakBeforeFirstCallParameter: 0
 PenaltyBreakComment: 0
-# PenaltyBreakFirstLessLess: 120
+PenaltyBreakFirstLessLess: 1000000
 PenaltyBreakOpenParenthesis: 0
-# PenaltyBreakString: 1000
-# PenaltyBreakTemplateDeclaration: 10
-# PenaltyExcessCharacter: 1000000
-# PenaltyIndentedWhitespace: 0
+PenaltyBreakString: 0
+PenaltyBreakTemplateDeclaration: 0
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 3
 PenaltyReturnTypeOnItsOwnLine: 1000000
 
 # Includes

--- a/src/jolt_area_3d.cpp
+++ b/src/jolt_area_3d.cpp
@@ -135,8 +135,9 @@ void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant
 }
 
 JPH::BroadPhaseLayer JoltArea3D::get_broad_phase_layer() const {
-	return monitorable ? JoltBroadPhaseLayer::AREA_DETECTABLE
-					   : JoltBroadPhaseLayer::AREA_UNDETECTABLE;
+	return monitorable
+		? JoltBroadPhaseLayer::AREA_DETECTABLE
+		: JoltBroadPhaseLayer::AREA_UNDETECTABLE;
 }
 
 void JoltArea3D::set_body_monitor_callback(const Callable& p_callback) {

--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -516,8 +516,9 @@ bool JoltBody3D::has_collision_exception(const RID& p_excepted_body, bool p_lock
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	const auto* group_filter =
-		static_cast<const JoltGroupFilterRID*>(body->GetCollisionGroup().GetGroupFilter());
+	const auto* group_filter = static_cast<const JoltGroupFilterRID*>(
+		body->GetCollisionGroup().GetGroupFilter()
+	);
 
 	return group_filter != nullptr && group_filter->has_exception(p_excepted_body);
 }
@@ -526,8 +527,9 @@ TypedArray<RID> JoltBody3D::get_collision_exceptions(bool p_lock) const {
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	const auto* group_filter =
-		static_cast<const JoltGroupFilterRID*>(body->GetCollisionGroup().GetGroupFilter());
+	const auto* group_filter = static_cast<const JoltGroupFilterRID*>(
+		body->GetCollisionGroup().GetGroupFilter()
+	);
 
 	if (group_filter == nullptr) {
 		return {};
@@ -856,8 +858,9 @@ void JoltBody3D::create_in_space(bool p_lock) {
 	settings.mLinearVelocity = to_jolt(initial_linear_velocity);
 	settings.mAngularVelocity = to_jolt(initial_angular_velocity);
 	settings.mAllowDynamicOrKinematic = true;
-	settings.mMotionQuality =
-		ccd_enabled ? JPH::EMotionQuality::LinearCast : JPH::EMotionQuality::Discrete;
+	settings.mMotionQuality = ccd_enabled
+		? JPH::EMotionQuality::LinearCast
+		: JPH::EMotionQuality::Discrete;
 	settings.mAllowSleeping = allowed_sleep;
 	settings.mFriction = friction;
 	settings.mRestitution = bounce;

--- a/src/jolt_contact_listener.cpp
+++ b/src/jolt_contact_listener.cpp
@@ -165,8 +165,11 @@ void JoltContactListener::flush_contacts() {
 	for (auto&& [shape_pair, manifold] : manifolds_by_shape_pair) {
 		const JPH::BodyID body_ids[] = {shape_pair.GetBody1ID(), shape_pair.GetBody2ID()};
 
-		const JoltReadableBodies3D jolt_bodies =
-			space->read_bodies(body_ids, count_of(body_ids), false);
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(
+			body_ids,
+			count_of(body_ids),
+			false
+		);
 
 		JoltBody3D* body1 = jolt_bodies[0].as_body();
 		ERR_FAIL_NULL(body1);
@@ -220,8 +223,11 @@ void JoltContactListener::flush_area_enters() {
 
 		const JPH::BodyID body_ids[] = {body_id1, body_id2};
 
-		const JoltReadableBodies3D jolt_bodies =
-			space->read_bodies(body_ids, count_of(body_ids), false);
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(
+			body_ids,
+			count_of(body_ids),
+			false
+		);
 
 		const JoltReadableBody3D jolt_body1 = jolt_bodies[0];
 		const JoltReadableBody3D jolt_body2 = jolt_bodies[1];
@@ -290,8 +296,11 @@ void JoltContactListener::flush_area_exits() {
 
 		const JPH::BodyID body_ids[] = {body_id1, body_id2};
 
-		const JoltReadableBodies3D jolt_bodies =
-			space->read_bodies(body_ids, count_of(body_ids), false);
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(
+			body_ids,
+			count_of(body_ids),
+			false
+		);
 
 		const JoltReadableBody3D jolt_body1 = jolt_bodies[0];
 		const JoltReadableBody3D jolt_body2 = jolt_bodies[1];
@@ -347,11 +356,11 @@ void JoltContactListener::add_debug_contacts(const JPH::ContactManifold& p_manif
 	for (int32_t i = 0; i < additional_pairs; ++i) {
 		const int32_t pair_index = current_count + i * 2;
 
-		debug_contacts[pair_index + 0] =
-			to_godot(p_manifold.GetWorldSpaceContactPointOn1((JPH::uint)i));
+		const JPH::Vec3 point_on_1 = p_manifold.GetWorldSpaceContactPointOn1((JPH::uint)i);
+		const JPH::Vec3 point_on_2 = p_manifold.GetWorldSpaceContactPointOn2((JPH::uint)i);
 
-		debug_contacts[pair_index + 1] =
-			to_godot(p_manifold.GetWorldSpaceContactPointOn2((JPH::uint)i));
+		debug_contacts[pair_index + 0] = to_godot(point_on_1);
+		debug_contacts[pair_index + 1] = to_godot(point_on_2);
 	}
 }
 

--- a/src/jolt_generic_6dof_joint_3d.cpp
+++ b/src/jolt_generic_6dof_joint_3d.cpp
@@ -427,8 +427,11 @@ void JoltGeneric6DOFJoint3D::rebuild(bool p_lock) {
 		body_ids.push_back(body_b->get_jolt_id());
 	}
 
-	const JoltWritableBodies3D bodies =
-		space->write_bodies(body_ids.ptr(), body_ids.size(), p_lock);
+	const JoltWritableBodies3D bodies = space->write_bodies(
+		body_ids.ptr(),
+		body_ids.size(),
+		p_lock
+	);
 
 	if (jolt_ref != nullptr) {
 		space->remove_joint(this);

--- a/src/jolt_physics_direct_space_state_3d.cpp
+++ b/src/jolt_physics_direct_space_state_3d.cpp
@@ -34,8 +34,9 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 
 	JPH::RayCastSettings settings;
 	settings.mTreatConvexAsSolid = p_hit_from_inside;
-	settings.mBackFaceMode = p_hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces
-											  : JPH::EBackFaceMode::IgnoreBackFaces;
+	settings.mBackFaceMode = p_hit_back_faces
+		? JPH::EBackFaceMode::CollideWithBackFaces
+		: JPH::EBackFaceMode::IgnoreBackFaces;
 
 	JoltQueryCollectorClosest<JPH::CastRayCollector> collector;
 
@@ -468,8 +469,14 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 
 	Vector3 recover_motion;
 
-	const bool recovered =
-		body_motion_recover(p_body, transform, scale, motion_direction, p_margin, recover_motion);
+	const bool recovered = body_motion_recover(
+		p_body,
+		transform,
+		scale,
+		motion_direction,
+		p_margin,
+		recover_motion
+	);
 
 	float safe_fraction = 1.0f;
 	float unsafe_fraction = 1.0f;

--- a/src/jolt_ray_shape.cpp
+++ b/src/jolt_ray_shape.cpp
@@ -156,8 +156,9 @@ JPH::ShapeSettings::ShapeResult JoltRayShapeSettings::Create() const {
 }
 
 void JoltRayShape::register_type() {
-	JPH::ShapeFunctions& shape_functions =
-		JPH::ShapeFunctions::sGet(JPH::EShapeSubType::UserConvex1);
+	constexpr auto ray_sub_type = JPH::EShapeSubType::UserConvex1;
+
+	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(ray_sub_type);
 
 	shape_functions.mConstruct = construct_ray;
 	shape_functions.mColor = JPH::Color::sDarkRed;
@@ -175,29 +176,20 @@ void JoltRayShape::register_type() {
 
 	for (const JPH::EShapeSubType concrete_sub_type : concrete_sub_types) {
 		JPH::CollisionDispatch::sRegisterCollideShape(
-			JPH::EShapeSubType::UserConvex1,
+			ray_sub_type,
 			concrete_sub_type,
 			collide_ray_vs_shape
 		);
 
 		JPH::CollisionDispatch::sRegisterCollideShape(
 			concrete_sub_type,
-			JPH::EShapeSubType::UserConvex1,
+			ray_sub_type,
 			JPH::CollisionDispatch::sReversedCollideShape
 		);
 	}
 
-	JPH::CollisionDispatch::sRegisterCollideShape(
-		JPH::EShapeSubType::UserConvex1,
-		JPH::EShapeSubType::UserConvex1,
-		collide_noop
-	);
-
-	JPH::CollisionDispatch::sRegisterCastShape(
-		JPH::EShapeSubType::UserConvex1,
-		JPH::EShapeSubType::UserConvex1,
-		cast_noop
-	);
+	JPH::CollisionDispatch::sRegisterCollideShape(ray_sub_type, ray_sub_type, collide_noop);
+	JPH::CollisionDispatch::sRegisterCastShape(ray_sub_type, ray_sub_type, cast_noop);
 }
 
 JPH::AABox JoltRayShape::GetLocalBounds() const {


### PR DESCRIPTION
This makes all the clang-format penalties explicit and changes a couple of them. These are used to control how clang-format prioritizes things like line breaks versus indentation.

I was unhappy with the line breaks applied after assignment operators, so I cranked up `PenaltyBreakAssignment` to essentially prevent this from ever happening. I also slightly bumped `PenaltyIndentedWhitespace` in order to suppress some of clang-format's habit of making big blocks of whitespace. The rest of the changes had no real impact currently, but seemed appropriate either way.