### PR TITLE
Added project settings for maximum velocities

### DIFF
--- a/src/objects/jolt_body_3d.cpp
+++ b/src/objects/jolt_body_3d.cpp
@@ -3,6 +3,7 @@
 #include "objects/jolt_area_3d.hpp"
 #include "objects/jolt_group_filter_rid.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
+#include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
@@ -982,6 +983,8 @@ void JoltBody3D::create_in_space() {
 	create_begin();
 
 	jolt_settings->mAllowDynamicOrKinematic = true;
+	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
+	jolt_settings->mMaxAngularVelocity = JoltProjectSettings::get_max_angular_velocity();
 	jolt_settings->mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
 	jolt_settings->mMassPropertiesOverride = calculate_mass_properties(*jolt_settings->GetShape());
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -17,6 +17,8 @@ constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_p
 
 constexpr char MORE_DETERMINISTIC[] = "physics/jolt_3d/simulation/more_deterministic";
 
+constexpr char MAX_LINEAR_VELOCITY[] = "physics/jolt_3d/limits/max_linear_velocity";
+constexpr char MAX_ANGULAR_VELOCITY[] = "physics/jolt_3d/limits/max_angular_velocity";
 constexpr char MAX_BODIES[] = "physics/jolt_3d/limits/max_bodies";
 constexpr char MAX_PAIRS[] = "physics/jolt_3d/limits/max_body_pairs";
 constexpr char MAX_CONTACTS[] = "physics/jolt_3d/limits/max_contact_constraints";
@@ -121,6 +123,8 @@ void JoltProjectSettings::register_settings() {
 
 	register_setting_plain(MORE_DETERMINISTIC, false);
 
+	register_setting_ranged(MAX_LINEAR_VELOCITY, 500.0f, "0,500,or_greater,suffix:m/s");
+	register_setting_ranged(MAX_ANGULAR_VELOCITY, 2700.0f, U"0,2700,or_greater,suffix:°/s");
 	register_setting_ranged(MAX_BODIES, 10240, "1,10240,or_greater", true);
 	register_setting_ranged(MAX_PAIRS, 65536, "8,65536,or_greater");
 	register_setting_ranged(MAX_CONTACTS, 20480, "8,20480,or_greater");
@@ -179,6 +183,16 @@ float JoltProjectSettings::get_contact_penetration() {
 
 bool JoltProjectSettings::is_more_deterministic() {
 	static const auto value = get_setting<bool>(MORE_DETERMINISTIC);
+	return value;
+}
+
+float JoltProjectSettings::get_max_linear_velocity() {
+	static const auto value = get_setting<float>(MAX_LINEAR_VELOCITY);
+	return value;
+}
+
+float JoltProjectSettings::get_max_angular_velocity() {
+	static const auto value = Math::deg_to_rad(get_setting<float>(MAX_ANGULAR_VELOCITY));
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -26,6 +26,10 @@ public:
 
 	static bool is_more_deterministic();
 
+	static float get_max_linear_velocity();
+
+	static float get_max_angular_velocity();
+
 	static int32_t get_max_bodies();
 
 	static int32_t get_max_body_pairs();


### PR DESCRIPTION
This adds two new project settings that allows configuring Jolt's maximum linear and angular velocities that a body can have. I figured this might be a good thing to expose since it might not otherwise be obvious that there's an upper bound on these.

The settings are:

- Max Linear Velocity (`physics/jolt_3d/limits/max_linear_velocity`)
- Max Angular Velocity (`physics/jolt_3d/limits/max_angular_velocity`)