### PR TITLE
Refactored object construction to allow moving between spaces

### DIFF
--- a/src/jolt_area_3d.cpp
+++ b/src/jolt_area_3d.cpp
@@ -396,11 +396,11 @@ void JoltArea3D::report_event(
 	p_callback.callv(arguments);
 }
 
-void JoltArea3D::create_in_space(bool p_lock) {
-	JPH::BodyCreationSettings settings = create_begin();
+void JoltArea3D::create_in_space() {
+	create_begin();
 
-	settings.mIsSensor = true;
-	settings.mUseManifoldReduction = false;
+	jolt_settings->mIsSensor = true;
+	jolt_settings->mUseManifoldReduction = false;
 
-	create_end(settings, p_lock);
+	create_end();
 }

--- a/src/jolt_area_3d.hpp
+++ b/src/jolt_area_3d.hpp
@@ -159,7 +159,7 @@ private:
 
 	JPH::EMotionType get_motion_type() const override { return JPH::EMotionType::Kinematic; }
 
-	void create_in_space(bool p_lock = true) override;
+	void create_in_space() override;
 
 	void body_monitoring_changed();
 

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -58,7 +58,7 @@ public:
 
 	void set_sleep_state(bool p_enabled, bool p_lock = true);
 
-	bool can_sleep() const { return allowed_sleep; }
+	bool can_sleep(bool p_lock = true) const;
 
 	void set_can_sleep(bool p_enabled, bool p_lock = true);
 
@@ -164,7 +164,7 @@ public:
 
 	bool is_rigid() const { return is_rigid_free() || is_rigid_linear(); }
 
-	bool is_ccd_enabled() const { return ccd_enabled; }
+	bool is_ccd_enabled(bool p_lock = true) const;
 
 	void set_ccd_enabled(bool p_enable, bool p_lock = true);
 
@@ -176,17 +176,17 @@ public:
 
 	void set_inertia(const Vector3& p_inertia, bool p_lock = true);
 
-	float get_bounce() const { return bounce; }
+	float get_bounce(bool p_lock = true) const;
 
 	void set_bounce(float p_bounce, bool p_lock = true);
 
-	float get_friction() const { return friction; }
+	float get_friction(bool p_lock = true) const;
 
 	void set_friction(float p_friction, bool p_lock = true);
 
-	float get_gravity_scale() const { return gravity_scale; }
+	float get_gravity_scale(bool p_lock = true) const;
 
-	void set_gravity_scale(float p_scale) { gravity_scale = p_scale; }
+	void set_gravity_scale(float p_scale, bool p_lock = true);
 
 	Vector3 get_gravity() const { return gravity; }
 
@@ -221,7 +221,7 @@ private:
 
 	JPH::EMotionType get_motion_type() const override;
 
-	void create_in_space(bool p_lock = true) override;
+	void create_in_space() override;
 
 	void destroy_in_space(bool p_lock = true) override;
 
@@ -251,25 +251,15 @@ private:
 
 	DampMode angular_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
 
-	bool ccd_enabled = false;
-
 	float mass = 1.0f;
 
 	Vector3 inertia;
-
-	float bounce = 0.0f;
-
-	float friction = 1.0f;
-
-	float gravity_scale = 1.0f;
 
 	float linear_damp = 0.0f;
 
 	float angular_damp = 0.0f;
 
 	bool initial_sleep_state = false;
-
-	bool allowed_sleep = true;
 
 	bool custom_center_of_mass = false;
 
@@ -280,10 +270,6 @@ private:
 	LocalVector<Contact> contacts;
 
 	LocalVector<JoltArea3D*> areas;
-
-	Vector3 initial_linear_velocity;
-
-	Vector3 initial_angular_velocity;
 
 	Vector3 center_of_mass_custom;
 

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -7,6 +7,8 @@ class JoltShape3D;
 
 class JoltCollisionObject3D {
 public:
+	JoltCollisionObject3D();
+
 	virtual ~JoltCollisionObject3D() = 0;
 
 	RID get_rid() const { return rid; }
@@ -45,11 +47,7 @@ public:
 
 	Basis get_basis(bool p_lock = true) const;
 
-	void set_basis(const Basis& p_basis, bool p_lock = true);
-
 	Vector3 get_position(bool p_lock = true) const;
-
-	void set_position(const Vector3& p_position, bool p_lock = true);
 
 	Vector3 get_center_of_mass(bool p_lock = true) const;
 
@@ -129,17 +127,17 @@ protected:
 
 	virtual JPH::EMotionType get_motion_type() const = 0;
 
-	virtual void create_in_space(bool p_lock = true) = 0;
-
-	virtual void destroy_in_space(bool p_lock = true);
+	virtual void create_in_space() = 0;
 
 	virtual void add_to_space(bool p_lock = true);
 
 	virtual void remove_from_space(bool p_lock = true);
 
-	JPH::BodyCreationSettings create_begin();
+	virtual void destroy_in_space(bool p_lock = true);
 
-	JPH::Body* create_end(const JPH::BodyCreationSettings& p_settings, bool p_lock = true);
+	void create_begin();
+
+	JPH::Body* create_end();
 
 	void object_layer_changed(bool p_lock = true);
 
@@ -155,6 +153,8 @@ protected:
 
 	JPH::BodyID jolt_id;
 
+	JPH::BodyCreationSettings* jolt_settings = new JPH::BodyCreationSettings();
+
 	JPH::ShapeRefC jolt_shape;
 
 	JPH::ShapeRefC previous_jolt_shape;
@@ -168,6 +168,4 @@ protected:
 	LocalVector<JoltShapeInstance3D> shapes;
 
 	bool ray_pickable = false;
-
-	Transform3D initial_transform;
 };


### PR DESCRIPTION
This changes the way collision objects (bodies and areas) deal with their "initial state", to allow for moving said collision objects inbetween two physics spaces.

Until now there's been a bunch of `initial_*` members in the collision objects, which has served to populate the eventual `JPH::BodyCreationSettings` once the body gets added to a space. Now instead the creation settings gets allocated along with the object itself and deallocated once the object is fully created within the space. This lets us remove all the previously mentioned `initial_*` members and instead use the creation settings directly as an intermediate storage.

What this also allows for is populating this intermediate `JPH::BodyCreationSettings`, using `JPH::Body::GetBodyCreationSettings`, when a body is moved between spaces, which helps preserve things like the body's current transform and velocities.