### PR TITLE
Removed "warnings as errors" flags for non-dev builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
+        env:
+          CXXFLAGS: -Werror
 
       - name: Build
         uses: ./.github/actions/cmake-build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,6 +37,8 @@ jobs:
         uses: ./.github/actions/cmake-configure
         with:
           platform: ${{ matrix.platform }}
+        env:
+          CXXFLAGS: -Werror
 
       - name: Build
         uses: ./.github/actions/cmake-build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -48,6 +48,8 @@ jobs:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
           args: ${{ matrix.args }}
+        env:
+          CXXFLAGS: /WX
 
       - name: Build
         uses: ./.github/actions/cmake-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,6 @@ if(MSVC)
 		PRIVATE /w44365 # Enable another implicit conversion warning
 		PRIVATE /w44800 # Enable another implicit conversion warning
 		PRIVATE /wd4324 # Disable structure padding warning
-		PRIVATE /EHsc # Enable exception handling
 		PRIVATE /GF # Enable string pooling
 		PRIVATE /Gy # Enable function-level linking
 		PRIVATE /permissive- # Enable standard conformance

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,8 +77,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl",
-        "CMAKE_CXX_COMPILER": "cl",
-        "CMAKE_CXX_FLAGS": "/WX"
+        "CMAKE_CXX_COMPILER": "cl"
       },
       "toolset": {
         "value": "host=x64",
@@ -103,8 +102,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -Werror"
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     },
     {
@@ -112,8 +110,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc",
-        "CMAKE_CXX_COMPILER": "g++",
-        "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -Werror"
+        "CMAKE_CXX_COMPILER": "g++"
       }
     },
     {


### PR DESCRIPTION
This removes the `/WX` and `-Werror` flags from MSVC-like and GCC-like builds respectively when just building normally, in favor of explicitly adding them to the CI builds and any CMake user preset instead.

I figured if people start using some new compiler version before I do, it'd be nice not to block them just because the newer compiler might have stricter warnings.

I also realized that the way these flags have been passed previously has actually been stomping the default `CMAKE_CXX_FLAGS`, which turned out to be why `/EHsc` had to be added explicitly. I went ahead and removed that (now redundant) flag as part of this change.