### PR TITLE
Added support for scaling bodies

### DIFF
--- a/src/jolt_area_3d.cpp
+++ b/src/jolt_area_3d.cpp
@@ -175,7 +175,7 @@ Vector3 JoltArea3D::compute_gravity(const Vector3& p_position, bool p_lock) {
 		return gravity_vector * gravity;
 	}
 
-	const Vector3 point = get_transform(p_lock).xform(gravity_vector);
+	const Vector3 point = get_transform_scaled(p_lock).xform(gravity_vector);
 	const Vector3 to_point = point - p_position;
 	const float to_point_dist_sq = max(to_point.length_squared(), CMP_EPSILON);
 	const Vector3 to_point_dir = to_point / Math::sqrt(to_point_dist_sq);

--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -45,7 +45,7 @@ JoltBody3D::~JoltBody3D() {
 Variant JoltBody3D::get_state(PhysicsServer3D::BodyState p_state) {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
-			return get_transform();
+			return get_transform_scaled();
 		}
 		case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY: {
 			return get_linear_velocity();

--- a/src/jolt_collision_object_3d.hpp
+++ b/src/jolt_collision_object_3d.hpp
@@ -41,15 +41,21 @@ public:
 
 	void set_collision_mask(uint32_t p_mask, bool p_lock = true);
 
-	Transform3D get_transform(bool p_lock = true) const;
+	Transform3D get_transform_unscaled(bool p_lock = true) const;
+
+	Transform3D get_transform_scaled(bool p_lock = true) const;
 
 	void set_transform(Transform3D p_transform, bool p_lock = true);
+
+	Vector3 get_scale() const { return scale; }
 
 	Basis get_basis(bool p_lock = true) const;
 
 	Vector3 get_position(bool p_lock = true) const;
 
 	Vector3 get_center_of_mass(bool p_lock = true) const;
+
+	Vector3 get_center_of_mass_local(bool p_lock = true) const;
 
 	Vector3 get_linear_velocity(bool p_lock = true) const;
 
@@ -92,7 +98,7 @@ public:
 
 	JoltShape3D* find_shape(const JPH::SubShapeID& p_sub_shape_id) const;
 
-	Transform3D get_shape_transform(int32_t p_index) const;
+	Transform3D get_shape_transform_unscaled(int32_t p_index) const;
 
 	Transform3D get_shape_transform_scaled(int32_t p_index) const;
 
@@ -168,6 +174,8 @@ protected:
 	uint32_t collision_layer = 1;
 
 	uint32_t collision_mask = 1;
+
+	Vector3 scale = {1.0f, 1.0f, 1.0f};
 
 	LocalVector<JoltShapeInstance3D> shapes;
 

--- a/src/jolt_cone_twist_joint_3d.cpp
+++ b/src/jolt_cone_twist_joint_3d.cpp
@@ -29,15 +29,21 @@ JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();
-	const JPH::Shape& jolt_shape_b = *jolt_body_b->GetShape();
+	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+
+	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
+	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
+
+	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
+	const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
 
 	JPH::SwingTwistConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPosition1 = to_jolt(p_local_ref_a.origin) - jolt_shape_a.GetCenterOfMass();
+	constraint_settings.mPosition1 = point_scaled_a - com_scaled_a;
 	constraint_settings.mTwistAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPosition2 = to_jolt(p_local_ref_b.origin) - jolt_shape_b.GetCenterOfMass();
+	constraint_settings.mPosition2 = point_scaled_b - com_scaled_b;
 	constraint_settings.mTwistAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
 
@@ -57,14 +63,19 @@ JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();
+	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+
+	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
+	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);
+
+	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
 
 	JPH::SwingTwistConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPosition1 = to_jolt(p_local_ref_a.origin) - jolt_shape_a.GetCenterOfMass();
+	constraint_settings.mPosition1 = point_scaled_a - com_scaled_a;
 	constraint_settings.mTwistAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPosition2 = to_jolt(p_local_ref_b.origin);
+	constraint_settings.mPosition2 = point_scaled_b;
 	constraint_settings.mTwistAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
 

--- a/src/jolt_generic_6dof_joint_3d.cpp
+++ b/src/jolt_generic_6dof_joint_3d.cpp
@@ -33,13 +33,10 @@ JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
 	[[maybe_unused]] const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a, p_body_b) {
-	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
-	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
-
-	world_ref = body_a->get_transform(false) * p_local_ref_a;
-
-	rebuild(false);
+	: JoltJoint3D(p_space, p_body_a, p_body_b)
+	, world_ref(body_a->get_transform_scaled(p_lock) * p_local_ref_a) {
+	world_ref.orthonormalize();
+	rebuild(p_lock);
 }
 
 JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
@@ -51,10 +48,7 @@ JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
 )
 	: JoltJoint3D(p_space, p_body_a)
 	, world_ref(p_local_ref_b) {
-	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
-	ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-	rebuild(false);
+	rebuild(p_lock);
 }
 
 double JoltGeneric6DOFJoint3D::get_param(

--- a/src/jolt_hinge_joint_3d.cpp
+++ b/src/jolt_hinge_joint_3d.cpp
@@ -30,15 +30,21 @@ JoltHingeJoint3D::JoltHingeJoint3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();
-	const JPH::Shape& jolt_shape_b = *jolt_body_b->GetShape();
+	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+
+	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
+	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
+
+	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
+	const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
 
 	JPH::HingeConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = to_jolt(p_local_ref_a.origin) - jolt_shape_a.GetCenterOfMass();
+	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
 	constraint_settings.mHingeAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mNormalAxis1 = to_jolt(p_local_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mPoint2 = to_jolt(p_local_ref_b.origin) - jolt_shape_b.GetCenterOfMass();
+	constraint_settings.mPoint2 = point_scaled_b - com_scaled_b;
 	constraint_settings.mHingeAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mNormalAxis2 = to_jolt(p_local_ref_b.basis.get_column(Vector3::AXIS_X));
 
@@ -58,14 +64,19 @@ JoltHingeJoint3D::JoltHingeJoint3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();
+	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+
+	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
+	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);
+
+	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
 
 	JPH::HingeConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = to_jolt(p_local_ref_a.origin) - jolt_shape_a.GetCenterOfMass();
+	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
 	constraint_settings.mHingeAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mNormalAxis1 = to_jolt(p_local_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mPoint2 = to_jolt(p_local_ref_b.origin);
+	constraint_settings.mPoint2 = point_scaled_b;
 	constraint_settings.mHingeAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mNormalAxis2 = to_jolt(p_local_ref_b.basis.get_column(Vector3::AXIS_X));
 

--- a/src/jolt_physics_direct_body_state_3d.cpp
+++ b/src/jolt_physics_direct_body_state_3d.cpp
@@ -29,7 +29,7 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass() const {
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass_local() const {
 	QUIET_FAIL_NULL_D_ED(body);
-	return body->get_transform().xform_inv(body->get_center_of_mass());
+	return body->get_center_of_mass_local();
 }
 
 Basis JoltPhysicsDirectBodyState3D::_get_principal_inertia_axes() const {
@@ -79,7 +79,7 @@ void JoltPhysicsDirectBodyState3D::_set_transform(const Transform3D& p_transform
 
 Transform3D JoltPhysicsDirectBodyState3D::_get_transform() const {
 	QUIET_FAIL_NULL_D_ED(body);
-	return body->get_transform();
+	return body->get_transform_scaled();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_velocity_at_local_position(

--- a/src/jolt_physics_direct_space_state_3d.hpp
+++ b/src/jolt_physics_direct_space_state_3d.hpp
@@ -127,6 +127,7 @@ private:
 	bool body_motion_cast(
 		const JoltBody3D& p_body,
 		const Transform3D& p_transform,
+		const Vector3& p_scale,
 		const Vector3& p_motion,
 		bool p_collide_separation_ray,
 		float& p_safe_fraction,

--- a/src/jolt_physics_server_3d.cpp
+++ b/src/jolt_physics_server_3d.cpp
@@ -394,7 +394,7 @@ Transform3D JoltPhysicsServer3D::_area_get_transform(const RID& p_area) const {
 	JoltArea3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
-	return area->get_transform();
+	return area->get_transform_scaled();
 }
 
 void JoltPhysicsServer3D::_area_set_collision_mask(const RID& p_area, uint32_t p_mask) {

--- a/src/jolt_shape_3d.cpp
+++ b/src/jolt_shape_3d.cpp
@@ -34,12 +34,6 @@ JPH::ShapeRefC JoltShape3D::try_build() {
 	return jolt_ref;
 }
 
-Vector3 JoltShape3D::get_center_of_mass() const {
-	ERR_FAIL_NULL_D(jolt_ref);
-
-	return to_godot(jolt_ref->GetCenterOfMass());
-}
-
 JPH::ShapeRefC JoltShape3D::with_scale(const JPH::Shape* p_shape, const Vector3& p_scale) {
 	ERR_FAIL_NULL_D(p_shape);
 

--- a/src/jolt_shape_3d.hpp
+++ b/src/jolt_shape_3d.hpp
@@ -34,8 +34,6 @@ public:
 
 	const JPH::Shape* get_jolt_ref() const { return jolt_ref; }
 
-	Vector3 get_center_of_mass() const;
-
 	static JPH::ShapeRefC with_scale(const JPH::Shape* p_shape, const Vector3& p_scale);
 
 	static JPH::ShapeRefC with_basis_origin(

--- a/src/jolt_shape_instance_3d.hpp
+++ b/src/jolt_shape_instance_3d.hpp
@@ -25,7 +25,7 @@ public:
 
 	const JPH::Shape* get_jolt_ref() const { return jolt_ref; }
 
-	const Transform3D& get_transform() const { return transform; }
+	const Transform3D& get_transform_unscaled() const { return transform; }
 
 	Transform3D get_transform_scaled() const { return transform.scaled_local(scale); }
 

--- a/src/jolt_slider_joint_3d.cpp
+++ b/src/jolt_slider_joint_3d.cpp
@@ -52,16 +52,22 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();
-	const JPH::Shape& jolt_shape_b = *jolt_body_b->GetShape();
+	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+
+	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
+	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
+
+	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
+	const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
 
 	JPH::SliderConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = to_jolt(p_local_ref_a.origin) - jolt_shape_a.GetCenterOfMass();
+	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
 	constraint_settings.mSliderAxis1 = to_jolt(p_local_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mNormalAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPoint2 = to_jolt(p_local_ref_b.origin) - jolt_shape_b.GetCenterOfMass();
+	constraint_settings.mPoint2 = point_scaled_b - com_scaled_b;
 	constraint_settings.mSliderAxis2 = to_jolt(p_local_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mNormalAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
 
@@ -81,15 +87,20 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JPH::Shape& jolt_shape_a = *jolt_body_a->GetShape();
+	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+
+	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
+	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);
+
+	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
 
 	JPH::SliderConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = to_jolt(p_local_ref_a.origin) - jolt_shape_a.GetCenterOfMass();
+	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
 	constraint_settings.mSliderAxis1 = to_jolt(p_local_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mNormalAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPoint2 = to_jolt(p_local_ref_b.origin);
+	constraint_settings.mPoint2 = point_scaled_b;
 	constraint_settings.mSliderAxis2 = to_jolt(p_local_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mNormalAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
 


### PR DESCRIPTION
I had been under the impression that Godot Physics ignored scaling on all types of bodies, and I had therefore discarded the body's scale completely in #252. This turned out to not be true. Godot Physics only seems to ignore scaling on `RigidBody3D`, so I did a bit of refactoring to accommodate for body scaling as well.

This does add support for scaling _all_ types of bodies, including `RigidBody3D`, although I can't speak to the soundness of actually using it on `RigidBody3D`. Considering that Godot Physics doesn't support it I wouldn't be surprised if some issues arose within the actual node. Either way, Godot will still emit a node configuration warning when you try to scale a `RigidBody3D`, which is the price we have to pay for piggybacking on the default node types I guess.