### PR TITLE
Fixed incorrect glob in clang-format script

### DIFF
--- a/scripts/run_clang_format.ps1
+++ b/scripts/run_clang_format.ps1
@@ -15,7 +15,7 @@ param (
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$SourceFiles = Get-ChildItem -Recurse -Path $SourcePath -Include ("*.cpp", "*.h")
+$SourceFiles = Get-ChildItem -Recurse -Path $SourcePath -Include ("*.cpp", "*.hpp")
 
 $Outputs = [Collections.Concurrent.ConcurrentBag[psobject]]::new()
 


### PR DESCRIPTION
Apparently the clang-format script that's run during CI has been globbing the wrong file extension for header files for who knows how long.

Thankfully there wasn't a single formatting issue in any of them.