### PR TITLE
Refactored methods related to reactive changes

### DIFF
--- a/src/jolt_area_3d.cpp
+++ b/src/jolt_area_3d.cpp
@@ -295,7 +295,7 @@ void JoltArea3D::area_monitoring_changed() {
 }
 
 void JoltArea3D::monitorable_changed(bool p_lock) {
-	object_layer_changed(p_lock);
+	update_object_layer(p_lock);
 }
 
 void JoltArea3D::add_shape_pair(

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -227,13 +227,15 @@ private:
 
 	void create_in_space() override;
 
-	void destroy_in_space(bool p_lock = true) override;
-
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 
 	JPH::MassProperties calculate_mass_properties() const;
 
-	void create_axes_constraint(bool p_lock = true);
+	void update_mass_properties(bool p_lock = true);
+
+	void update_damp(bool p_lock = true);
+
+	void update_axes_constraint(bool p_lock = true);
 
 	void destroy_axes_constraint();
 
@@ -241,13 +243,13 @@ private:
 
 	void shapes_changed(bool p_lock) override;
 
+	void space_changing(bool p_lock = true) override;
+
+	void space_changed(bool p_lock = true) override;
+
 	void areas_changed(bool p_lock = true);
 
-	void damp_changed(bool p_lock = true);
-
 	void axis_lock_changed(bool p_lock = true);
-
-	void mass_properties_changed(bool p_lock = true);
 
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
 

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -41,6 +41,8 @@ void JoltCollisionObject3D::set_space(JoltSpace3D* p_space, bool p_lock) {
 		return;
 	}
 
+	space_changing(p_lock);
+
 	if (space != nullptr) {
 		const JoltWritableBody3D body = space->write_body(jolt_id, p_lock);
 		ERR_FAIL_COND(body.is_invalid());
@@ -57,6 +59,8 @@ void JoltCollisionObject3D::set_space(JoltSpace3D* p_space, bool p_lock) {
 		create_in_space();
 		add_to_space();
 	}
+
+	space_changed(p_lock);
 }
 
 void JoltCollisionObject3D::set_collision_layer(uint32_t p_layer, bool p_lock) {
@@ -440,7 +444,7 @@ JPH::Body* JoltCollisionObject3D::create_end() {
 	return body;
 }
 
-void JoltCollisionObject3D::object_layer_changed(bool p_lock) {
+void JoltCollisionObject3D::update_object_layer(bool p_lock) {
 	if (space == nullptr) {
 		return;
 	}
@@ -449,9 +453,9 @@ void JoltCollisionObject3D::object_layer_changed(bool p_lock) {
 }
 
 void JoltCollisionObject3D::collision_layer_changed(bool p_lock) {
-	object_layer_changed(p_lock);
+	update_object_layer(p_lock);
 }
 
 void JoltCollisionObject3D::collision_mask_changed(bool p_lock) {
-	object_layer_changed(p_lock);
+	update_object_layer(p_lock);
 }

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -139,13 +139,17 @@ protected:
 
 	JPH::Body* create_end();
 
-	void object_layer_changed(bool p_lock = true);
+	void update_object_layer(bool p_lock = true);
 
 	void collision_layer_changed(bool p_lock = true);
 
 	void collision_mask_changed(bool p_lock = true);
 
-	virtual void shapes_changed([[maybe_unused]] bool p_lock) { }
+	virtual void shapes_changed([[maybe_unused]] bool p_lock = true) { }
+
+	virtual void space_changing([[maybe_unused]] bool p_lock = true) { }
+
+	virtual void space_changed([[maybe_unused]] bool p_lock = true) { }
 
 	RID rid;
 


### PR DESCRIPTION
There were inconsistencies in the naming and usage of `*_changed` methods that needed to be addressed.

Instead of giving the name `*_changed` to any sort of reactive change, I now make the distinction between methods that are meant to represent a value changing and the methods are meant to produce some side effect. The former are still called `*_changed` and the latter are now instead called `update_*`.

This is needed for an upcoming PR that deals with waking up sleeping bodies.