### PR TITLE
Fixed error spam when starting editor

### DIFF
--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -8,89 +8,89 @@ JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D* p_body)
 	: body(p_body) { }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_total_gravity() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_gravity();
 }
 
 double JoltPhysicsDirectBodyState3D::_get_total_angular_damp() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return (double)body->get_total_angular_damp();
 }
 
 double JoltPhysicsDirectBodyState3D::_get_total_linear_damp() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return (double)body->get_total_linear_damp();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_center_of_mass();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass_local() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_transform().xform_inv(body->get_center_of_mass());
 }
 
 Basis JoltPhysicsDirectBodyState3D::_get_principal_inertia_axes() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_principal_inertia_axes();
 }
 
 double JoltPhysicsDirectBodyState3D::_get_inverse_mass() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return 1.0 / body->get_mass();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_inverse_inertia() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_inverse_inertia();
 }
 
 Basis JoltPhysicsDirectBodyState3D::_get_inverse_inertia_tensor() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_inverse_inertia_tensor();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_linear_velocity() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_linear_velocity();
 }
 
 void JoltPhysicsDirectBodyState3D::_set_linear_velocity(const Vector3& p_velocity) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->set_linear_velocity(p_velocity);
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_angular_velocity() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_angular_velocity();
 }
 
 void JoltPhysicsDirectBodyState3D::_set_angular_velocity(const Vector3& p_velocity) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->set_angular_velocity(p_velocity);
 }
 
 void JoltPhysicsDirectBodyState3D::_set_transform(const Transform3D& p_transform) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->set_transform(p_transform);
 }
 
 Transform3D JoltPhysicsDirectBodyState3D::_get_transform() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_transform();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_velocity_at_local_position(
 	const Vector3& p_local_position
 ) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_velocity_at_position(body->get_position() + p_local_position);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_central_impulse(const Vector3& p_impulse) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->apply_central_impulse(p_impulse);
 }
 
@@ -98,32 +98,32 @@ void JoltPhysicsDirectBodyState3D::_apply_impulse(
 	const Vector3& p_impulse,
 	const Vector3& p_position
 ) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->apply_impulse(p_impulse, p_position);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_torque_impulse(const Vector3& p_impulse) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->apply_torque_impulse(p_impulse);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_central_force(const Vector3& p_force) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->apply_central_force(p_force);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_force(const Vector3& p_force, const Vector3& p_position) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->apply_force(p_force, p_position);
 }
 
 void JoltPhysicsDirectBodyState3D::_apply_torque(const Vector3& p_torque) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->apply_torque(p_torque);
 }
 
 void JoltPhysicsDirectBodyState3D::_add_constant_central_force(const Vector3& p_force) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->add_constant_central_force(p_force);
 }
 
@@ -131,100 +131,100 @@ void JoltPhysicsDirectBodyState3D::_add_constant_force(
 	const Vector3& p_force,
 	const Vector3& p_position
 ) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->add_constant_force(p_force, p_position);
 }
 
 void JoltPhysicsDirectBodyState3D::_add_constant_torque(const Vector3& p_torque) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->add_constant_torque(p_torque);
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_constant_force() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_constant_force();
 }
 
 void JoltPhysicsDirectBodyState3D::_set_constant_force(const Vector3& p_force) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->set_constant_force(p_force);
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_constant_torque() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_constant_torque();
 }
 
 void JoltPhysicsDirectBodyState3D::_set_constant_torque(const Vector3& p_torque) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	return body->set_constant_torque(p_torque);
 }
 
 bool JoltPhysicsDirectBodyState3D::_is_sleeping() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_sleep_state();
 }
 
 void JoltPhysicsDirectBodyState3D::_set_sleep_state(bool p_enabled) {
-	ERR_FAIL_NULL(body);
+	QUIET_FAIL_NULL_ED(body);
 	body->set_sleep_state(p_enabled);
 }
 
 int32_t JoltPhysicsDirectBodyState3D::_get_contact_count() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return body->get_contact_count();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_contact_local_position(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).position;
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_contact_local_normal(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).normal;
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_contact_impulse(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).impulse;
 }
 
 int32_t JoltPhysicsDirectBodyState3D::_get_contact_local_shape(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).shape_index;
 }
 
 RID JoltPhysicsDirectBodyState3D::_get_contact_collider(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).collider_rid;
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_contact_collider_position(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).collider_position;
 }
 
 uint64_t JoltPhysicsDirectBodyState3D::_get_contact_collider_id(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).collider_id;
 }
 
 Object* JoltPhysicsDirectBodyState3D::_get_contact_collider_object(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return ObjectDB::get_instance(body->get_contact(p_contact_idx).collider_id);
 }
 
 int32_t JoltPhysicsDirectBodyState3D::_get_contact_collider_shape(int32_t p_contact_idx) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).collider_shape_index;
 }
