### PR TITLE
Updated mimalloc to 2.1.2

### DIFF
--- a/cmake/GodotJoltExternalMimalloc.cmake
+++ b/cmake/GodotJoltExternalMimalloc.cmake
@@ -25,7 +25,7 @@ endif()
 
 gdj_add_external_library(mimalloc "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/mimalloc.git
-	GIT_COMMIT 3e313478d91c04ac5821743688ce55fc27432c4f
+	GIT_COMMIT 43ce4bd7fd34bcc730c1c7471c99995597415488
 	LANGUAGE C
 	OUTPUT_NAME ${output_name}
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps mimalloc from godot-jolt/mimalloc@3e313478d91c04ac5821743688ce55fc27432c4f aka `v2.1.1` to godot-jolt/mimalloc@3e313478d91c04ac5821743688ce55fc27432c4f aka `v2.1.2` (see diff [here](https://github.com/godot-jolt/mimalloc/compare/3e313478d91c04ac5821743688ce55fc27432c4f...43ce4bd7fd34bcc730c1c7471c99995597415488)).