### PR TITLE
Removed the copyright year

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ gdj_get_build_id(PROJECT_VERSION_BUILD)
 
 set(PROJECT_TITLE "Godot Jolt")
 set(PROJECT_DESCRIPTION "Godot extension that integrates the Jolt physics engine")
-set(PROJECT_COPYRIGHT "Copyright (c) 2022 Mikael Hermansson and Godot Jolt contributors")
+set(PROJECT_COPYRIGHT "Copyright (c) Mikael Hermansson and Godot Jolt contributors")
 set(PROJECT_BUNDLE_IDENTIFIER "org.godot-jolt.godot-jolt")
 set(PROJECT_VERSION_STATUS "dev")
 set(PROJECT_VERSION_WITH_STATUS ${PROJECT_VERSION}-${PROJECT_VERSION_STATUS})

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Mikael Hermansson and Godot Jolt contributors.
+Copyright (c) Mikael Hermansson and Godot Jolt contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
I wasn't sure if I should update the copyright year at all, but it seems like most tech organizations are moving away from updating it, Godot included.

The [general consensus](https://hynek.me/til/copyright-years/) seems to be that the year is pointless from a legal perspective, so it might as well be removed altogether.