### PR TITLE
Added compile definitions for the various configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,9 @@ target_link_libraries(godot-jolt
 
 set(is_editor_config $<CONFIG:EditorDebug,EditorDevelopment,EditorDistribution>)
 set(is_debug_config $<CONFIG:Debug,EditorDebug>)
-set(is_optimized_config $<CONFIG:Development,Distribution,EditorDevelopment,EditorDistribution>)
+set(is_development_config $<CONFIG:Development,EditorDevelopment>)
 set(is_distribution_config $<CONFIG:Distribution,EditorDistribution>)
+set(is_optimized_config $<OR:${is_development_config},${is_distribution_config}>)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
 	set(suffix_platform -windows)
@@ -95,6 +96,10 @@ target_compile_features(godot-jolt
 
 target_compile_definitions(godot-jolt
 	PRIVATE $<IF:${is_debug_config},_DEBUG,NDEBUG>
+	PRIVATE $<${is_debug_config}:GJ_CONFIG_DEBUG>
+	PRIVATE $<${is_development_config}:GJ_CONFIG_DEVELOPMENT>
+	PRIVATE $<${is_distribution_config}:GJ_CONFIG_DISTRIBUTION>
+	PRIVATE $<${is_editor_config}:GJ_CONFIG_EDITOR>
 )
 
 if(GJ_PRECOMPILE_HEADERS)

--- a/src/misc/error_macros.hpp
+++ b/src/misc/error_macros.hpp
@@ -59,7 +59,7 @@
 #define QUIET_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval) QUIET_FAIL_COND_V((m_index) >= (m_size), m_retval)
 #define QUIET_FAIL_UNSIGNED_INDEX_D(m_index, m_size) QUIET_FAIL_UNSIGNED_INDEX_V(m_index, m_size, {})
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 
 #define QUIET_FAIL_COND_D_ED(m_cond, m_retval) QUIET_FAIL_COND_D(m_cond, m_retval)
 #define QUIET_FAIL_NULL_ED(m_param) QUIET_FAIL_NULL(m_param)
@@ -74,7 +74,7 @@
 #define QUIET_BREAK_ED(m_cond) QUIET_BREAK(m_cond)
 #define QUIET_CONTINUE_ED(m_cond) QUIET_CONTINUE(m_cond)
 
-#else // DEBUG_ENABLED
+#else // GJ_CONFIG_EDITOR
 
 #define QUIET_FAIL_COND_D_ED(m_cond, m_retval)
 #define QUIET_FAIL_NULL_ED(m_param)
@@ -89,4 +89,4 @@
 #define QUIET_BREAK_ED(m_cond)
 #define QUIET_CONTINUE_ED(m_cond)
 
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -189,35 +189,35 @@ void JoltPhysicsServer3D::_space_set_debug_contacts(
 	[[maybe_unused]] const RID& p_space,
 	[[maybe_unused]] int32_t p_max_contacts
 ) {
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
 	space->set_max_debug_contacts(p_max_contacts);
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 }
 
 PackedVector3Array JoltPhysicsServer3D::_space_get_contacts([[maybe_unused]] const RID& p_space
 ) const {
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_D(space);
 
 	return space->get_debug_contacts();
-#else // DEBUG_ENABLED
+#else // GJ_CONFIG_EDITOR
 	return {};
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 }
 
 int32_t JoltPhysicsServer3D::_space_get_contact_count([[maybe_unused]] const RID& p_space) const {
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_D(space);
 
 	return space->get_debug_contact_count();
-#else // DEBUG_ENABLED
+#else // GJ_CONFIG_EDITOR
 	return 0;
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 }
 
 RID JoltPhysicsServer3D::_area_create() {
@@ -988,14 +988,14 @@ PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(const RID&
 }
 
 RID JoltPhysicsServer3D::_soft_body_create() {
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	// HACK(mihe): The editor needs to have a usable body in order for the documentation generation
 	// to not emit errors when doing stuff like attaching instance IDs, so we just give it a regular
 	// body instead.
 	return _body_create();
-#else // DEBUG_ENABLED
+#else // GJ_CONFIG_EDITOR
 	ERR_FAIL_D_MSG("SoftBody3D is not supported by Godot Jolt.");
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 }
 
 void JoltPhysicsServer3D::_soft_body_update_rendering_server(

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -23,9 +23,9 @@ void JoltContactListener3D::listen_for(JoltCollisionObject3D* p_object) {
 void JoltContactListener3D::pre_step() {
 	listening_for.clear();
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	debug_contact_count = 0;
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 }
 
 void JoltContactListener3D::post_step() {
@@ -41,9 +41,9 @@ void JoltContactListener3D::OnContactAdded(
 	const JPH::ContactManifold& p_manifold,
 	JPH::ContactSettings& p_settings
 ) {
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	add_debug_contacts(p_manifold);
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 
 	if (!is_listening_for(p_body1) && !is_listening_for(p_body2)) {
 		return;
@@ -67,9 +67,9 @@ void JoltContactListener3D::OnContactPersisted(
 	const JPH::ContactManifold& p_manifold,
 	JPH::ContactSettings& p_settings
 ) {
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	add_debug_contacts(p_manifold);
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 
 	if (p_body1.IsSensor() || p_body2.IsSensor()) {
 		return;
@@ -328,7 +328,7 @@ void JoltContactListener3D::flush_area_exits() {
 	area_exits.clear();
 }
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 
 void JoltContactListener3D::add_debug_contacts(const JPH::ContactManifold& p_manifold) {
 	const int64_t max_count = debug_contacts.size();
@@ -364,4 +364,4 @@ void JoltContactListener3D::add_debug_contacts(const JPH::ContactManifold& p_man
 	}
 }
 
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -62,7 +62,7 @@ public:
 
 	void post_step();
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	const PackedVector3Array& get_debug_contacts() const { return debug_contacts; }
 
 	int32_t get_debug_contact_count() const { return debug_contact_count; }
@@ -70,7 +70,7 @@ public:
 	int32_t get_max_debug_contacts() const { return (int32_t)debug_contacts.size(); }
 
 	void set_max_debug_contacts(int32_t p_count) { debug_contacts.resize(p_count); }
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 
 private:
 	void OnContactAdded(
@@ -106,9 +106,9 @@ private:
 
 	void flush_area_exits();
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	void add_debug_contacts(const JPH::ContactManifold& p_manifold);
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 
 	ManifoldsByShapePair manifolds_by_shape_pair;
 
@@ -124,9 +124,9 @@ private:
 
 	JoltSpace3D* space = nullptr;
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	PackedVector3Array debug_contacts;
 
 	std::atomic<int32_t> debug_contact_count = 0;
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 };

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -345,7 +345,7 @@ void JoltSpace3D::remove_joint(JoltJoint3D* p_joint) {
 	remove_joint(p_joint->get_jolt_ref());
 }
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 
 const PackedVector3Array& JoltSpace3D::get_debug_contacts() const {
 	return contact_listener->get_debug_contacts();
@@ -363,7 +363,7 @@ void JoltSpace3D::set_max_debug_contacts(int32_t p_count) {
 	contact_listener->set_max_debug_contacts(p_count);
 }
 
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 
 void JoltSpace3D::pre_step(float p_step) {
 	body_accessor.acquire_all(true);

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -88,7 +88,7 @@ public:
 
 	void remove_joint(JoltJoint3D* p_joint);
 
-#ifdef DEBUG_ENABLED
+#ifdef GJ_CONFIG_EDITOR
 	const PackedVector3Array& get_debug_contacts() const;
 
 	int32_t get_debug_contact_count() const;
@@ -96,7 +96,7 @@ public:
 	int32_t get_max_debug_contacts() const;
 
 	void set_max_debug_contacts(int32_t p_count);
-#endif // DEBUG_ENABLED
+#endif // GJ_CONFIG_EDITOR
 
 private:
 	void pre_step(float p_step);


### PR DESCRIPTION
This adds compile definitions to allow compile-time differences between the various configurations.

The definitions introduced are:

- `GJ_CONFIG_DEBUG` (applies to `Debug` and `EditorDebug`)
- `GJ_CONFIG_DEVELOPMENT` (applies to `Development` and `EditorDevelopment`)
- `GJ_CONFIG_DISTRIBUTION` (applies to `Distribution` and `EditorDistribution`)
- `GJ_CONFIG_EDITOR` (applies to `EditorDebug`, `EditorDevelopment` and `EditorDistribution`)

I also replaced any usage of the godot-cpp definition `DEBUG_ENABLED` with `GJ_CONFIG_EDITOR`, since they are analogous and the former is somewhat confusing in the context of Godot Jolt's configurations.