### PR TITLE
Fixed stale references when changing the space of an area

### DIFF
--- a/src/objects/jolt_area_3d.hpp
+++ b/src/objects/jolt_area_3d.hpp
@@ -169,11 +169,11 @@ private:
 
 	void force_bodies_entered();
 
-	void force_bodies_exited();
+	void force_bodies_exited(bool p_remove);
 
 	void force_areas_entered();
 
-	void force_areas_exited();
+	void force_areas_exited(bool p_remove);
 
 	void add_shape_pair(
 		Overlap& p_overlap,
@@ -198,6 +198,10 @@ private:
 		int32_t p_other_shape_index,
 		int32_t p_self_shape_index
 	) const;
+
+	void notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock = true);
+
+	void notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock = true);
 
 	bool monitorable = false;
 

--- a/src/objects/jolt_body_3d.cpp
+++ b/src/objects/jolt_body_3d.cpp
@@ -630,18 +630,18 @@ TypedArray<RID> JoltBody3D::get_collision_exceptions(bool p_lock) const {
 	return result;
 }
 
-void JoltBody3D::add_area(JoltArea3D* p_area) {
+void JoltBody3D::add_area(JoltArea3D* p_area, bool p_lock) {
 	areas.ordered_insert(p_area, [](JoltArea3D* p_lhs, JoltArea3D* p_rhs) {
 		return p_lhs->get_priority() > p_rhs->get_priority();
 	});
 
-	areas_changed();
+	areas_changed(p_lock);
 }
 
-void JoltBody3D::remove_area(JoltArea3D* p_area) {
+void JoltBody3D::remove_area(JoltArea3D* p_area, bool p_lock) {
 	areas.erase(p_area);
 
-	areas_changed();
+	areas_changed(p_lock);
 }
 
 void JoltBody3D::integrate_forces(float p_step, bool p_lock) {

--- a/src/objects/jolt_body_3d.hpp
+++ b/src/objects/jolt_body_3d.hpp
@@ -142,9 +142,9 @@ public:
 
 	TypedArray<RID> get_collision_exceptions(bool p_lock = true) const;
 
-	void add_area(JoltArea3D* p_area);
+	void add_area(JoltArea3D* p_area, bool p_lock = true);
 
-	void remove_area(JoltArea3D* p_area);
+	void remove_area(JoltArea3D* p_area, bool p_lock = true);
 
 	void integrate_forces(float p_step, bool p_lock = true);
 


### PR DESCRIPTION
Related to #274.

When an area was moved between (or out of) spaces it would only notify the monitor callback that its overlapping bodies/areas were exiting but not actually remove them internally nor report the disconnect to any of its overlapping bodies. This fixes all that.