@@ -232,13 +232,13 @@ int32_t JoltPhysicsDirectBodyState3D::_get_contact_collider_shape(int32_t p_cont
 Vector3 JoltPhysicsDirectBodyState3D::_get_contact_collider_velocity_at_position(
 	int32_t p_contact_idx
 ) const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
 	return body->get_contact(p_contact_idx).collider_velocity;
 }
 
 double JoltPhysicsDirectBodyState3D::_get_step() const {
-	ERR_FAIL_NULL_D(body);
+	QUIET_FAIL_NULL_D_ED(body);
 	return (double)body->get_space()->get_last_step();
 }
 

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -987,80 +987,92 @@ PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(const RID&
 }
 
 RID JoltPhysicsServer3D::_soft_body_create() {
+#ifdef DEBUG_ENABLED
+	// HACK(mihe): The editor needs to have a usable body in order for the documentation generation
+	// to not emit errors when doing stuff like attaching instance IDs, so we just give it a regular
+	// body instead.
+	return _body_create();
+#else // DEBUG_ENABLED
 	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+#endif // DEBUG_ENABLED
 }
 
 void JoltPhysicsServer3D::_soft_body_update_rendering_server(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] PhysicsServer3DRenderingServerHandler* p_rendering_server_handler
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 void JoltPhysicsServer3D::_soft_body_set_space(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] const RID& p_space
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 RID JoltPhysicsServer3D::_soft_body_get_space([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_mesh(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] const RID& p_mesh
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 AABB JoltPhysicsServer3D::_soft_body_get_bounds([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_collision_layer(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] uint32_t p_layer
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 uint32_t JoltPhysicsServer3D::_soft_body_get_collision_layer([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_collision_mask(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] uint32_t p_mask
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 uint32_t JoltPhysicsServer3D::_soft_body_get_collision_mask([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_add_collision_exception(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] const RID& p_body_b
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 void JoltPhysicsServer3D::_soft_body_remove_collision_exception(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] const RID& p_body_b
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 TypedArray<RID> JoltPhysicsServer3D::_soft_body_get_collision_exceptions(
 	[[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_state(
@@ -1068,99 +1080,106 @@ void JoltPhysicsServer3D::_soft_body_set_state(
 	[[maybe_unused]] BodyState p_state,
 	[[maybe_unused]] const Variant& p_variant
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 Variant JoltPhysicsServer3D::_soft_body_get_state(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] BodyState p_state
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_transform(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] const Transform3D& p_transform
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 void JoltPhysicsServer3D::_soft_body_set_ray_pickable(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] bool p_enable
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 void JoltPhysicsServer3D::_soft_body_set_simulation_precision(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] int32_t p_simulation_precision
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 int32_t JoltPhysicsServer3D::_soft_body_get_simulation_precision([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_total_mass(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_total_mass
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 double JoltPhysicsServer3D::_soft_body_get_total_mass([[maybe_unused]] const RID& p_body) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_linear_stiffness(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_linear_stiffness
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 double JoltPhysicsServer3D::_soft_body_get_linear_stiffness([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_pressure_coefficient(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_pressure_coefficient
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 double JoltPhysicsServer3D::_soft_body_get_pressure_coefficient([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_damping_coefficient(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_damping_coefficient
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 double JoltPhysicsServer3D::_soft_body_get_damping_coefficient([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_set_drag_coefficient(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] double p_drag_coefficient
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 double JoltPhysicsServer3D::_soft_body_get_drag_coefficient([[maybe_unused]] const RID& p_body
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_move_point(
@@ -1168,18 +1187,19 @@ void JoltPhysicsServer3D::_soft_body_move_point(
 	[[maybe_unused]] int32_t p_point_index,
 	[[maybe_unused]] const Vector3& p_global_position
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 Vector3 JoltPhysicsServer3D::_soft_body_get_point_global_position(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] int32_t p_point_index
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 void JoltPhysicsServer3D::_soft_body_remove_all_pinned_points([[maybe_unused]] const RID& p_body) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 void JoltPhysicsServer3D::_soft_body_pin_point(
@@ -1187,14 +1207,15 @@ void JoltPhysicsServer3D::_soft_body_pin_point(
 	[[maybe_unused]] int32_t p_point_index,
 	[[maybe_unused]] bool p_pin
 ) {
-	ERR_FAIL_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
 }
 
 bool JoltPhysicsServer3D::_soft_body_is_point_pinned(
 	[[maybe_unused]] const RID& p_body,
 	[[maybe_unused]] int32_t p_point_index
 ) const {
-	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
+	// SoftBody3D is not supported
+	return {};
 }
 
 RID JoltPhysicsServer3D::_joint_create() {

--- a/src/misc/error_macros.hpp
+++ b/src/misc/error_macros.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+// clang-format off
+
 #define ERR_FAIL_INDEX_D(m_index, m_size) ERR_FAIL_INDEX_V(m_index, m_size, {})
-#define ERR_FAIL_INDEX_D_MSG(m_index, m_size, m_msg) \
-	ERR_FAIL_INDEX_V_MSG(m_index, m_size, {}, m_msg)
+#define ERR_FAIL_INDEX_D_MSG(m_index, m_size, m_msg) ERR_FAIL_INDEX_V_MSG(m_index, m_size, {}, m_msg)
 #define ERR_FAIL_UNSIGNED_INDEX_D(m_index, m_size) ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, {})
-#define ERR_FAIL_UNSIGNED_INDEX_D_MSG(m_index, m_size, m_msg) \
-	ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, {}, m_msg)
+#define ERR_FAIL_UNSIGNED_INDEX_D_MSG(m_index, m_size, m_msg) ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, {}, m_msg)
 #define ERR_FAIL_NULL_D(m_param) ERR_FAIL_NULL_V(m_param, {})
 #define ERR_FAIL_NULL_D_MSG(m_param, m_msg) ERR_FAIL_NULL_V_MSG(m_param, {}, m_msg)
 #define ERR_FAIL_COND_D(m_cond) ERR_FAIL_COND_V(m_cond, {})
@@ -17,5 +17,76 @@
 #define ERR_FAIL_NOT_IMPL() ERR_FAIL_MSG(GDJOLT_MSG_NOT_IMPL)
 #define ERR_FAIL_V_NOT_IMPL(m_retval) ERR_FAIL_V_MSG(m_retval, GDJOLT_MSG_NOT_IMPL)
 #define ERR_FAIL_D_NOT_IMPL() ERR_FAIL_D_MSG(GDJOLT_MSG_NOT_IMPL)
-#define ERR_BREAK_NOT_IMPL() ERR_BREAK_MSG(GDJOLT_MSG_NOT_IMPL)
-#define ERR_CONTINUE_NOT_IMPL() ERR_CONTINUE_MSG(GDJOLT_MSG_NOT_IMPL)
+#define ERR_BREAK_NOT_IMPL(m_cond) ERR_BREAK_MSG(m_cond, GDJOLT_MSG_NOT_IMPL)
+#define ERR_CONTINUE_NOT_IMPL(m_cond) ERR_CONTINUE_MSG(m_cond, GDJOLT_MSG_NOT_IMPL)
+
+// clang-format on
+
+#define QUIET_FAIL_COND(m_cond) \
+	if (unlikely(m_cond)) {     \
+		return;                 \
+	} else                      \
+		((void)0)
+
+#define QUIET_FAIL_COND_V(m_cond, m_retval) \
+	if (unlikely(m_cond)) {                 \
+		return m_retval;                    \
+	} else                                  \
+		((void)0)
+
+#define QUIET_BREAK(m_cond) \
+	if (unlikely(m_cond)) { \
+		break;              \
+	} else                  \
+		((void)0)
+
+#define QUIET_CONTINUE(m_cond) \
+	if (unlikely(m_cond)) {    \
+		continue;              \
+	} else                     \
+		((void)0)
+
+// clang-format off
+
+#define QUIET_FAIL_COND_D(m_cond) QUIET_FAIL_COND_V(m_cond, {})
+#define QUIET_FAIL_NULL(m_param) QUIET_FAIL_COND((m_param) == nullptr)
+#define QUIET_FAIL_NULL_V(m_param, m_retval) QUIET_FAIL_COND_V((m_param) == nullptr, m_retval)
+#define QUIET_FAIL_NULL_D(m_param) QUIET_FAIL_NULL_V(m_param, {})
+#define QUIET_FAIL_INDEX(m_index, m_size) QUIET_FAIL_COND((m_index) < 0 || (m_index) >= (m_size))
+#define QUIET_FAIL_INDEX_V(m_index, m_size, m_retval) QUIET_FAIL_COND_V((m_index) < 0 || (m_index) >= (m_size), m_retval)
+#define QUIET_FAIL_INDEX_D(m_index, m_size) QUIET_FAIL_INDEX_V(m_index, m_size, {})
+#define QUIET_FAIL_UNSIGNED_INDEX(m_index, m_size) QUIET_FAIL_COND((m_index) >= (m_size))
+#define QUIET_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval) QUIET_FAIL_COND_V((m_index) >= (m_size), m_retval)
+#define QUIET_FAIL_UNSIGNED_INDEX_D(m_index, m_size) QUIET_FAIL_UNSIGNED_INDEX_V(m_index, m_size, {})
+
+#ifdef DEBUG_ENABLED
+
+#define QUIET_FAIL_COND_D_ED(m_cond, m_retval) QUIET_FAIL_COND_D(m_cond, m_retval)
+#define QUIET_FAIL_NULL_ED(m_param) QUIET_FAIL_NULL(m_param)
+#define QUIET_FAIL_NULL_V_ED(m_param, m_retval) QUIET_FAIL_NULL_V(m_param, m_retval)
+#define QUIET_FAIL_NULL_D_ED(m_param) QUIET_FAIL_NULL_D(m_param)
+#define QUIET_FAIL_INDEX_ED(m_index, m_size) QUIET_FAIL_INDEX(m_index, m_size)
+#define QUIET_FAIL_INDEX_V_ED(m_index, m_size, m_retval) QUIET_FAIL_INDEX_V(m_index, m_size, m_retval)
+#define QUIET_FAIL_INDEX_D_ED(m_index, m_size) QUIET_FAIL_INDEX_D(m_index, m_size)
+#define QUIET_FAIL_UNSIGNED_INDEX_ED(m_index, m_size) QUIET_FAIL_UNSIGNED_INDEX(m_index, m_size)
+#define QUIET_FAIL_UNSIGNED_INDEX_V_ED(m_index, m_size, m_retval) QUIET_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)
+#define QUIET_FAIL_UNSIGNED_INDEX_D_ED(m_index, m_size) QUIET_FAIL_UNSIGNED_INDEX_D(m_index, m_size)
+#define QUIET_BREAK_ED(m_cond) QUIET_BREAK(m_cond)
+#define QUIET_CONTINUE_ED(m_cond) QUIET_CONTINUE(m_cond)
+
+#else // DEBUG_ENABLED
+
+#define QUIET_FAIL_COND_D_ED(m_cond, m_retval)
+#define QUIET_FAIL_NULL_ED(m_param)
+#define QUIET_FAIL_NULL_V_ED(m_param, m_retval)
+#define QUIET_FAIL_NULL_D_ED(m_param)
+#define QUIET_FAIL_INDEX_ED(m_index, m_size)
+#define QUIET_FAIL_INDEX_V_ED(m_index, m_size, m_retval)
+#define QUIET_FAIL_INDEX_D_ED(m_index, m_size)
+#define QUIET_FAIL_UNSIGNED_INDEX_ED(m_index, m_size)
+#define QUIET_FAIL_UNSIGNED_INDEX_V_ED(m_index, m_size, m_retval)
+#define QUIET_FAIL_UNSIGNED_INDEX_D_ED(m_index, m_size)
+#define QUIET_BREAK_ED(m_cond)
+#define QUIET_CONTINUE_ED(m_cond)
+
+#endif // DEBUG_ENABLED


### PR DESCRIPTION
Until now there's been a ton of errors emitted into `stdout` when you start up the editor, from places related to `SoftBody3D` and `PhysicsDirectBodyState3D`. This seems to be because the editor will, during documentation generation, instantiate classes that have been registered in `ClassDB` and run any property getters in order to figure out the default values of those properties.

To fix the issue with `PhysicsDirectBodyState3D` I added a couple of extra error macros that not only do not emit error messages, but also disappear completely in non-editor builds. This removes any potential branching from checking the `body` pointer, which is more or less guaranteed to never be `nullptr` anyway.

For `SoftBody3D` there needed to be an actually valid RID allocated, so that the documentation generation can perform operations like `body_attach_object_instance_id` on it during instantiation, so I worked around that by creating a regular `JoltBody3D`, which seems to work for now.