### PR TITLE
Reordered class/struct members to reduce padding

### DIFF
--- a/src/joints/jolt_generic_6dof_joint_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.hpp
@@ -60,9 +60,7 @@ public:
 private:
 	void rebuild(bool p_lock = true);
 
-	bool use_limits[AXIS_COUNT] = {};
-
-	bool motor_enabled[AXIS_COUNT] = {};
+	Transform3D world_ref;
 
 	double limit_lower[AXIS_COUNT] = {};
 
@@ -72,5 +70,7 @@ private:
 
 	double motor_limit[AXIS_COUNT] = {};
 
-	Transform3D world_ref;
+	bool use_limits[AXIS_COUNT] = {};
+
+	bool motor_enabled[AXIS_COUNT] = {};
 };

--- a/src/objects/jolt_area_3d.hpp
+++ b/src/objects/jolt_area_3d.hpp
@@ -36,15 +36,15 @@ class JoltArea3D final : public JoltCollisionObject3D {
 	};
 
 	struct Overlap {
-		ObjectID instance_id;
-
-		RID rid;
-
-		InlineVector<ShapeIndexPair, 1> pending_removed;
+		HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair> shape_pairs;
 
 		InlineVector<ShapeIndexPair, 1> pending_added;
 
-		HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair> shape_pairs;
+		InlineVector<ShapeIndexPair, 1> pending_removed;
+
+		RID rid;
+
+		ObjectID instance_id;
 	};
 
 	using OverlapsById = HashMap<JPH::BodyID, Overlap, BodyIDHasher>;
@@ -203,9 +203,15 @@ private:
 
 	void monitorable_changed(bool p_lock = true);
 
-	bool monitorable = false;
+	OverlapsById bodies_by_id;
 
-	bool point_gravity = false;
+	OverlapsById areas_by_id;
+
+	Vector3 gravity_vector = {0, -1, 0};
+
+	Callable body_monitor_callback;
+
+	Callable area_monitor_callback;
 
 	float priority = 0.0f;
 
@@ -223,13 +229,7 @@ private:
 
 	OverrideMode angular_damp_mode = PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED;
 
-	Vector3 gravity_vector = {0, -1, 0};
+	bool monitorable = false;
 
-	Callable body_monitor_callback;
-
-	Callable area_monitor_callback;
-
-	OverlapsById bodies_by_id;
-
-	OverlapsById areas_by_id;
+	bool point_gravity = false;
 };

--- a/src/objects/jolt_body_3d.hpp
+++ b/src/objects/jolt_body_3d.hpp
@@ -257,31 +257,13 @@ private:
 
 	void axis_lock_changed(bool p_lock = true);
 
-	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
-
-	DampMode linear_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
-
-	DampMode angular_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
-
-	float mass = 1.0f;
-
-	Vector3 inertia;
-
-	float linear_damp = 0.0f;
-
-	float angular_damp = 0.0f;
-
-	float collision_priority = 1.0f;
-
-	bool custom_center_of_mass = false;
-
-	uint32_t locked_axes = 0;
-
-	int32_t contact_count = 0;
-
 	LocalVector<Contact> contacts;
 
 	LocalVector<JoltArea3D*> areas;
+
+	Variant force_integration_userdata;
+
+	Vector3 inertia;
 
 	Vector3 center_of_mass_custom;
 
@@ -295,9 +277,27 @@ private:
 
 	Callable force_integration_callback;
 
-	Variant force_integration_userdata;
-
 	JoltPhysicsDirectBodyState3D* direct_state = nullptr;
 
 	JPH::Ref<JPH::Constraint> axes_constraint;
+
+	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
+
+	DampMode linear_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
+
+	DampMode angular_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
+
+	float mass = 1.0f;
+
+	float linear_damp = 0.0f;
+
+	float angular_damp = 0.0f;
+
+	float collision_priority = 1.0f;
+
+	int32_t contact_count = 0;
+
+	uint32_t locked_axes = 0;
+
+	bool custom_center_of_mass = false;
 };

--- a/src/objects/jolt_collision_object_3d.hpp
+++ b/src/objects/jolt_collision_object_3d.hpp
@@ -159,11 +159,15 @@ protected:
 
 	virtual void transform_changed([[maybe_unused]] bool p_lock = true) { }
 
+	LocalVector<JoltShapeInstance3D> shapes;
+
+	Vector3 scale = {1.0f, 1.0f, 1.0f};
+
 	RID rid;
 
 	ObjectID instance_id;
 
-	JPH::BodyID jolt_id;
+	JoltSpace3D* space = nullptr;
 
 	JPH::BodyCreationSettings* jolt_settings = new JPH::BodyCreationSettings();
 
@@ -171,15 +175,11 @@ protected:
 
 	JPH::ShapeRefC previous_jolt_shape;
 
-	JoltSpace3D* space = nullptr;
+	JPH::BodyID jolt_id;
 
 	uint32_t collision_layer = 1;
 
 	uint32_t collision_mask = 1;
