### PR TITLE
Added logging of Jolt errors

### DIFF
--- a/src/jolt_body_3d.cpp
+++ b/src/jolt_body_3d.cpp
@@ -988,6 +988,7 @@ void JoltBody3D::create_in_space() {
 	jolt_settings->mMassPropertiesOverride = calculate_mass_properties(*jolt_settings->GetShape());
 
 	JPH::Body* body = create_end();
+	ERR_FAIL_NULL(body);
 
 	// HACK(mihe): Since group filters don't grant us access to user data we are instead forced
 	// abuse the collision group to carry the upper and lower bits of our RID, which we can then

--- a/src/jolt_body_accessor_3d.cpp
+++ b/src/jolt_body_accessor_3d.cpp
@@ -111,6 +111,7 @@ JoltBodyReader3D::JoltBodyReader3D(const JoltSpace3D* p_space)
 	: JoltBodyAccessor3D(p_space) { }
 
 const JPH::Body* JoltBodyReader3D::try_get(const JPH::BodyID& p_id) const {
+	ERR_FAIL_COND_D(p_id.IsInvalid());
 	ERR_FAIL_COND_D(not_acquired());
 	return lock_iface->TryGetBody(p_id);
 }
@@ -138,6 +139,7 @@ JoltBodyWriter3D::JoltBodyWriter3D(const JoltSpace3D* p_space)
 	: JoltBodyAccessor3D(p_space) { }
 
 JPH::Body* JoltBodyWriter3D::try_get(const JPH::BodyID& p_id) const {
+	ERR_FAIL_COND_D(p_id.IsInvalid());
 	ERR_FAIL_COND_D(not_acquired());
 	return lock_iface->TryGetBody(p_id);
 }

--- a/src/jolt_collision_object_3d.cpp
+++ b/src/jolt_collision_object_3d.cpp
@@ -469,14 +469,15 @@ JPH::Body* JoltCollisionObject3D::create_end() {
 	JPH::BodyInterface& body_iface = space->get_body_iface(false);
 	JPH::Body* body = body_iface.CreateBody(*jolt_settings);
 
-	if (unlikely(body == nullptr)) {
-		CRASH_NOW_MSG(vformat(
+	ERR_FAIL_NULL_D_MSG(
+		body,
+		vformat(
 			"Failed to create Jolt body. "
-			"Consider increasing maximum number of bodies. "
+			"Consider increasing maximum number of bodies in project settings. "
 			"Maximum number of bodies is currently set to %d.",
 			JoltProjectSettings::get_max_bodies()
-		));
-	}
+		)
+	);
 
 	body->SetUserData(reinterpret_cast<JPH::uint64>(this));
 

--- a/src/jolt_job_system.cpp
+++ b/src/jolt_job_system.cpp
@@ -102,9 +102,8 @@ JPH::JobHandle JoltJobSystem::CreateJob(
 		}
 
 		WARN_PRINT_ONCE(
-			"Job system exceeded maximum number of jobs. "
-			"Waiting for jobs to become available. "
-			"Consider increasing maximum number of jobs."
+			"Godot Jolt's job system exceeded maximum number of jobs. This should not happen. "
+			"Waiting for jobs to become available."
 		);
 
 		OS::get_singleton()->delay_usec(100);

--- a/src/jolt_space_3d.cpp
+++ b/src/jolt_space_3d.cpp
@@ -67,7 +67,38 @@ void JoltSpace3D::step(float p_step) {
 
 	pre_step(p_step);
 
-	physics_system->Update(p_step, 1, 1, temp_allocator, job_system);
+	switch (physics_system->Update(p_step, 1, 1, temp_allocator, job_system)) {
+		case JPH::EPhysicsUpdateError::None: {
+			// All good!
+		} break;
+
+		case JPH::EPhysicsUpdateError::ManifoldCacheFull: {
+			WARN_PRINT_ONCE(vformat(
+				"Jolt's manifold cache exceeded capacity and contacts were ignored. "
+				"Consider increasing maximum number of contact constraints in project settings. "
+				"Maximum number of contact constraints is currently set to %d.",
+				JoltProjectSettings::get_max_contact_constraints()
+			));
+		} break;
+
+		case JPH::EPhysicsUpdateError::BodyPairCacheFull: {
+			WARN_PRINT_ONCE(vformat(
+				"Jolt's body pair cache exceeded capacity and contacts were ignored. "
+				"Consider increasing maximum number of body pairs in project settings. "
+				"Maximum number of body pairs is currently set to %d.",
+				JoltProjectSettings::get_max_body_pairs()
+			));
+		} break;
+
+		case JPH::EPhysicsUpdateError::ContactConstraintsFull: {
+			WARN_PRINT_ONCE(vformat(
+				"Jolt's contact constraint buffer exceeded capacity and contacts were ignored. "
+				"Consider increasing maximum number of contact constraints in project settings. "
+				"Maximum number of contact constraints is currently set to %d.",
+				JoltProjectSettings::get_max_contact_constraints()
+			));
+		} break;
+	}
 
 	post_step(p_step);
 

--- a/src/jolt_temp_allocator.hpp
+++ b/src/jolt_temp_allocator.hpp
@@ -25,9 +25,9 @@ public:
 			ptr = base + top;
 		} else {
 			WARN_PRINT_ONCE(vformat(
-				"Temporary memory allocator exceeded capacity of %d MiB. "
+				"Godot Jolt's temporary memory allocator exceeded capacity of %d MiB. "
 				"Falling back to slower general-purpose allocator. "
-				"Consider increasing maximum temporary memory. ",
+				"Consider increasing maximum temporary memory in project settings.",
 				JoltProjectSettings::get_max_temp_memory_mib()
 			));
 


### PR DESCRIPTION
This makes use of the newly introduced `JPH::EPhysicsUpdateError` that allows for emitting log messages when some of Jolt's limits were hit, like the maximum number of contact constraints or maximum number of body pairs, as specified in the project settings.

I took the opportunity to modify some of the existing log messages as well changing the `CRASH_NOW` that happens when you exceed the maximum number of bodies to instead be `ERR_FAIL`. It's likely that it'll crash somewhere else anyway, but at least now we give it a fighting chance, which is important since this can technically happen while we're working in the editor.