### PR TITLE
Removed "warnings as errors" flag for clang-cl builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -89,8 +89,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang-cl",
-        "CMAKE_CXX_COMPILER": "clang-cl",
-        "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} /WX"
+        "CMAKE_CXX_COMPILER": "clang-cl"
       },
       "toolset": {
         "value": "ClangCL,host=x64",


### PR DESCRIPTION
It seems I missed this one when removing the other similar flags in #318.

Similar to that one, this one also caused `CMAKE_CXX_FLAGS` to get stomped, meaning clang-cl builds have been running with exception-handling disabled since #318 was merged.