### PR TITLE
Fixed issues with shape scaling

### DIFF
--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -243,11 +243,14 @@ void JoltCollisionObject3D::rebuild_shape(bool p_lock) {
 
 void JoltCollisionObject3D::add_shape(
 	JoltShape3D* p_shape,
-	const Transform3D& p_transform,
+	Transform3D p_transform,
 	bool p_disabled,
 	bool p_lock
 ) {
-	shapes.emplace_back(this, p_shape, p_transform, p_disabled);
+	Vector3 scale;
+	try_strip_scale(p_transform, scale);
+
+	shapes.emplace_back(this, p_shape, p_transform, scale, p_disabled);
 
 	rebuild_shape(p_lock);
 }
@@ -314,6 +317,12 @@ Transform3D JoltCollisionObject3D::get_shape_transform(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].get_transform();
+}
+
+Transform3D JoltCollisionObject3D::get_shape_transform_scaled(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_transform_scaled();
 }
 
 Vector3 JoltCollisionObject3D::get_shape_scale(int32_t p_index) const {

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -69,7 +69,7 @@ public:
 
 	void add_shape(
 		JoltShape3D* p_shape,
-		const Transform3D& p_transform,
+		Transform3D p_transform,
 		bool p_disabled,
 		bool p_lock = true
 	);
@@ -95,6 +95,8 @@ public:
 	JoltShape3D* find_shape(const JPH::SubShapeID& p_sub_shape_id) const;
 
 	Transform3D get_shape_transform(int32_t p_index) const;
+
+	Transform3D get_shape_transform_scaled(int32_t p_index) const;
 
 	Vector3 get_shape_scale(int32_t p_index) const;
 

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -315,7 +315,7 @@ Transform3D JoltPhysicsServer3D::_area_get_shape_transform(const RID& p_area, in
 	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
-	return area->get_shape_transform(p_shape_idx);
+	return area->get_shape_transform_scaled(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_area_remove_shape(const RID& p_area, int32_t p_shape_idx) {
@@ -568,7 +568,7 @@ Transform3D JoltPhysicsServer3D::_body_get_shape_transform(const RID& p_body, in
 	JoltBody3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
-	return body->get_shape_transform(p_shape_idx);
+	return body->get_shape_transform_scaled(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_body_remove_shape(const RID& p_body, int32_t p_shape_idx) {

--- a/src/jolt_shape_instance_3d.cpp
+++ b/src/jolt_shape_instance_3d.cpp
@@ -6,9 +6,11 @@ JoltShapeInstance3D::JoltShapeInstance3D(
 	JoltCollisionObject3D* p_parent,
 	JoltShape3D* p_shape,
 	const Transform3D& p_transform,
+	const Vector3& p_scale,
 	bool p_disabled
 )
 	: transform(p_transform)
+	, scale(p_scale)
 	, parent(p_parent)
 	, shape(p_shape)
 	, disabled(p_disabled) {
@@ -51,6 +53,7 @@ bool JoltShapeInstance3D::try_build() {
 JoltShapeInstance3D& JoltShapeInstance3D::operator=(JoltShapeInstance3D&& p_other) noexcept {
 	if (this != &p_other) {
 		transform = p_other.transform;
+		scale = p_other.scale;
 		parent = std::exchange(p_other.parent, nullptr);
 		shape = std::exchange(p_other.shape, nullptr);
 		jolt_ref = std::move(p_other.jolt_ref);

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -9,6 +9,7 @@ public:
 		JoltCollisionObject3D* p_parent,
 		JoltShape3D* p_shape,
 		const Transform3D& p_transform = {},
+		const Vector3& p_scale = {1.0f, 1.0f, 1.0f},
 		bool p_disabled = false
 	);
 
@@ -25,6 +26,8 @@ public:
 	const JPH::Shape* get_jolt_ref() const { return jolt_ref; }
 
 	const Transform3D& get_transform() const { return transform; }
+
+	Transform3D get_transform_scaled() const { return transform.scaled_local(scale); }
 
 	void set_transform(const Transform3D& p_transform) { transform = p_transform; }
 


### PR DESCRIPTION
It seems I was a bit sloppy with #252 and left out a couple of `Transform3D` usages that needed to take scaling into account, so this PR addresses exactly that.