### PR TITLE
Added support for collision priority in `body_test_motion`

### DIFF
--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -202,6 +202,10 @@ public:
 
 	float get_total_angular_damp(bool p_lock = true) const;
 
+	float get_collision_priority() const { return collision_priority; }
+
+	void set_collision_priority(float p_priority) { collision_priority = p_priority; }
+
 	DampMode get_linear_damp_mode() const { return linear_damp_mode; }
 
 	void set_linear_damp_mode(DampMode p_mode) { linear_damp_mode = p_mode; }
@@ -258,6 +262,8 @@ private:
 	float linear_damp = 0.0f;
 
 	float angular_damp = 0.0f;
+
+	float collision_priority = 1.0f;
 
 	bool initial_sleep_state = false;
 

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -655,20 +655,18 @@ uint32_t JoltPhysicsServer3D::_body_get_collision_mask(const RID& p_body) const 
 	return body->get_collision_mask();
 }
 
-void JoltPhysicsServer3D::_body_set_collision_priority(
-	[[maybe_unused]] const RID& p_body,
-	double p_priority
-) {
-	if (!Math::is_equal_approx(p_priority, 1.0)) {
-		WARN_PRINT(
-			"Collision priority is not supported by Godot Jolt. "
-			"Any value will be treated as a value of 1."
-		);
-	}
+void JoltPhysicsServer3D::_body_set_collision_priority(const RID& p_body, double p_priority) {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_collision_priority((float)p_priority);
 }
 
-double JoltPhysicsServer3D::_body_get_collision_priority([[maybe_unused]] const RID& p_body) const {
-	return 1.0;
+double JoltPhysicsServer3D::_body_get_collision_priority(const RID& p_body) const {
+	JoltBody3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_D(body);
+
+	return (float)body->get_collision_priority();
 }
 
 void JoltPhysicsServer3D::_body_set_user_flags(


### PR DESCRIPTION
This adds support for the `collision_priority` property on `CollisionObject3D`, which helps with preventing things like `CharacterBody3D` clipping through walls that absolutely shouldn't be clipped through.

As of writing this collision priority is only really a thing that affects `body_test_motion` in Godot Physics, but it seems like there are plans/hopes of adding this to Godot's general collision solver. Once that happens (if ever) then things will probably diverge a bit in terms of support.