### PR TITLE
Changed various things related to sleeping

### DIFF
--- a/src/jolt_area_3d.hpp
+++ b/src/jolt_area_3d.hpp
@@ -155,8 +155,6 @@ public:
 	Vector3 get_center_of_mass_custom() const override { return {0, 0, 0}; }
 
 private:
-	bool get_initial_sleep_state() const override { return false; }
-
 	JPH::EMotionType get_motion_type() const override { return JPH::EMotionType::Kinematic; }
 
 	void create_in_space() override;

--- a/src/jolt_body_3d.hpp
+++ b/src/jolt_body_3d.hpp
@@ -54,9 +54,13 @@ public:
 		force_integration_userdata = p_userdata;
 	}
 
-	bool get_sleep_state(bool p_lock = true) const;
+	bool is_sleeping(bool p_lock = true) const;
 
-	void set_sleep_state(bool p_enabled, bool p_lock = true);
+	void set_is_sleeping(bool p_enabled, bool p_lock = true);
+
+	void put_to_sleep(bool p_lock = true) { set_is_sleeping(true, p_lock); }
+
+	void wake_up(bool p_lock = true) { set_is_sleeping(false, p_lock); }
 
 	bool can_sleep(bool p_lock = true) const;
 
@@ -116,19 +120,19 @@ public:
 
 	void apply_torque_impulse(const Vector3& p_impulse, bool p_lock = true);
 
-	void add_constant_central_force(const Vector3& p_force);
+	void add_constant_central_force(const Vector3& p_force, bool p_lock = true);
 
 	void add_constant_force(const Vector3& p_force, const Vector3& p_position, bool p_lock = true);
 
-	void add_constant_torque(const Vector3& p_torque);
+	void add_constant_torque(const Vector3& p_torque, bool p_lock = true);
 
 	Vector3 get_constant_force() const;
 
-	void set_constant_force(const Vector3& p_force);
+	void set_constant_force(const Vector3& p_force, bool p_lock = true);
 
 	Vector3 get_constant_torque() const;
 
-	void set_constant_torque(const Vector3& p_torque);
+	void set_constant_torque(const Vector3& p_torque, bool p_lock = true);
 
 	void add_collision_exception(const RID& p_excepted_body, bool p_lock = true);
 
@@ -221,8 +225,6 @@ public:
 	bool are_axes_locked() const { return locked_axes != 0; }
 
 private:
-	bool get_initial_sleep_state() const override { return initial_sleep_state; }
-
 	JPH::EMotionType get_motion_type() const override;
 
 	void create_in_space() override;
@@ -249,6 +251,10 @@ private:
 
 	void areas_changed(bool p_lock = true);
 
+	void transform_changed(bool p_lock = true) override;
+
+	void motion_changed(bool p_lock = true);
+
 	void axis_lock_changed(bool p_lock = true);
 
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
@@ -266,8 +272,6 @@ private:
 	float angular_damp = 0.0f;
 
 	float collision_priority = 1.0f;
-
-	bool initial_sleep_state = false;
 
 	bool custom_center_of_mass = false;
 

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -123,8 +123,6 @@ protected:
 
 	virtual Vector3 get_center_of_mass_custom() const = 0;
 
-	virtual bool get_initial_sleep_state() const = 0;
-
 	virtual JPH::EMotionType get_motion_type() const = 0;
 
 	virtual void create_in_space() = 0;
@@ -150,6 +148,8 @@ protected:
 	virtual void space_changing([[maybe_unused]] bool p_lock = true) { }
 
 	virtual void space_changed([[maybe_unused]] bool p_lock = true) { }
+
+	virtual void transform_changed([[maybe_unused]] bool p_lock = true) { }
 
 	RID rid;
 

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -162,12 +162,12 @@ void JoltPhysicsDirectBodyState3D::_set_constant_torque(const Vector3& p_torque)
 
 bool JoltPhysicsDirectBodyState3D::_is_sleeping() const {
 	QUIET_FAIL_NULL_D_ED(body);
-	return body->get_sleep_state();
+	return body->is_sleeping();
 }
 
 void JoltPhysicsDirectBodyState3D::_set_sleep_state(bool p_enabled) {
 	QUIET_FAIL_NULL_ED(body);
-	body->set_sleep_state(p_enabled);
+	body->set_is_sleeping(p_enabled);
 }
 
 int32_t JoltPhysicsDirectBodyState3D::_get_contact_count() const {


### PR DESCRIPTION
This changes a number of things related to the sleep state of bodies:

- More wake-ups have been added.
- Some places that previously did a wake-up now check that the relevant value has changed first.
- The `initial_sleep_state` member of `JoltBody3D` has been removed, since it doesn't serve much purpose currently, due to Godot disrupting any initial sleep state with `NOTIFICATION_ENTER_WORLD`.
- Only non-sleeping bodies will now integrate things like gravity and constant forces/torques, to prevent them from accumulating while sleeping.