### PR TITLE
Reverted removal of null checks from #282

### DIFF
--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -149,11 +149,15 @@ public:
 	bool is_invalid() const { return body == nullptr; }
 
 	JoltCollisionObject3D* as_object() const {
-		return reinterpret_cast<JoltCollisionObject3D*>(body->GetUserData());
+		if (body != nullptr) {
+			return reinterpret_cast<JoltCollisionObject3D*>(body->GetUserData());
+		} else {
+			return nullptr;
+		}
 	}
 
 	JoltBody3D* as_body() const {
-		if (!body->IsSensor()) {
+		if (body != nullptr && !body->IsSensor()) {
 			return reinterpret_cast<JoltBody3D*>(body->GetUserData());
 		} else {
 			return nullptr;
@@ -161,7 +165,7 @@ public:
 	}
 
 	JoltArea3D* as_area() const {
-		if (body->IsSensor()) {
+		if (body != nullptr && body->IsSensor()) {
 			return reinterpret_cast<JoltArea3D*>(body->GetUserData());
 		} else {
 			return nullptr;


### PR DESCRIPTION
Fixes #298.

This reverts the removal of some null checks that I had removed from `JoltAccessibleBody3D` as part of the cleanup in #282.

I'm not quite sure what I was thinking there.