### PR TITLE
Disabled locking of bodies in `Distribution` configurations

### DIFF
--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -229,40 +229,49 @@ void JoltSpace3D::set_param(
 	}
 }
 
-JPH::BodyInterface& JoltSpace3D::get_body_iface(bool p_locked) {
+JPH::BodyInterface& JoltSpace3D::get_body_iface([[maybe_unused]] bool p_locked) {
+#ifndef GJ_CONFIG_DISTRIBUTION
 	if (p_locked && body_accessor.not_acquired()) {
 		return physics_system->GetBodyInterface();
-	} else {
-		return physics_system->GetBodyInterfaceNoLock();
 	}
+#endif // GJ_CONFIG_DISTRIBUTION
+
+	return physics_system->GetBodyInterfaceNoLock();
 }
 
-const JPH::BodyInterface& JoltSpace3D::get_body_iface(bool p_locked) const {
+const JPH::BodyInterface& JoltSpace3D::get_body_iface([[maybe_unused]] bool p_locked) const {
+#ifndef GJ_CONFIG_DISTRIBUTION
 	if (p_locked && body_accessor.not_acquired()) {
 		return physics_system->GetBodyInterface();
-	} else {
-		return physics_system->GetBodyInterfaceNoLock();
 	}
+#endif // GJ_CONFIG_DISTRIBUTION
+
+	return physics_system->GetBodyInterfaceNoLock();
 }
 
-const JPH::BodyLockInterface& JoltSpace3D::get_lock_iface(bool p_locked) const {
+const JPH::BodyLockInterface& JoltSpace3D::get_lock_iface([[maybe_unused]] bool p_locked) const {
+#ifndef GJ_CONFIG_DISTRIBUTION
 	if (p_locked && body_accessor.not_acquired()) {
 		return physics_system->GetBodyLockInterface();
-	} else {
-		return physics_system->GetBodyLockInterfaceNoLock();
 	}
+#endif // GJ_CONFIG_DISTRIBUTION
+
+	return physics_system->GetBodyLockInterfaceNoLock();
 }
 
 const JPH::BroadPhaseQuery& JoltSpace3D::get_broad_phase_query() const {
 	return physics_system->GetBroadPhaseQuery();
 }
 
-const JPH::NarrowPhaseQuery& JoltSpace3D::get_narrow_phase_query(bool p_locked) const {
+const JPH::NarrowPhaseQuery& JoltSpace3D::get_narrow_phase_query([[maybe_unused]] bool p_locked
+) const {
+#ifndef GJ_CONFIG_DISTRIBUTION
 	if (p_locked && body_accessor.not_acquired()) {
 		return physics_system->GetNarrowPhaseQuery();
-	} else {
-		return physics_system->GetNarrowPhaseQueryNoLock();
 	}
+#endif // GJ_CONFIG_DISTRIBUTION
+
+	return physics_system->GetNarrowPhaseQueryNoLock();
 }
 
 JPH::ObjectLayer JoltSpace3D::map_to_object_layer(


### PR DESCRIPTION
The locking has never really been necessary, due to no multi-threading happening outside of `JPH::PhysicsSystem::Update`, so I'm disabling it in `Distribution` configurations in exchange for whatever performance benefit it might offer.

I'm leaving it enabled in `Debug` and `Development` configurations just to keep myself in check with regards to any potential deadlocks, for whenever I'm ready to make a decision on how to approach multi-threading.