### PR TITLE
Fixed issues with `body_test_motion` when stuck

### DIFF
--- a/src/jolt_physics_direct_space_state_3d.hpp
+++ b/src/jolt_physics_direct_space_state_3d.hpp
@@ -110,6 +110,7 @@ private:
 		const JPH::ObjectLayerFilter& p_object_layer_filter,
 		const JPH::BodyFilter& p_body_filter,
 		const JPH::ShapeFilter& p_shape_filter,
+		bool p_ignore_overlaps,
 		float& p_closest_safe,
 		float& p_closest_unsafe
 	) const;
@@ -123,13 +124,14 @@ private:
 		const JPH::ObjectLayerFilter& p_object_layer_filter,
 		const JPH::BodyFilter& p_body_filter,
 		const JPH::ShapeFilter& p_shape_filter,
+		bool p_ignore_overlaps,
 		float& p_closest_safe,
 		float& p_closest_unsafe
 	) const;
 
 	bool body_motion_recover(
 		const JoltBody3D& p_body,
-		Transform3D& p_transform,
+		const Transform3D& p_transform,
 		const Vector3& p_scale,
 		const Vector3& p_direction,
 		float p_margin,


### PR DESCRIPTION
This fixes some jitter and various other problems when (for example) a `CharacterBody3D` is wedged inbetween two shapes.

I had tried to skip the iterative solving done during the recovery phase, unlike what pretty much every other character controller does, but having a capsule-shaped `CharacterBody3D` walk up against a wedge at even low speeds showed how broken that approach was. So this PR adds that exact thing.

I also realized that shape-casting is done differently during `body_test_motion`, where it will actually respect initial overlaps, which also created problems when stuck, so I added a parameter to `cast_motion` to handle that.

I also snuck in a lower bound of 0.0001 to the `margin` parameter of `body_test_motion`, to better align with Godot Physics.