-
-	Vector3 scale = {1.0f, 1.0f, 1.0f};
-
-	LocalVector<JoltShapeInstance3D> shapes;
 
 	bool ray_pickable = false;
 };

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -568,14 +568,6 @@ public:
 	JoltJoint3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
 
 private:
-	bool active = true;
-
-	bool flushing_queries = false;
-
-	JoltJobSystem* job_system = nullptr;
-
-	HashSet<JoltSpace3D*> active_spaces;
-
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 
 	mutable RID_PtrOwner<JoltArea3D> area_owner;
@@ -585,4 +577,12 @@ private:
 	mutable RID_PtrOwner<JoltShape3D> shape_owner;
 
 	mutable RID_PtrOwner<JoltJoint3D> joint_owner;
+
+	HashSet<JoltSpace3D*> active_spaces;
+
+	JoltJobSystem* job_system = nullptr;
+
+	bool active = true;
+
+	bool flushing_queries = false;
 };

--- a/src/shapes/jolt_ray_shape.hpp
+++ b/src/shapes/jolt_ray_shape.hpp
@@ -11,17 +11,17 @@ public:
 		bool p_slide_on_slope,
 		const JPH::PhysicsMaterial* p_material = nullptr
 	)
-		: slide_on_slope(p_slide_on_slope)
+		: material(p_material)
 		, length(p_length)
-		, material(p_material) { }
+		, slide_on_slope(p_slide_on_slope) { }
 
 	JPH::ShapeSettings::ShapeResult Create() const override;
 
-	bool slide_on_slope = false;
+	JPH::RefConst<JPH::PhysicsMaterial> material;
 
 	float length = 1.0f;
 
-	JPH::RefConst<JPH::PhysicsMaterial> material;
+	bool slide_on_slope = false;
 };
 
 class JoltRayShape final : public JPH::ConvexShape {
@@ -33,9 +33,9 @@ public:
 
 	JoltRayShape(const JoltRayShapeSettings& p_settings, JPH::Shape::ShapeResult& p_result)
 		: JPH::ConvexShape(JoltShapeSubType::RAY, p_settings, p_result)
-		, slide_on_slope(p_settings.slide_on_slope)
+		, material(p_settings.material)
 		, length(p_settings.length)
-		, material(p_settings.material) {
+		, slide_on_slope(p_settings.slide_on_slope) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);
 		}
@@ -47,9 +47,9 @@ public:
 		const JPH::PhysicsMaterial* p_material = nullptr
 	)
 		: JPH::ConvexShape(JoltShapeSubType::RAY)
-		, slide_on_slope(p_slide_on_slope)
+		, material(p_material)
 		, length(p_length)
-		, material(p_material) { }
+		, slide_on_slope(p_slide_on_slope) { }
 
 	JPH::AABox GetLocalBounds() const override;
 
@@ -130,9 +130,9 @@ public:
 		JPH::Vec3Arg p_scale
 	) const override;
 
-	bool slide_on_slope = false;
+	JPH::RefConst<JPH::PhysicsMaterial> material;
 
 	float length = 0.0f;
 
-	JPH::RefConst<JPH::PhysicsMaterial> material;
+	bool slide_on_slope = false;
 };

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -70,11 +70,11 @@ protected:
 
 	virtual void invalidated(bool p_lock = true);
 
+	HashMap<JoltCollisionObject3D*, int32_t> ref_counts_by_owner;
+
 	RID rid;
 
 	JPH::ShapeRefC jolt_ref;
