### PR TITLE
Added support for `disable_mode` in `Area3D`

### DIFF
--- a/src/jolt_area_3d.hpp
+++ b/src/jolt_area_3d.hpp
@@ -159,11 +159,21 @@ private:
 
 	void create_in_space() override;
 
+	void space_changing(bool p_lock = true) override;
+
 	void body_monitoring_changed();
 
 	void area_monitoring_changed();
 
 	void monitorable_changed(bool p_lock = true);
+
+	void force_bodies_entered();
+
+	void force_bodies_exited();
+
+	void force_areas_entered();
+
+	void force_areas_exited();
 
 	void add_shape_pair(
 		Overlap& p_overlap,


### PR DESCRIPTION
This adds support for `disable_mode` in `Area3D`. More specifically it adds support for `DISABLE_MODE_REMOVE`, which was the only mode that wasn't working as intended previously.

I suspect this also fixes a more general issue with areas, where if you destroyed an area it wouldn't report its overlapping bodies/areas as having exited.