### PR TITLE
Updated godot-cpp to 4.0.2-stable

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 GodotJoltExternalLibrary_Add(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 576431062f94ba19c43fc6733d03681090a89699
+	GIT_COMMIT 716178a3d6c24b49df0fb6f1a1aa1782b8df7952
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@576431062f94ba19c43fc6733d03681090a89699 aka `4.0.1-stable` to godot-jolt/godot-cpp@716178a3d6c24b49df0fb6f1a1aa1782b8df7952 aka `4.0.2-stable` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/576431062f94ba19c43fc6733d03681090a89699...716178a3d6c24b49df0fb6f1a1aa1782b8df7952)).