### PR TITLE
Refactored toolchain version handling for CI builds

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -3,14 +3,24 @@ name: Setup Linux
 inputs:
   toolchain:
     required: true
-  version:
-    required: true
+  version-gcc:
+    default: 11
+  version-llvm:
+    default: 14
 
 runs:
   using: composite
   steps:
-    - shell: pwsh
+    - if: inputs.toolchain == 'gcc'
+      shell: pwsh
       run: >
         sudo ./scripts/ci_setup_linux.ps1
-        -Toolchain ${{ inputs.toolchain }}
-        -Version ${{ inputs.version }}
+        -Toolchain gcc
+        -VersionGcc ${{ inputs.version-gcc }}
+    - if: inputs.toolchain == 'llvm'
+      shell: pwsh
+      run: >
+        sudo ./scripts/ci_setup_linux.ps1
+        -Toolchain llvm
+        -VersionGcc ${{ inputs.version-gcc }}
+        -VersionLlvm ${{ inputs.version-llvm }}

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -2,7 +2,7 @@ name: Setup macOS
 
 inputs:
   version:
-    required: true
+    default: 14.1
 
 runs:
   using: composite

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -2,7 +2,7 @@ name: Setup Windows
 
 inputs:
   version:
-    required: true
+    default: 17
   arch:
     required: true
 

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -18,7 +18,6 @@ jobs:
         uses: ./.github/actions/setup-linux
         with:
           toolchain: llvm
-          version: 14
 
       - name: Identify clang-format
         shell: pwsh
@@ -45,7 +44,6 @@ jobs:
         uses: ./.github/actions/setup-linux
         with:
           toolchain: llvm
-          version: 14
 
       - name: Configure
         uses: ./.github/actions/cmake-configure

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,10 +25,8 @@ jobs:
         include:
           - platform: linux-clang
             toolchain: llvm
-            version: 14
           - platform: linux-gcc
             toolchain: gcc
-            version: 11
 
     steps:
       - name: Checkout code
@@ -38,7 +36,6 @@ jobs:
         uses: ./.github/actions/setup-linux
         with:
           toolchain: ${{ matrix.toolchain }}
-          version: ${{ matrix.version }}
 
       - name: Configure
         uses: ./.github/actions/cmake-configure

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -19,7 +19,6 @@ jobs:
         platform: [macos-clang]
         editor: [false, true]
         config: [debug, development, distribution]
-        version: [14.1]
 
     steps:
       - name: Checkout code
@@ -27,8 +26,6 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/setup-macos
-        with:
-          version: ${{ matrix.version }}
 
       - name: Configure
         uses: ./.github/actions/cmake-configure

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,7 +21,6 @@ jobs:
         arch: [x64, x86]
         editor: [false, true]
         config: [debug, development, distribution]
-        version: [17]
 
         include:
           - platform: windows-clangcl
@@ -35,7 +34,6 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-windows
         with:
-          version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
 
       - name: Configure

--- a/scripts/ci_setup_linux.ps1
+++ b/scripts/ci_setup_linux.ps1
@@ -9,10 +9,15 @@ param (
 	[string]
 	$Toolchain,
 
-	[Parameter(Mandatory = $true, HelpMessage = "Major version of the toolchain")]
+	[Parameter(Mandatory = $true, HelpMessage = "Major version of GCC")]
 	[ValidatePattern("^\d+$")]
 	[string]
-	$Version
+	$VersionGcc,
+
+	[Parameter(Mandatory = $false, HelpMessage = "Major version of LLVM")]
+	[ValidatePattern("^\d+$")]
+	[string]
+	$VersionLlvm
 )
 
 Set-StrictMode -Version Latest
@@ -37,25 +42,31 @@ Write-Output "Adding the ubuntu-toolchain-r repository..."
 
 add-apt-repository --yes --update ppa:ubuntu-toolchain-r/ppa
 
-if ($Toolchain -eq "gcc") {
-	Write-Output "Installing g++-$Version-multilib..."
+Write-Output "Installing GCC $VersionGcc..."
 
-	apt install --quiet --yes g++-$Version-multilib
+apt install --quiet --yes `
+	g++-$VersionGcc `
+	g++-$VersionGcc-multilib
 
-	Write-Output "Setting GCC $Version as the default..."
+Write-Output "Setting GCC $VersionGcc as the default..."
 
-	Set-DefaultCommand -Name gcc -Path /usr/bin/gcc-$Version
-	Set-DefaultCommand -Name g++ -Path /usr/bin/g++-$Version
-}
-elseif ($Toolchain -eq "llvm") {
-	Write-Output "Installing g++-multilib..."
+Set-DefaultCommand -Name gcc -Path /usr/bin/gcc-$VersionGcc
+Set-DefaultCommand -Name g++ -Path /usr/bin/g++-$VersionGcc
 
-	apt install --quiet --yes g++-multilib
+if ($Toolchain -eq "llvm") {
+	Write-Output "Installing LLVM $VersionLlvm..."
 
-	Write-Output "Setting LLVM $Version as the default..."
+	apt install --quiet --yes `
+		clang-$VersionLlvm `
+		clang-format-$VersionLlvm `
+		clang-tidy-$VersionLlvm `
+		lld-$VersionLlvm
 
-	Set-DefaultCommand -Name clang -Path /usr/bin/clang-$Version
-	Set-DefaultCommand -Name clang++ -Path /usr/bin/clang++-$Version
-	Set-DefaultCommand -Name clang-format -Path /usr/bin/clang-format-$Version
-	Set-DefaultCommand -Name clang-tidy -Path /usr/bin/clang-tidy-$Version
+	Write-Output "Setting LLVM $VersionLlvm as the default..."
+
+	Set-DefaultCommand -Name clang -Path /usr/bin/clang-$VersionLlvm
+	Set-DefaultCommand -Name clang++ -Path /usr/bin/clang++-$VersionLlvm
+	Set-DefaultCommand -Name clang-format -Path /usr/bin/clang-format-$VersionLlvm
+	Set-DefaultCommand -Name clang-tidy -Path /usr/bin/clang-tidy-$VersionLlvm
+	Set-DefaultCommand -Name lld -Path /usr/bin/lld-$VersionLlvm
 }


### PR DESCRIPTION
This PR removes the explicit toolchain versions that were strewn all over the CI workflows, in favor of default values in each platform's setup action.

I also added explicit installation of the relevant LLVM packages, because GitHub's Ubuntu runners seem to be lagging behind on updating to LLVM 15 for some reason, which I will switch to in an upcoming PR.

This PR also splits the `Version` parameter for `ci_setup_linux.ps1` to instead be `VersionGcc` and `VersionLlvm`. This allows for being explicit about the GCC version to install when setting up an LLVM environment, which is useful because Clang defaults to using libstdc++ on Linux.

This doesn't actually guarantee that this version will be the one actually used by Clang, since Clang will still pick the largest version number of GCC that's installed. This does however guarantee a minimum version. It would technically be possible to do some symlink shenanigans and use `--gcc-toolchain` to enforce a particular version of GCC, but it doesn't seem worth the hassle.