### PR TITLE
Added CI workflow for packaging releases

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,5 +1,11 @@
 name: 🔍 Analyze
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,5 +1,11 @@
 name: 🐧 Build (Linux)
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,5 +1,11 @@
 name: 🍎 Build (macOS)
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,5 +1,11 @@
 name: 🪟 Build (Windows)
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,258 @@
+name: 📦 Package
+
+on:
+  push:
+    tags:
+      - v\d+.\d+.\d+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  windows:
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, x86]
+
+    name: Build (windows-${{ matrix.arch }})
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-windows
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: windows-clangcl
+          arch: ${{ matrix.arch }}
+          args: >
+            -DCMAKE_INSTALL_PREFIX=dist
+            -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
+
+      - name: Build (non-editor)
+        uses: ./.github/actions/cmake-build
+        with:
+          platform: windows-clangcl
+          arch: ${{ matrix.arch }}
+          editor: false
+          config: distribution
+
+      - name: Build (editor)
+        uses: ./.github/actions/cmake-build
+        with:
+          platform: windows-clangcl
+          arch: ${{ matrix.arch }}
+          editor: true
+          config: distribution
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-${{ matrix.arch }}
+          path: ./dist/**
+          retention-days: 1
+
+  linux:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, x86]
+
+    name: Build (linux-${{ matrix.arch }})
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-linux
+        with:
+          toolchain: llvm
+
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: linux-clang
+          arch: ${{ matrix.arch }}
+          args: >
+            -DCMAKE_INSTALL_PREFIX=dist
+            -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
+
+      - name: Build (non-editor)
+        uses: ./.github/actions/cmake-build
+        with:
+          platform: linux-clang
+          arch: ${{ matrix.arch }}
+          editor: false
+          config: distribution
+
+      - name: Build (editor)
+        uses: ./.github/actions/cmake-build
+        with:
+          platform: linux-clang
+          arch: ${{ matrix.arch }}
+          editor: true
+          config: distribution
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-${{ matrix.arch }}
+          path: ./dist/**
+          retention-days: 1
+
+  macos:
+    runs-on: macos-13
+
+    name: Build (macos)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-macos
+
+      - name: Configure
+        uses: ./.github/actions/cmake-configure
+        with:
+          platform: macos-clang
+          args: >
+            -DCMAKE_INSTALL_PREFIX=tmp
+            -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
+
+      - name: Build (non-editor)
+        uses: ./.github/actions/cmake-build
+        with:
+          platform: macos-clang
+          editor: false
+          config: distribution
+
+      - name: Build (editor)
+        uses: ./.github/actions/cmake-build
+        with:
+          platform: macos-clang
+          editor: true
+          config: distribution
+
+      # HACK(mihe): Framework bundles contain symlinks to help with supporting multiple versions in
+      # a bundle. This can result in multiple physical duplicates of the bundled library when we do
+      # things like zip them, push them to source control or just deal with them in general on
+      # platforms that don't do well with symlinks, like Windows. So to mitigate this we replace the
+      # symlinks with the actual files and remove any duplicates.
+      - name: Remove symbolic links
+        run: >
+          rsync ./tmp/ ./dist
+          --archive
+          --copy-links
+          --exclude="*/Versions/"
+
+      - name: Sign frameworks
+        shell: pwsh
+        env:
+          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_DEV_ID: ${{ secrets.APPLE_DEV_ID }}
+          APPLE_DEV_TEAM_ID: ${{ secrets.APPLE_DEV_TEAM_ID }}
+          APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
+        run: gci -R ./dist/*.framework | ./scripts/ci_sign_macos.ps1
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos
+          path: ./dist/**
+          retention-days: 1
+
+  upload:
+    runs-on: ubuntu-22.04
+    needs: [windows, linux, macos]
+
+    name: Upload
+
+    steps:
+      - name: Download builds (windows-x64)
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-x64
+          path: ./dist
+
+      - name: Download builds (windows-x86)
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-x86
+          path: ./dist
+
+      - name: Download builds (linux-x64)
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x64
+          path: ./dist
+
+      - name: Download builds (linux-x86)
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x86
+          path: ./dist
+
+      - name: Download builds (macos)
+        uses: actions/download-artifact@v3
+        with:
+          name: macos
+          path: ./dist
+
+      - name: Delete temporary artifacts
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: |
+            windows-x64
+            windows-x86
+            linux-x64
+            linux-x86
+            macos
+
+      - name: Delete temporary artifacts
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: macos
+
+      - name: Separate debug symbols
+        run: >
+          rsync ./dist/./ ./symbols
+          --archive
+          --relative
+          --remove-source-files
+          --include="*/"
+          --include="*.pdb"
+          --include="*.debug"
+          --include="*.dSYM/**"
+          --exclude="*"
+
+      - name: Delete empty directories
+        run: find . -type d -empty -delete
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: godot-jolt_${{ github.ref_name }}
+          path: ./dist/**
+          retention-days: 1
+
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@v3
+        with:
+          name: godot-jolt_${{ github.ref_name }}_symbols
+          path: ./symbols/**
+          retention-days: 1

--- a/scripts/ci_sign_macos.ps1
+++ b/scripts/ci_sign_macos.ps1
@@ -1,0 +1,93 @@
+#!/usr/bin/env pwsh
+
+#Requires -PSEdition Core
+#Requires -Version 7.2
+
+param (
+	[Parameter(
+		Mandatory,
+		ValueFromRemainingArguments,
+		ValueFromPipeline,
+		HelpMessage = "Paths to framework bundles"
+	)]
+	[ValidateScript({ Test-Path $_ -PathType Container })]
+	[string[]]
+	$Frameworks
+)
+
+begin {
+	Set-StrictMode -Version Latest
+	$ErrorActionPreference = "Stop"
+
+	$CodesignPath = Get-Command codesign | Resolve-Path
+
+	$CertificateBase64 = $env:APPLE_CERT_BASE64
+	$CertificatePassword = $env:APPLE_CERT_PASSWORD
+	$CertificatePath = [IO.Path]::ChangeExtension((New-TemporaryFile), "p12")
+
+	$Keychain = "ephemeral.keychain"
+	$KeychainPassword = (New-Guid).ToString().Replace("-", "")
+
+	$DevId = $env:APPLE_DEV_ID
+	$DevTeamId = $env:APPLE_DEV_TEAM_ID
+	$DevPassword = $env:APPLE_DEV_PASSWORD
+
+	if (!$CertificateBase64) { throw "No certificate provided" }
+	if (!$CertificatePassword) { throw "No certificate password provided" }
+	if (!$DevId) { throw "No Apple Developer ID provided" }
+	if (!$DevTeamId) { throw "No Apple Team ID provided" }
+	if (!$DevPassword) { throw "No Apple Developer password provided" }
+
+	Write-Output "Decoding certificate..."
+
+	$Certificate = [Convert]::FromBase64String($CertificateBase64)
+
+	Write-Output "Writing certificate to disk..."
+
+	[IO.File]::WriteAllBytes($CertificatePath, $Certificate)
+
+	Write-Output "Creating keychain..."
+
+	security create-keychain -p $KeychainPassword $Keychain
+
+	Write-Output "Setting keychain as default..."
+
+	security default-keychain -s $Keychain
+
+	Write-Output "Importing certificate into keychain..."
+
+	security import $CertificatePath `
+		-k ~/Library/Keychains/$Keychain `
+		-P $CertificatePassword `
+		-T $CodesignPath
+
+	Write-Output "Granting access to keychain..."
+
+	security set-key-partition-list -S "apple-tool:,apple:" -s -k $KeychainPassword $Keychain
+}
+
+process {
+	foreach ($Framework in $Frameworks) {
+		$Archive = [IO.Path]::ChangeExtension((New-TemporaryFile), "zip")
+
+		Write-Output "Signing '$Framework'..."
+
+		& $CodesignPath --sign "Developer ID" "$Framework"
+
+		Write-Output "Verifying signing..."
+
+		& $CodesignPath --verify "$Framework"
+
+		Write-Output "Archiving framework to '$Archive'..."
+
+		ditto -ck "$Framework" "$Archive"
+
+		Write-Output "Submitting archive for notarization..."
+
+		xcrun notarytool submit "$Archive" `
+			--apple-id $DevId `
+			--team-id $DevTeamId `
+			--password $DevPassword `
+			--wait
+	}
+}


### PR DESCRIPTION
I'm gonna give myself one of these, due to the amount of work this took: 🎉

This workflow will build, prepare, sign (for macOS), package and upload builds for any version tag that's pushed.

It will however not create a GitHub release automatically, since the code signing for Windows binaries has to happen locally.

I also changed the event triggers for the regular build/analyze workflows to not trigger when pushing tags.