-
-	HashMap<JoltCollisionObject3D*, int32_t> ref_counts_by_owner;
 };
 
 class JoltWorldBoundaryShape3D final : public JoltShape3D {

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -110,19 +110,19 @@ private:
 	void add_debug_contacts(const JPH::ContactManifold& p_manifold);
 #endif // DEBUG_ENABLED
 
-	JoltSpace3D* space = nullptr;
-
-	Mutex write_mutex;
+	ManifoldsByShapePair manifolds_by_shape_pair;
 
 	BodyIDs listening_for;
-
-	ManifoldsByShapePair manifolds_by_shape_pair;
 
 	Overlaps area_overlaps;
 
 	Overlaps area_enters;
 
 	Overlaps area_exits;
+
+	Mutex write_mutex;
+
+	JoltSpace3D* space = nullptr;
 
 #ifdef DEBUG_ENABLED
 	PackedVector3Array debug_contacts;

--- a/src/spaces/jolt_debug_geometry_3d.cpp
+++ b/src/spaces/jolt_debug_geometry_3d.cpp
@@ -82,8 +82,8 @@ void JoltDebugGeometry3D::_bind_methods() {
 #ifdef JPH_DEBUG_RENDERER
 
 JoltDebugGeometry3D::JoltDebugGeometry3D()
-	: debug_renderer(JoltDebugRenderer3D::acquire())
-	, mesh(RenderingServer::get_singleton()->mesh_create()) {
+	: mesh(RenderingServer::get_singleton()->mesh_create())
+	, debug_renderer(JoltDebugRenderer3D::acquire()) {
 	set_base(mesh);
 
 	set_cast_shadows_setting(GeometryInstance3D::SHADOW_CASTING_SETTING_OFF);

--- a/src/spaces/jolt_debug_geometry_3d.hpp
+++ b/src/spaces/jolt_debug_geometry_3d.hpp
@@ -75,13 +75,13 @@ public:
 
 private:
 #ifdef JPH_DEBUG_RENDERER
-	JoltDebugRenderer3D* debug_renderer = nullptr;
+	JoltDebugRenderer3D::DrawSettings draw_settings;
 
 	RID mesh;
 
-	Ref<StandardMaterial3D> default_material;
+	JoltDebugRenderer3D* debug_renderer = nullptr;
 
-	JoltDebugRenderer3D::DrawSettings draw_settings;
+	Ref<StandardMaterial3D> default_material;
 #endif // JPH_DEBUG_RENDERER
 };
 

--- a/src/spaces/jolt_debug_renderer_3d.hpp
+++ b/src/spaces/jolt_debug_renderer_3d.hpp
@@ -7,6 +7,8 @@ class JoltSpace3D;
 class JoltDebugRenderer3D final : public JPH::DebugRenderer {
 public:
 	struct DrawSettings {
+		JPH::BodyManager::EShapeColor color_scheme = JPH::BodyManager::EShapeColor::ShapeTypeColor;
+
 		bool draw_bodies = true;
 
 		bool draw_shapes = true;
@@ -26,8 +28,6 @@ public:
 		bool draw_constraint_limits = false;
 
 		bool draw_as_wireframe = true;
-
-		JPH::BodyManager::EShapeColor color_scheme = JPH::BodyManager::EShapeColor::ShapeTypeColor;
 	};
 
 	static JoltDebugRenderer3D* acquire();
@@ -97,13 +97,9 @@ private:
 
 	inline static int32_t ref_count = 0;
 
-	int32_t triangle_capacity = 0;
+	AABB triangles_aabb;
 
-	int32_t triangle_count = 0;
-
-	int32_t line_capacity = 0;
-
-	int32_t line_count = 0;
+	AABB lines_aabb;
 
 	PackedByteArray triangle_vertices;
 
@@ -113,11 +109,15 @@ private:
 
 	PackedByteArray line_attributes;
 
-	AABB triangles_aabb;
-
-	AABB lines_aabb;
-
 	JPH::Vec3 camera_position = {0, 0, 0};
+
+	int32_t triangle_capacity = 0;
+
+	int32_t triangle_count = 0;
+
+	int32_t line_capacity = 0;
+
+	int32_t line_count = 0;
 };
 
 #endif // JPH_DEBUG_RENDERER

--- a/src/spaces/jolt_job_system.hpp
+++ b/src/spaces/jolt_job_system.hpp
@@ -40,9 +40,9 @@ private:
 
 		inline static std::atomic<Job*> completed_head = nullptr;
 
-		std::atomic<Job*> completed_next = nullptr;
-
 		int64_t task_id = -1;
+
+		std::atomic<Job*> completed_next = nullptr;
 	};
 
 	int GetMaxConcurrency() const override;

--- a/src/spaces/jolt_layer_mapper.hpp
+++ b/src/spaces/jolt_layer_mapper.hpp
@@ -39,11 +39,11 @@ private:
 	bool ShouldCollide(JPH::ObjectLayer p_encoded_layer1, JPH::BroadPhaseLayer p_broad_phase_layer2)
 		const override;
 
-	JPH::ObjectLayer next_object_layer = 1;
-
 	HashMap<uint64_t, JPH::ObjectLayer> layers_by_collision;
 
 	HashMap<JPH::ObjectLayer, uint64_t> collisions_by_layer;
 
 	mutable Mutex collisions_mutex;
+
+	JPH::ObjectLayer next_object_layer = 1;
 };

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -22,12 +22,12 @@ constexpr double DEFAULT_SOLVER_ITERATIONS = 8;
 } // namespace
 
 JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
-	: job_system(p_job_system)
+	: body_accessor(this)
+	, job_system(p_job_system)
 	, temp_allocator(new JoltTempAllocator())
 	, layer_mapper(new JoltLayerMapper())
 	, contact_listener(new JoltContactListener3D(this))
-	, physics_system(new JPH::PhysicsSystem())
-	, body_accessor(this) {
+	, physics_system(new JPH::PhysicsSystem()) {
 	physics_system->Init(
 		(JPH::uint)JoltProjectSettings::get_max_bodies(),
 		0,

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -103,6 +103,8 @@ private:
 
 	void post_step(float p_step);
 
+	JoltBodyWriter3D body_accessor;
+
 	RID rid;
 
 	JPH::JobSystem* job_system = nullptr;
@@ -114,8 +116,6 @@ private:
 	JoltContactListener3D* contact_listener = nullptr;
 
 	JPH::PhysicsSystem* physics_system = nullptr;
-
-	JoltBodyWriter3D body_accessor;
 
 	JoltPhysicsDirectSpaceState3D* direct_state = nullptr;
 


### PR DESCRIPTION
This reorders any class/struct members from largest to smallest in an effort to minimize any padding that might arise inbetween them. It doesn't do a perfect job, but it does shave off a couple of bytes here and there.