### PR TITLE
Renamed classes that would clash with new nodes/resources

### DIFF
--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -13,8 +13,8 @@ constexpr double DEFAULT_RELAXATION = 1.0;
 
 JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
-	JoltBody3D* p_body_b,
+	JoltBodyImpl3D* p_body_a,
+	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
@@ -54,7 +54,7 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 
 JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
+	JoltBodyImpl3D* p_body_a,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock

--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -19,7 +19,7 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a, p_body_b) {
+	: JoltJointImpl3D(p_space, p_body_a, p_body_b) {
 	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
@@ -59,7 +59,7 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a) {
+	: JoltJointImpl3D(p_space, p_body_a) {
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 

--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -11,7 +11,7 @@ constexpr double DEFAULT_RELAXATION = 1.0;
 
 } // namespace
 
-JoltConeTwistJoint3D::JoltConeTwistJoint3D(
+JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	JoltBody3D* p_body_b,
@@ -52,7 +52,7 @@ JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 	space->add_joint(this);
 }
 
-JoltConeTwistJoint3D::JoltConeTwistJoint3D(
+JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	const Transform3D& p_local_ref_a,
@@ -84,7 +84,7 @@ JoltConeTwistJoint3D::JoltConeTwistJoint3D(
 	space->add_joint(this);
 }
 
-double JoltConeTwistJoint3D::get_param(PhysicsServer3D::ConeTwistJointParam p_param) const {
+double JoltConeTwistJointImpl3D::get_param(PhysicsServer3D::ConeTwistJointParam p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
 			return swing_span;
@@ -107,7 +107,10 @@ double JoltConeTwistJoint3D::get_param(PhysicsServer3D::ConeTwistJointParam p_pa
 	}
 }
 
-void JoltConeTwistJoint3D::set_param(PhysicsServer3D::ConeTwistJointParam p_param, double p_value) {
+void JoltConeTwistJointImpl3D::set_param(
+	PhysicsServer3D::ConeTwistJointParam p_param,
+	double p_value
+) {
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
 			swing_span = p_value;
@@ -147,7 +150,7 @@ void JoltConeTwistJoint3D::set_param(PhysicsServer3D::ConeTwistJointParam p_para
 	}
 }
 
-void JoltConeTwistJoint3D::spans_changed() {
+void JoltConeTwistJointImpl3D::spans_changed() {
 	auto* jolt_constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL(jolt_constraint);
 

--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -29,8 +29,8 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
-	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
@@ -63,7 +63,7 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);

--- a/src/joints/jolt_cone_twist_joint_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltConeTwistJointImpl3D final : public JoltJoint3D {
+class JoltConeTwistJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltConeTwistJointImpl3D(
 		JoltSpace3D* p_space,

--- a/src/joints/jolt_cone_twist_joint_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_3d.hpp
@@ -6,8 +6,8 @@ class JoltConeTwistJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltConeTwistJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
-		JoltBody3D* p_body_b,
+		JoltBodyImpl3D* p_body_a,
+		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -15,7 +15,7 @@ public:
 
 	JoltConeTwistJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
+		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true

--- a/src/joints/jolt_cone_twist_joint_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_3d.hpp
@@ -2,9 +2,9 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltConeTwistJoint3D final : public JoltJoint3D {
+class JoltConeTwistJointImpl3D final : public JoltJoint3D {
 public:
-	JoltConeTwistJoint3D(
+	JoltConeTwistJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		JoltBody3D* p_body_b,
@@ -13,7 +13,7 @@ public:
 		bool p_lock = true
 	);
 
-	JoltConeTwistJoint3D(
+	JoltConeTwistJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_generic_6dof_joint_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.cpp
@@ -33,7 +33,7 @@ JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	[[maybe_unused]] const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a, p_body_b)
+	: JoltJointImpl3D(p_space, p_body_a, p_body_b)
 	, world_ref(body_a->get_transform_scaled(p_lock) * p_local_ref_a) {
 	world_ref.orthonormalize();
 	rebuild(p_lock);
@@ -46,7 +46,7 @@ JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a)
+	: JoltJointImpl3D(p_space, p_body_a)
 	, world_ref(p_local_ref_b) {
 	rebuild(p_lock);
 }

--- a/src/joints/jolt_generic_6dof_joint_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.cpp
@@ -27,8 +27,8 @@ constexpr double DEFAULT_ANGULAR_SPRING_EQUILIBRIUM_POINT = 0.0;
 
 JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
-	JoltBody3D* p_body_b,
+	JoltBodyImpl3D* p_body_a,
+	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	[[maybe_unused]] const Transform3D& p_local_ref_b,
 	bool p_lock
@@ -41,7 +41,7 @@ JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 
 JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
+	JoltBodyImpl3D* p_body_a,
 	[[maybe_unused]] const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock

--- a/src/joints/jolt_generic_6dof_joint_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.cpp
@@ -25,7 +25,7 @@ constexpr double DEFAULT_ANGULAR_SPRING_EQUILIBRIUM_POINT = 0.0;
 
 } // namespace
 
-JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
+JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	JoltBody3D* p_body_b,
@@ -39,7 +39,7 @@ JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
 	rebuild(p_lock);
 }
 
-JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
+JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	[[maybe_unused]] const Transform3D& p_local_ref_a,
@@ -51,7 +51,7 @@ JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D(
 	rebuild(p_lock);
 }
 
-double JoltGeneric6DOFJoint3D::get_param(
+double JoltGeneric6DOFJointImpl3D::get_param(
 	Vector3::Axis p_axis,
 	PhysicsServer3D::G6DOFJointAxisParam p_param
 ) const {
@@ -131,7 +131,7 @@ double JoltGeneric6DOFJoint3D::get_param(
 	}
 }
 
-void JoltGeneric6DOFJoint3D::set_param(
+void JoltGeneric6DOFJointImpl3D::set_param(
 	Vector3::Axis p_axis,
 	PhysicsServer3D::G6DOFJointAxisParam p_param,
 	double p_value,
@@ -306,7 +306,7 @@ void JoltGeneric6DOFJoint3D::set_param(
 	}
 }
 
-bool JoltGeneric6DOFJoint3D::get_flag(
+bool JoltGeneric6DOFJointImpl3D::get_flag(
 	Vector3::Axis p_axis,
 	PhysicsServer3D::G6DOFJointAxisFlag p_flag
 ) const {
@@ -338,7 +338,7 @@ bool JoltGeneric6DOFJoint3D::get_flag(
 	}
 }
 
-void JoltGeneric6DOFJoint3D::set_flag(
+void JoltGeneric6DOFJointImpl3D::set_flag(
 	Vector3::Axis p_axis,
 	PhysicsServer3D::G6DOFJointAxisFlag p_flag,
 	bool p_enabled,
@@ -397,7 +397,7 @@ void JoltGeneric6DOFJoint3D::set_flag(
 	}
 }
 
-void JoltGeneric6DOFJoint3D::rebuild(bool p_lock) {
+void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	// HACK(mihe): This joint has to be rebuilt whenever the limits change for three reasons:
 	//
 	// 1. Jolt seems to cache the fixed/free/limited state of each axis, and doesn't seem to allow

--- a/src/joints/jolt_generic_6dof_joint_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.hpp
@@ -20,8 +20,8 @@ class JoltGeneric6DOFJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltGeneric6DOFJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
-		JoltBody3D* p_body_b,
+		JoltBodyImpl3D* p_body_a,
+		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -29,7 +29,7 @@ public:
 
 	JoltGeneric6DOFJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
+		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true

--- a/src/joints/jolt_generic_6dof_joint_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltGeneric6DOFJointImpl3D final : public JoltJoint3D {
+class JoltGeneric6DOFJointImpl3D final : public JoltJointImpl3D {
 	using JoltAxis = JPH::SixDOFConstraintSettings::EAxis;
 
 	enum Axis {

--- a/src/joints/jolt_generic_6dof_joint_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltGeneric6DOFJoint3D final : public JoltJoint3D {
+class JoltGeneric6DOFJointImpl3D final : public JoltJoint3D {
 	using JoltAxis = JPH::SixDOFConstraintSettings::EAxis;
 
 	enum Axis {
@@ -18,7 +18,7 @@ class JoltGeneric6DOFJoint3D final : public JoltJoint3D {
 	};
 
 public:
-	JoltGeneric6DOFJoint3D(
+	JoltGeneric6DOFJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		JoltBody3D* p_body_b,
@@ -27,7 +27,7 @@ public:
 		bool p_lock = true
 	);
 
-	JoltGeneric6DOFJoint3D(
+	JoltGeneric6DOFJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -20,7 +20,7 @@ JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a, p_body_b) {
+	: JoltJointImpl3D(p_space, p_body_a, p_body_b) {
 	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
@@ -60,7 +60,7 @@ JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a) {
+	: JoltJointImpl3D(p_space, p_body_a) {
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 

--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -14,8 +14,8 @@ constexpr double DEFAULT_RELAXATION = 1.0;
 
 JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
-	JoltBody3D* p_body_b,
+	JoltBodyImpl3D* p_body_a,
+	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
@@ -55,7 +55,7 @@ JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 
 JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
+	JoltBodyImpl3D* p_body_a,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock

--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -30,8 +30,8 @@ JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
-	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
@@ -64,7 +64,7 @@ JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);

--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -12,7 +12,7 @@ constexpr double DEFAULT_RELAXATION = 1.0;
 
 } // namespace
 
-JoltHingeJoint3D::JoltHingeJoint3D(
+JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	JoltBody3D* p_body_b,
@@ -53,7 +53,7 @@ JoltHingeJoint3D::JoltHingeJoint3D(
 	space->add_joint(this);
 }
 
-JoltHingeJoint3D::JoltHingeJoint3D(
+JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	const Transform3D& p_local_ref_a,
@@ -85,7 +85,7 @@ JoltHingeJoint3D::JoltHingeJoint3D(
 	space->add_joint(this);
 }
 
-double JoltHingeJoint3D::get_param(PhysicsServer3D::HingeJointParam p_param) const {
+double JoltHingeJointImpl3D::get_param(PhysicsServer3D::HingeJointParam p_param) const {
 	const auto* jolt_constraint = static_cast<const JPH::HingeConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL_D(jolt_constraint);
 
@@ -120,7 +120,7 @@ double JoltHingeJoint3D::get_param(PhysicsServer3D::HingeJointParam p_param) con
 	}
 }
 
-void JoltHingeJoint3D::set_param(PhysicsServer3D::HingeJointParam p_param, double p_value) {
+void JoltHingeJointImpl3D::set_param(PhysicsServer3D::HingeJointParam p_param, double p_value) {
 	auto* jolt_constraint = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL(jolt_constraint);
 
@@ -187,7 +187,7 @@ void JoltHingeJoint3D::set_param(PhysicsServer3D::HingeJointParam p_param, doubl
 	}
 }
 
-bool JoltHingeJoint3D::get_flag(PhysicsServer3D::HingeJointFlag p_flag) const {
+bool JoltHingeJointImpl3D::get_flag(PhysicsServer3D::HingeJointFlag p_flag) const {
 	const auto* jolt_constraint = static_cast<const JPH::HingeConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL_D(jolt_constraint);
 
@@ -204,7 +204,7 @@ bool JoltHingeJoint3D::get_flag(PhysicsServer3D::HingeJointFlag p_flag) const {
 	}
 }
 
-void JoltHingeJoint3D::set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled) {
+void JoltHingeJointImpl3D::set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled) {
 	auto* jolt_constraint = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL(jolt_constraint);
 
@@ -224,7 +224,7 @@ void JoltHingeJoint3D::set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_e
 	}
 }
 
-void JoltHingeJoint3D::limits_changed() {
+void JoltHingeJointImpl3D::limits_changed() {
 	auto* jolt_constraint = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL(jolt_constraint);
 

--- a/src/joints/jolt_hinge_joint_3d.hpp
+++ b/src/joints/jolt_hinge_joint_3d.hpp
@@ -6,8 +6,8 @@ class JoltHingeJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltHingeJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
-		JoltBody3D* p_body_b,
+		JoltBodyImpl3D* p_body_a,
+		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -15,7 +15,7 @@ public:
 
 	JoltHingeJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
+		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true

--- a/src/joints/jolt_hinge_joint_3d.hpp
+++ b/src/joints/jolt_hinge_joint_3d.hpp
@@ -2,9 +2,9 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltHingeJoint3D final : public JoltJoint3D {
+class JoltHingeJointImpl3D final : public JoltJoint3D {
 public:
-	JoltHingeJoint3D(
+	JoltHingeJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		JoltBody3D* p_body_b,
@@ -13,7 +13,7 @@ public:
 		bool p_lock = true
 	);
 
-	JoltHingeJoint3D(
+	JoltHingeJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_hinge_joint_3d.hpp
+++ b/src/joints/jolt_hinge_joint_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltHingeJointImpl3D final : public JoltJoint3D {
+class JoltHingeJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltHingeJointImpl3D(
 		JoltSpace3D* p_space,

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -9,7 +9,11 @@ constexpr int32_t DEFAULT_SOLVER_PRIORITY = 1;
 
 } // namespace
 
-JoltJointImpl3D::JoltJointImpl3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b)
+JoltJointImpl3D::JoltJointImpl3D(
+	JoltSpace3D* p_space,
+	JoltBodyImpl3D* p_body_a,
+	JoltBodyImpl3D* p_body_b
+)
 	: space(p_space)
 	, body_a(p_body_a)
 	, body_b(p_body_b) { }

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -9,22 +9,22 @@ constexpr int32_t DEFAULT_SOLVER_PRIORITY = 1;
 
 } // namespace
 
-JoltJoint3D::JoltJoint3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b)
+JoltJointImpl3D::JoltJointImpl3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b)
 	: space(p_space)
 	, body_a(p_body_a)
 	, body_b(p_body_b) { }
 
-JoltJoint3D::~JoltJoint3D() {
+JoltJointImpl3D::~JoltJointImpl3D() {
 	if (jolt_ref != nullptr) {
 		space->remove_joint(this);
 	}
 }
 
-int32_t JoltJoint3D::get_solver_priority() const {
+int32_t JoltJointImpl3D::get_solver_priority() const {
 	return DEFAULT_SOLVER_PRIORITY;
 }
 
-void JoltJoint3D::set_solver_priority(int32_t p_priority) {
+void JoltJointImpl3D::set_solver_priority(int32_t p_priority) {
 	if (p_priority != DEFAULT_SOLVER_PRIORITY) {
 		WARN_PRINT(
 			"Joint solver priority is not supported by Godot Jolt. "
@@ -33,7 +33,7 @@ void JoltJoint3D::set_solver_priority(int32_t p_priority) {
 	}
 }
 
-void JoltJoint3D::set_collision_disabled(bool p_disabled) {
+void JoltJointImpl3D::set_collision_disabled(bool p_disabled) {
 	collision_disabled = p_disabled;
 
 	if (body_b == nullptr) {

--- a/src/joints/jolt_joint_3d.hpp
+++ b/src/joints/jolt_joint_3d.hpp
@@ -3,13 +3,13 @@
 class JoltBody3D;
 class JoltSpace3D;
 
-class JoltJoint3D {
+class JoltJointImpl3D {
 public:
-	JoltJoint3D() = default;
+	JoltJointImpl3D() = default;
 
-	JoltJoint3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b = nullptr);
+	JoltJointImpl3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b = nullptr);
 
-	virtual ~JoltJoint3D();
+	virtual ~JoltJointImpl3D();
 
 	virtual PhysicsServer3D::JointType get_type() const { return PhysicsServer3D::JOINT_TYPE_MAX; }
 

--- a/src/joints/jolt_joint_3d.hpp
+++ b/src/joints/jolt_joint_3d.hpp
@@ -1,13 +1,17 @@
 #pragma once
 
-class JoltBody3D;
+class JoltBodyImpl3D;
 class JoltSpace3D;
 
 class JoltJointImpl3D {
 public:
 	JoltJointImpl3D() = default;
 
-	JoltJointImpl3D(JoltSpace3D* p_space, JoltBody3D* p_body_a, JoltBody3D* p_body_b = nullptr);
+	JoltJointImpl3D(
+		JoltSpace3D* p_space,
+		JoltBodyImpl3D* p_body_a,
+		JoltBodyImpl3D* p_body_b = nullptr
+	);
 
 	virtual ~JoltJointImpl3D();
 
@@ -34,9 +38,9 @@ protected:
 
 	JoltSpace3D* space = nullptr;
 
-	JoltBody3D* body_a = nullptr;
+	JoltBodyImpl3D* body_a = nullptr;
 
-	JoltBody3D* body_b = nullptr;
+	JoltBodyImpl3D* body_b = nullptr;
 
 	JPH::Ref<JPH::Constraint> jolt_ref;
 

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -19,7 +19,7 @@ JoltPinJoint3D::JoltPinJoint3D(
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a, p_body_b)
+	: JoltJointImpl3D(p_space, p_body_a, p_body_b)
 	, local_a(p_local_a)
 	, local_b(p_local_b) {
 	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
@@ -57,7 +57,7 @@ JoltPinJoint3D::JoltPinJoint3D(
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a)
+	: JoltJointImpl3D(p_space, p_body_a)
 	, local_a(p_local_a)
 	, local_b(p_local_b) {
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -13,8 +13,8 @@ constexpr double DEFAULT_IMPULSE_CLAMP = 0.0;
 
 JoltPinJointImpl3D::JoltPinJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
-	JoltBody3D* p_body_b,
+	JoltBodyImpl3D* p_body_a,
+	JoltBodyImpl3D* p_body_b,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock
@@ -52,7 +52,7 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 
 JoltPinJointImpl3D::JoltPinJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
+	JoltBodyImpl3D* p_body_a,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -31,8 +31,8 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
-	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(local_a * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(local_b * object_b.get_scale());
@@ -63,7 +63,7 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(local_a * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(local_b);
@@ -89,7 +89,7 @@ void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
 	const JoltReadableBody3D jolt_body_a = space->read_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
 	const JPH::Vec3 point_scaled_a = to_jolt(local_a * object_a.get_scale());
 	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
 
@@ -109,7 +109,7 @@ void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
 		const JoltReadableBody3D jolt_body_b = space->read_body(*body_b, p_lock);
 		ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-		const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+		const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
 		const JPH::Vec3 point_scaled_b = to_jolt(local_b * object_b.get_scale());
 		const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
 

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -11,7 +11,7 @@ constexpr double DEFAULT_IMPULSE_CLAMP = 0.0;
 
 } // namespace
 
-JoltPinJoint3D::JoltPinJoint3D(
+JoltPinJointImpl3D::JoltPinJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	JoltBody3D* p_body_b,
@@ -50,7 +50,7 @@ JoltPinJoint3D::JoltPinJoint3D(
 	space->add_joint(this);
 }
 
-JoltPinJoint3D::JoltPinJoint3D(
+JoltPinJointImpl3D::JoltPinJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	const Vector3& p_local_a,
@@ -80,7 +80,7 @@ JoltPinJoint3D::JoltPinJoint3D(
 	space->add_joint(this);
 }
 
-void JoltPinJoint3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
+void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
 	local_a = p_local_a;
 
 	auto* jolt_constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());
@@ -99,7 +99,7 @@ void JoltPinJoint3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
 	);
 }
 
-void JoltPinJoint3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
+void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
 	local_b = p_local_b;
 
 	auto* jolt_constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());
@@ -122,7 +122,7 @@ void JoltPinJoint3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
 	}
 }
 
-double JoltPinJoint3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
+double JoltPinJointImpl3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::PIN_JOINT_BIAS: {
 			return DEFAULT_BIAS;
@@ -139,7 +139,7 @@ double JoltPinJoint3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
 	}
 }
 
-void JoltPinJoint3D::set_param(PhysicsServer3D::PinJointParam p_param, double p_value) {
+void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, double p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::PIN_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -5,9 +5,9 @@
 class JoltBody3D;
 class JoltSpace3D;
 
-class JoltPinJoint3D final : public JoltJointImpl3D {
+class JoltPinJointImpl3D final : public JoltJointImpl3D {
 public:
-	JoltPinJoint3D(
+	JoltPinJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		JoltBody3D* p_body_b,
@@ -16,7 +16,7 @@ public:
 		bool p_lock = true
 	);
 
-	JoltPinJoint3D(
+	JoltPinJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		const Vector3& p_local_a,

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -5,7 +5,7 @@
 class JoltBody3D;
 class JoltSpace3D;
 
-class JoltPinJoint3D final : public JoltJoint3D {
+class JoltPinJoint3D final : public JoltJointImpl3D {
 public:
 	JoltPinJoint3D(
 		JoltSpace3D* p_space,

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -2,15 +2,15 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltBody3D;
+class JoltBodyImpl3D;
 class JoltSpace3D;
 
 class JoltPinJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltPinJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
-		JoltBody3D* p_body_b,
+		JoltBodyImpl3D* p_body_a,
+		JoltBodyImpl3D* p_body_b,
 		const Vector3& p_local_a,
 		const Vector3& p_local_b,
 		bool p_lock = true
@@ -18,7 +18,7 @@ public:
 
 	JoltPinJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
+		JoltBodyImpl3D* p_body_a,
 		const Vector3& p_local_a,
 		const Vector3& p_local_b,
 		bool p_lock = true

--- a/src/joints/jolt_slider_joint_3d.cpp
+++ b/src/joints/jolt_slider_joint_3d.cpp
@@ -41,7 +41,7 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a, p_body_b) {
+	: JoltJointImpl3D(p_space, p_body_a, p_body_b) {
 	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
 	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
 
@@ -82,7 +82,7 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJoint3D(p_space, p_body_a) {
+	: JoltJointImpl3D(p_space, p_body_a) {
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 

--- a/src/joints/jolt_slider_joint_3d.cpp
+++ b/src/joints/jolt_slider_joint_3d.cpp
@@ -51,8 +51,8 @@ JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	const JoltWritableBody3D jolt_body_b = bodies[1];
 	ERR_FAIL_COND(jolt_body_b.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
-	const JoltCollisionObject3D& object_b = *jolt_body_b.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
@@ -86,7 +86,7 @@ JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
 	ERR_FAIL_COND(jolt_body_a.is_invalid());
 
-	const JoltCollisionObject3D& object_a = *jolt_body_a.as_object();
+	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
 
 	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
 	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);

--- a/src/joints/jolt_slider_joint_3d.cpp
+++ b/src/joints/jolt_slider_joint_3d.cpp
@@ -35,8 +35,8 @@ constexpr double DEFAULT_ANGULAR_ORTHO_DAMPING = 1.0;
 
 JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
-	JoltBody3D* p_body_b,
+	JoltBodyImpl3D* p_body_a,
+	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
@@ -77,7 +77,7 @@ JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 
 JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	JoltSpace3D* p_space,
-	JoltBody3D* p_body_a,
+	JoltBodyImpl3D* p_body_a,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock

--- a/src/joints/jolt_slider_joint_3d.cpp
+++ b/src/joints/jolt_slider_joint_3d.cpp
@@ -33,7 +33,7 @@ constexpr double DEFAULT_ANGULAR_ORTHO_DAMPING = 1.0;
 
 } // namespace
 
-JoltSliderJoint3D::JoltSliderJoint3D(
+JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	JoltBody3D* p_body_b,
@@ -75,7 +75,7 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 	space->add_joint(this);
 }
 
-JoltSliderJoint3D::JoltSliderJoint3D(
+JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	JoltSpace3D* p_space,
 	JoltBody3D* p_body_a,
 	const Transform3D& p_local_ref_a,
@@ -108,7 +108,7 @@ JoltSliderJoint3D::JoltSliderJoint3D(
 	space->add_joint(this);
 }
 
-double JoltSliderJoint3D::get_param(PhysicsServer3D::SliderJointParam p_param) const {
+double JoltSliderJointImpl3D::get_param(PhysicsServer3D::SliderJointParam p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_UPPER: {
 			return limit_upper;
@@ -182,7 +182,7 @@ double JoltSliderJoint3D::get_param(PhysicsServer3D::SliderJointParam p_param) c
 	}
 }
 
-void JoltSliderJoint3D::set_param(PhysicsServer3D::SliderJointParam p_param, double p_value) {
+void JoltSliderJointImpl3D::set_param(PhysicsServer3D::SliderJointParam p_param, double p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_UPPER: {
 			limit_upper = p_value;
@@ -360,7 +360,7 @@ void JoltSliderJoint3D::set_param(PhysicsServer3D::SliderJointParam p_param, dou
 	}
 }
 
-void JoltSliderJoint3D::limits_changed() {
+void JoltSliderJointImpl3D::limits_changed() {
 	auto* jolt_constraint = static_cast<JPH::SliderConstraint*>(jolt_ref.GetPtr());
 	ERR_FAIL_NULL(jolt_constraint);
 

--- a/src/joints/jolt_slider_joint_3d.hpp
+++ b/src/joints/jolt_slider_joint_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltSliderJoint3D final : public JoltJoint3D {
+class JoltSliderJoint3D final : public JoltJointImpl3D {
 public:
 	JoltSliderJoint3D(
 		JoltSpace3D* p_space,

--- a/src/joints/jolt_slider_joint_3d.hpp
+++ b/src/joints/jolt_slider_joint_3d.hpp
@@ -2,9 +2,9 @@
 
 #include "joints/jolt_joint_3d.hpp"
 
-class JoltSliderJoint3D final : public JoltJointImpl3D {
+class JoltSliderJointImpl3D final : public JoltJointImpl3D {
 public:
-	JoltSliderJoint3D(
+	JoltSliderJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		JoltBody3D* p_body_b,
@@ -13,7 +13,7 @@ public:
 		bool p_lock = true
 	);
 
-	JoltSliderJoint3D(
+	JoltSliderJointImpl3D(
 		JoltSpace3D* p_space,
 		JoltBody3D* p_body_a,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_slider_joint_3d.hpp
+++ b/src/joints/jolt_slider_joint_3d.hpp
@@ -6,8 +6,8 @@ class JoltSliderJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltSliderJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
-		JoltBody3D* p_body_b,
+		JoltBodyImpl3D* p_body_a,
+		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true
@@ -15,7 +15,7 @@ public:
 
 	JoltSliderJointImpl3D(
 		JoltSpace3D* p_space,
-		JoltBody3D* p_body_a,
+		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
 		bool p_lock = true

--- a/src/objects/jolt_area_3d.cpp
+++ b/src/objects/jolt_area_3d.cpp
@@ -14,7 +14,7 @@ const Vector3 DEFAULT_WIND_DIRECTION = {};
 
 } // namespace
 
-Variant JoltArea3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
+Variant JoltAreaImpl3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE: {
 			return get_gravity_mode();
@@ -64,7 +64,7 @@ Variant JoltArea3D::get_param(PhysicsServer3D::AreaParameter p_param) const {
 	}
 }
 
-void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
+void JoltAreaImpl3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::AREA_PARAM_GRAVITY_OVERRIDE_MODE: {
 			set_gravity_mode((OverrideMode)(int32_t)p_value);
@@ -134,13 +134,13 @@ void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant
 	}
 }
 
-JPH::BroadPhaseLayer JoltArea3D::get_broad_phase_layer() const {
+JPH::BroadPhaseLayer JoltAreaImpl3D::get_broad_phase_layer() const {
 	return monitorable
 		? JoltBroadPhaseLayer::AREA_DETECTABLE
 		: JoltBroadPhaseLayer::AREA_UNDETECTABLE;
 }
 
-void JoltArea3D::set_body_monitor_callback(const Callable& p_callback) {
+void JoltAreaImpl3D::set_body_monitor_callback(const Callable& p_callback) {
 	if (p_callback == body_monitor_callback) {
 		return;
 	}
@@ -150,7 +150,7 @@ void JoltArea3D::set_body_monitor_callback(const Callable& p_callback) {
 	body_monitoring_changed();
 }
 
-void JoltArea3D::set_area_monitor_callback(const Callable& p_callback) {
+void JoltAreaImpl3D::set_area_monitor_callback(const Callable& p_callback) {
 	if (p_callback == area_monitor_callback) {
 		return;
 	}
@@ -160,7 +160,7 @@ void JoltArea3D::set_area_monitor_callback(const Callable& p_callback) {
 	area_monitoring_changed();
 }
 
-void JoltArea3D::set_monitorable(bool p_monitorable, bool p_lock) {
+void JoltAreaImpl3D::set_monitorable(bool p_monitorable, bool p_lock) {
 	if (p_monitorable == monitorable) {
 		return;
 	}
@@ -170,7 +170,7 @@ void JoltArea3D::set_monitorable(bool p_monitorable, bool p_lock) {
 	monitorable_changed(p_lock);
 }
 
-Vector3 JoltArea3D::compute_gravity(const Vector3& p_position, bool p_lock) const {
+Vector3 JoltAreaImpl3D::compute_gravity(const Vector3& p_position, bool p_lock) const {
 	if (!point_gravity) {
 		return gravity_vector * gravity;
 	}
@@ -185,7 +185,7 @@ Vector3 JoltArea3D::compute_gravity(const Vector3& p_position, bool p_lock) cons
 	return to_point_dir * (gravity * gravity_dist_sq / to_point_dist_sq);
 }
 
-void JoltArea3D::body_shape_entered(
+void JoltAreaImpl3D::body_shape_entered(
 	const JPH::BodyID& p_body_id,
 	const JPH::SubShapeID& p_other_shape_id,
 	const JPH::SubShapeID& p_self_shape_id
@@ -199,7 +199,7 @@ void JoltArea3D::body_shape_entered(
 	add_shape_pair(overlap, p_body_id, p_other_shape_id, p_self_shape_id);
 }
 
-bool JoltArea3D::body_shape_exited(
+bool JoltAreaImpl3D::body_shape_exited(
 	const JPH::BodyID& p_body_id,
 	const JPH::SubShapeID& p_other_shape_id,
 	const JPH::SubShapeID& p_self_shape_id
@@ -221,7 +221,7 @@ bool JoltArea3D::body_shape_exited(
 	return true;
 }
 
-void JoltArea3D::area_shape_entered(
+void JoltAreaImpl3D::area_shape_entered(
 	const JPH::BodyID& p_body_id,
 	const JPH::SubShapeID& p_other_shape_id,
 	const JPH::SubShapeID& p_self_shape_id
@@ -229,7 +229,7 @@ void JoltArea3D::area_shape_entered(
 	add_shape_pair(areas_by_id[p_body_id], p_body_id, p_other_shape_id, p_self_shape_id);
 }
 
-bool JoltArea3D::area_shape_exited(
+bool JoltAreaImpl3D::area_shape_exited(
 	const JPH::BodyID& p_body_id,
 	const JPH::SubShapeID& p_other_shape_id,
 	const JPH::SubShapeID& p_self_shape_id
@@ -243,7 +243,7 @@ bool JoltArea3D::area_shape_exited(
 	return remove_shape_pair(*overlap, p_other_shape_id, p_self_shape_id);
 }
 
-bool JoltArea3D::shape_exited(
+bool JoltAreaImpl3D::shape_exited(
 	const JPH::BodyID& p_body_id,
 	const JPH::SubShapeID& p_other_shape_id,
 	const JPH::SubShapeID& p_self_shape_id
@@ -252,12 +252,12 @@ bool JoltArea3D::shape_exited(
 		area_shape_exited(p_body_id, p_other_shape_id, p_self_shape_id);
 }
 
-void JoltArea3D::call_queries() {
+void JoltAreaImpl3D::call_queries() {
 	flush_events(bodies_by_id, body_monitor_callback);
 	flush_events(areas_by_id, area_monitor_callback);
 }
 
-void JoltArea3D::create_in_space() {
+void JoltAreaImpl3D::create_in_space() {
 	create_begin();
 
 	jolt_settings->mIsSensor = true;
@@ -266,7 +266,7 @@ void JoltArea3D::create_in_space() {
 	create_end();
 }
 
-void JoltArea3D::add_shape_pair(
+void JoltAreaImpl3D::add_shape_pair(
 	Overlap& p_overlap,
 	const JPH::BodyID& p_body_id,
 	const JPH::SubShapeID& p_other_shape_id,
@@ -287,7 +287,7 @@ void JoltArea3D::add_shape_pair(
 	p_overlap.pending_added.push_back(shape_indices);
 }
 
-bool JoltArea3D::remove_shape_pair(
+bool JoltAreaImpl3D::remove_shape_pair(
 	Overlap& p_overlap,
 	const JPH::SubShapeID& p_other_shape_id,
 	const JPH::SubShapeID& p_self_shape_id
@@ -304,7 +304,7 @@ bool JoltArea3D::remove_shape_pair(
 	return true;
 }
 
-void JoltArea3D::flush_events(OverlapsById& p_objects, const Callable& p_callback) {
+void JoltAreaImpl3D::flush_events(OverlapsById& p_objects, const Callable& p_callback) {
 	p_objects.erase_if([&](auto& p_pair) {
 		auto& [id, overlap] = p_pair;
 
@@ -339,7 +339,7 @@ void JoltArea3D::flush_events(OverlapsById& p_objects, const Callable& p_callbac
 	});
 }
 
-void JoltArea3D::report_event(
+void JoltAreaImpl3D::report_event(
 	const Callable& p_callback,
 	PhysicsServer3D::AreaBodyStatus p_status,
 	const RID& p_other_rid,
@@ -364,7 +364,7 @@ void JoltArea3D::report_event(
 	p_callback.callv(arguments);
 }
 
-void JoltArea3D::notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock) {
+void JoltAreaImpl3D::notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock) {
 	const JoltReadableBody3D jolt_body = space->read_body(p_body_id, p_lock);
 
 	JoltBody3D* body = jolt_body.as_body();
@@ -373,7 +373,7 @@ void JoltArea3D::notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock) 
 	body->add_area(this, false);
 }
 
-void JoltArea3D::notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock) {
+void JoltAreaImpl3D::notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock) {
 	const JoltReadableBody3D jolt_body = space->read_body(p_body_id, p_lock);
 
 	JoltBody3D* body = jolt_body.as_body();
@@ -382,7 +382,7 @@ void JoltArea3D::notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock) {
 	body->remove_area(this, false);
 }
 
-void JoltArea3D::force_bodies_entered() {
+void JoltAreaImpl3D::force_bodies_entered() {
 	for (auto& [id, body] : bodies_by_id) {
 		for (const auto& [id_pair, index_pair] : body.shape_pairs) {
 			body.pending_added.push_back(index_pair);
@@ -390,7 +390,7 @@ void JoltArea3D::force_bodies_entered() {
 	}
 }
 
-void JoltArea3D::force_bodies_exited(bool p_remove, bool p_lock) {
+void JoltAreaImpl3D::force_bodies_exited(bool p_remove, bool p_lock) {
 	for (auto& [id, body] : bodies_by_id) {
 		for (const auto& [id_pair, index_pair] : body.shape_pairs) {
 			body.pending_removed.push_back(index_pair);
@@ -403,7 +403,7 @@ void JoltArea3D::force_bodies_exited(bool p_remove, bool p_lock) {
 	}
 }
 
-void JoltArea3D::force_areas_entered() {
+void JoltAreaImpl3D::force_areas_entered() {
 	for (auto& [id, area] : areas_by_id) {
 		for (const auto& [id_pair, index_pair] : area.shape_pairs) {
 			area.pending_added.push_back(index_pair);
@@ -411,7 +411,7 @@ void JoltArea3D::force_areas_entered() {
 	}
 }
 
-void JoltArea3D::force_areas_exited(bool p_remove, [[maybe_unused]] bool p_lock) {
+void JoltAreaImpl3D::force_areas_exited(bool p_remove, [[maybe_unused]] bool p_lock) {
 	for (auto& [id, area] : areas_by_id) {
 		for (const auto& [id_pair, index_pair] : area.shape_pairs) {
 			area.pending_removed.push_back(index_pair);
@@ -423,7 +423,7 @@ void JoltArea3D::force_areas_exited(bool p_remove, [[maybe_unused]] bool p_lock)
 	}
 }
 
-void JoltArea3D::space_changing(bool p_lock) {
+void JoltAreaImpl3D::space_changing(bool p_lock) {
 	if (space != nullptr) {
 		// HACK(mihe): Ideally we would rely on our contact listener to report all the exits when we
 		// move between (or out of) spaces, but because our Jolt body is going to be destroyed when
@@ -434,7 +434,7 @@ void JoltArea3D::space_changing(bool p_lock) {
 	}
 }
 
-void JoltArea3D::body_monitoring_changed() {
+void JoltAreaImpl3D::body_monitoring_changed() {
 	if (has_body_monitor_callback()) {
 		force_bodies_entered();
 	} else {
@@ -442,7 +442,7 @@ void JoltArea3D::body_monitoring_changed() {
 	}
 }
 
-void JoltArea3D::area_monitoring_changed() {
+void JoltAreaImpl3D::area_monitoring_changed() {
 	if (has_area_monitor_callback()) {
 		force_areas_entered();
 	} else {
@@ -450,6 +450,6 @@ void JoltArea3D::area_monitoring_changed() {
 	}
 }
 
-void JoltArea3D::monitorable_changed(bool p_lock) {
+void JoltAreaImpl3D::monitorable_changed(bool p_lock) {
 	update_object_layer(p_lock);
 }

--- a/src/objects/jolt_area_3d.cpp
+++ b/src/objects/jolt_area_3d.cpp
@@ -367,7 +367,7 @@ void JoltAreaImpl3D::report_event(
 void JoltAreaImpl3D::notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock) {
 	const JoltReadableBody3D jolt_body = space->read_body(p_body_id, p_lock);
 
-	JoltBody3D* body = jolt_body.as_body();
+	JoltBodyImpl3D* body = jolt_body.as_body();
 	QUIET_FAIL_NULL(body);
 
 	body->add_area(this, false);
@@ -376,7 +376,7 @@ void JoltAreaImpl3D::notify_body_entered(const JPH::BodyID& p_body_id, bool p_lo
 void JoltAreaImpl3D::notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock) {
 	const JoltReadableBody3D jolt_body = space->read_body(p_body_id, p_lock);
 
-	JoltBody3D* body = jolt_body.as_body();
+	JoltBodyImpl3D* body = jolt_body.as_body();
 	QUIET_FAIL_NULL(body);
 
 	body->remove_area(this, false);

--- a/src/objects/jolt_area_3d.cpp
+++ b/src/objects/jolt_area_3d.cpp
@@ -273,7 +273,7 @@ void JoltAreaImpl3D::add_shape_pair(
 	const JPH::SubShapeID& p_self_shape_id
 ) {
 	const JoltReadableBody3D other_jolt_body = space->read_body(p_body_id, false);
-	const JoltCollisionObject3D* other_object = other_jolt_body.as_object();
+	const JoltObjectImpl3D* other_object = other_jolt_body.as_object();
 	ERR_FAIL_NULL(other_object);
 
 	p_overlap.rid = other_object->get_rid();

--- a/src/objects/jolt_area_3d.hpp
+++ b/src/objects/jolt_area_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "objects/jolt_collision_object_3d.hpp"
 
-class JoltArea3D final : public JoltCollisionObject3D {
+class JoltAreaImpl3D final : public JoltCollisionObject3D {
 	struct BodyIDHasher {
 		static uint32_t hash(const JPH::BodyID& p_id) {
 			return hash_fmix32(p_id.GetIndexAndSequenceNumber());

--- a/src/objects/jolt_area_3d.hpp
+++ b/src/objects/jolt_area_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "objects/jolt_collision_object_3d.hpp"
 
-class JoltAreaImpl3D final : public JoltCollisionObject3D {
+class JoltAreaImpl3D final : public JoltObjectImpl3D {
 	struct BodyIDHasher {
 		static uint32_t hash(const JPH::BodyID& p_id) {
 			return hash_fmix32(p_id.GetIndexAndSequenceNumber());

--- a/src/objects/jolt_body_3d.cpp
+++ b/src/objects/jolt_body_3d.cpp
@@ -39,11 +39,11 @@ bool integrate(TValue& p_value, PhysicsServer3D::AreaSpaceOverrideMode p_mode, T
 
 } // namespace
 
-JoltBody3D::~JoltBody3D() {
+JoltBodyImpl3D::~JoltBodyImpl3D() {
 	memdelete_safely(direct_state);
 }
 
-Variant JoltBody3D::get_state(PhysicsServer3D::BodyState p_state) {
+Variant JoltBodyImpl3D::get_state(PhysicsServer3D::BodyState p_state) {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
 			return get_transform_scaled();
@@ -66,7 +66,7 @@ Variant JoltBody3D::get_state(PhysicsServer3D::BodyState p_state) {
 	}
 }
 
-void JoltBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value) {
+void JoltBodyImpl3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value) {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
 			set_transform(p_value);
@@ -89,7 +89,7 @@ void JoltBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_
 	}
 }
 
-Variant JoltBody3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
+Variant JoltBodyImpl3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::BODY_PARAM_BOUNCE: {
 			return get_bounce();
@@ -127,7 +127,7 @@ Variant JoltBody3D::get_param(PhysicsServer3D::BodyParameter p_param) const {
 	}
 }
 
-void JoltBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value) {
+void JoltBodyImpl3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::BODY_PARAM_BOUNCE: {
 			set_bounce(p_value);
@@ -165,7 +165,7 @@ void JoltBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Variant
 	}
 }
 
-JPH::BroadPhaseLayer JoltBody3D::get_broad_phase_layer() const {
+JPH::BroadPhaseLayer JoltBodyImpl3D::get_broad_phase_layer() const {
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {
 			return JoltBroadPhaseLayer::BODY_STATIC;
@@ -181,7 +181,7 @@ JPH::BroadPhaseLayer JoltBody3D::get_broad_phase_layer() const {
 	}
 }
 
-bool JoltBody3D::is_sleeping(bool p_lock) const {
+bool JoltBodyImpl3D::is_sleeping(bool p_lock) const {
 	if (space == nullptr) {
 		// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or
 		// less impossible to have a body be sleeping when created, so we simply report this as not
@@ -195,7 +195,7 @@ bool JoltBody3D::is_sleeping(bool p_lock) const {
 	return !body->IsActive();
 }
 
-void JoltBody3D::set_is_sleeping(bool p_enabled, bool p_lock) {
+void JoltBodyImpl3D::set_is_sleeping(bool p_enabled, bool p_lock) {
 	if (space == nullptr) {
 		// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or
 		// less impossible to have a body be sleeping when created, so we don't bother storing this.
@@ -211,7 +211,7 @@ void JoltBody3D::set_is_sleeping(bool p_enabled, bool p_lock) {
 	}
 }
 
-bool JoltBody3D::can_sleep(bool p_lock) const {
+bool JoltBodyImpl3D::can_sleep(bool p_lock) const {
 	if (space == nullptr) {
 		return jolt_settings->mAllowSleeping;
 	}
@@ -222,7 +222,7 @@ bool JoltBody3D::can_sleep(bool p_lock) const {
 	return body->GetAllowSleeping();
 }
 
-void JoltBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
+void JoltBodyImpl3D::set_can_sleep(bool p_enabled, bool p_lock) {
 	if (space == nullptr) {
 		jolt_settings->mAllowSleeping = p_enabled;
 		return;
@@ -234,7 +234,7 @@ void JoltBody3D::set_can_sleep(bool p_enabled, bool p_lock) {
 	body->SetAllowSleeping(p_enabled);
 }
 
-Basis JoltBody3D::get_principal_inertia_axes(bool p_lock) const {
+Basis JoltBodyImpl3D::get_principal_inertia_axes(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	if (is_static() || is_kinematic()) {
@@ -253,7 +253,7 @@ Basis JoltBody3D::get_principal_inertia_axes(bool p_lock) const {
 	return principal_inertia_axes;
 }
 
-Vector3 JoltBody3D::get_inverse_inertia(bool p_lock) const {
+Vector3 JoltBodyImpl3D::get_inverse_inertia(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	if (is_static() || is_kinematic()) {
@@ -266,7 +266,7 @@ Vector3 JoltBody3D::get_inverse_inertia(bool p_lock) const {
 	return to_godot(body->GetMotionPropertiesUnchecked()->GetInverseInertiaDiagonal());
 }
 
-Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
+Basis JoltBodyImpl3D::get_inverse_inertia_tensor(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	if (is_static() || is_kinematic()) {
@@ -279,7 +279,7 @@ Basis JoltBody3D::get_inverse_inertia_tensor(bool p_lock) const {
 	return to_godot(body->GetInverseInertia()).basis;
 }
 
-void JoltBody3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
+void JoltBodyImpl3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
 	if (space == nullptr) {
 		jolt_settings->mLinearVelocity = to_jolt(p_velocity);
 		motion_changed(p_lock);
@@ -294,7 +294,7 @@ void JoltBody3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
+void JoltBodyImpl3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
 	if (space == nullptr) {
 		jolt_settings->mAngularVelocity = to_jolt(p_velocity);
 		motion_changed(p_lock);
@@ -309,7 +309,7 @@ void JoltBody3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock) {
+void JoltBodyImpl3D::set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock) {
 	const Vector3 axis = p_axis_velocity.normalized();
 
 	if (space == nullptr) {
@@ -332,7 +332,7 @@ void JoltBody3D::set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock) 
 	}
 }
 
-void JoltBody3D::set_center_of_mass_custom(const Vector3& p_center_of_mass, bool p_lock) {
+void JoltBodyImpl3D::set_center_of_mass_custom(const Vector3& p_center_of_mass, bool p_lock) {
 	if (custom_center_of_mass && p_center_of_mass == center_of_mass_custom) {
 		return;
 	}
@@ -343,8 +343,8 @@ void JoltBody3D::set_center_of_mass_custom(const Vector3& p_center_of_mass, bool
 	build_shape(p_lock);
 }
 
-void JoltBody3D::add_contact(
-	const JoltBody3D* p_collider,
+void JoltBodyImpl3D::add_contact(
+	const JoltBodyImpl3D* p_collider,
 	float p_depth,
 	int32_t p_shape_index,
 	int32_t p_collider_shape_index,
@@ -391,14 +391,14 @@ void JoltBody3D::add_contact(
 	}
 }
 
-void JoltBody3D::reset_mass_properties(bool p_lock) {
+void JoltBodyImpl3D::reset_mass_properties(bool p_lock) {
 	inertia.zero();
 	custom_center_of_mass = false;
 	center_of_mass_custom.zero();
 	update_mass_properties(p_lock);
 }
 
-void JoltBody3D::apply_force(const Vector3& p_force, const Vector3& p_position, bool p_lock) {
+void JoltBodyImpl3D::apply_force(const Vector3& p_force, const Vector3& p_position, bool p_lock) {
 	ERR_FAIL_NULL(space);
 
 	if (p_force == Vector3()) {
@@ -413,7 +413,7 @@ void JoltBody3D::apply_force(const Vector3& p_force, const Vector3& p_position, 
 	motion_changed(false);
 }
 
-void JoltBody3D::apply_central_force(const Vector3& p_force, bool p_lock) {
+void JoltBodyImpl3D::apply_central_force(const Vector3& p_force, bool p_lock) {
 	ERR_FAIL_NULL(space);
 
 	if (p_force == Vector3()) {
@@ -428,7 +428,11 @@ void JoltBody3D::apply_central_force(const Vector3& p_force, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::apply_impulse(const Vector3& p_impulse, const Vector3& p_position, bool p_lock) {
+void JoltBodyImpl3D::apply_impulse(
+	const Vector3& p_impulse,
+	const Vector3& p_position,
+	bool p_lock
+) {
 	ERR_FAIL_NULL(space);
 
 	if (p_impulse == Vector3()) {
@@ -443,7 +447,7 @@ void JoltBody3D::apply_impulse(const Vector3& p_impulse, const Vector3& p_positi
 	motion_changed(false);
 }
 
-void JoltBody3D::apply_central_impulse(const Vector3& p_impulse, bool p_lock) {
+void JoltBodyImpl3D::apply_central_impulse(const Vector3& p_impulse, bool p_lock) {
 	ERR_FAIL_NULL(space);
 
 	if (p_impulse == Vector3()) {
@@ -458,7 +462,7 @@ void JoltBody3D::apply_central_impulse(const Vector3& p_impulse, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::apply_torque(const Vector3& p_torque, bool p_lock) {
+void JoltBodyImpl3D::apply_torque(const Vector3& p_torque, bool p_lock) {
 	ERR_FAIL_NULL(space);
 
 	if (p_torque == Vector3()) {
@@ -473,7 +477,7 @@ void JoltBody3D::apply_torque(const Vector3& p_torque, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::apply_torque_impulse(const Vector3& p_impulse, bool p_lock) {
+void JoltBodyImpl3D::apply_torque_impulse(const Vector3& p_impulse, bool p_lock) {
 	ERR_FAIL_NULL(space);
 
 	if (p_impulse == Vector3()) {
@@ -488,7 +492,7 @@ void JoltBody3D::apply_torque_impulse(const Vector3& p_impulse, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::add_constant_central_force(const Vector3& p_force, bool p_lock) {
+void JoltBodyImpl3D::add_constant_central_force(const Vector3& p_force, bool p_lock) {
 	if (p_force == Vector3()) {
 		return;
 	}
@@ -498,7 +502,7 @@ void JoltBody3D::add_constant_central_force(const Vector3& p_force, bool p_lock)
 	motion_changed(p_lock);
 }
 
-void JoltBody3D::add_constant_force(
+void JoltBodyImpl3D::add_constant_force(
 	const Vector3& p_force,
 	const Vector3& p_position,
 	bool p_lock
@@ -520,7 +524,7 @@ void JoltBody3D::add_constant_force(
 	motion_changed(false);
 }
 
-void JoltBody3D::add_constant_torque(const Vector3& p_torque, bool p_lock) {
+void JoltBodyImpl3D::add_constant_torque(const Vector3& p_torque, bool p_lock) {
 	if (p_torque == Vector3()) {
 		return;
 	}
@@ -530,11 +534,11 @@ void JoltBody3D::add_constant_torque(const Vector3& p_torque, bool p_lock) {
 	motion_changed(p_lock);
 }
 
-Vector3 JoltBody3D::get_constant_force() const {
+Vector3 JoltBodyImpl3D::get_constant_force() const {
 	return constant_force;
 }
 
-void JoltBody3D::set_constant_force(const Vector3& p_force, bool p_lock) {
+void JoltBodyImpl3D::set_constant_force(const Vector3& p_force, bool p_lock) {
 	if (constant_force == p_force) {
 		return;
 	}
@@ -544,11 +548,11 @@ void JoltBody3D::set_constant_force(const Vector3& p_force, bool p_lock) {
 	motion_changed(p_lock);
 }
 
-Vector3 JoltBody3D::get_constant_torque() const {
+Vector3 JoltBodyImpl3D::get_constant_torque() const {
 	return constant_torque;
 }
 
-void JoltBody3D::set_constant_torque(const Vector3& p_torque, bool p_lock) {
+void JoltBodyImpl3D::set_constant_torque(const Vector3& p_torque, bool p_lock) {
 	if (constant_torque == p_torque) {
 		return;
 	}
@@ -558,7 +562,7 @@ void JoltBody3D::set_constant_torque(const Vector3& p_torque, bool p_lock) {
 	motion_changed(p_lock);
 }
 
-void JoltBody3D::add_collision_exception(const RID& p_excepted_body, bool p_lock) {
+void JoltBodyImpl3D::add_collision_exception(const RID& p_excepted_body, bool p_lock) {
 	const JoltWritableBody3D body = space->write_body(jolt_id, p_lock);
 	ERR_FAIL_COND(body.is_invalid());
 
@@ -574,7 +578,7 @@ void JoltBody3D::add_collision_exception(const RID& p_excepted_body, bool p_lock
 	group_filter->add_exception(p_excepted_body);
 }
 
-void JoltBody3D::remove_collision_exception(const RID& p_excepted_body, bool p_lock) {
+void JoltBodyImpl3D::remove_collision_exception(const RID& p_excepted_body, bool p_lock) {
 	const JoltWritableBody3D body = space->write_body(jolt_id, p_lock);
 	ERR_FAIL_COND(body.is_invalid());
 
@@ -594,7 +598,7 @@ void JoltBody3D::remove_collision_exception(const RID& p_excepted_body, bool p_l
 	}
 }
 
-bool JoltBody3D::has_collision_exception(const RID& p_excepted_body, bool p_lock) const {
+bool JoltBodyImpl3D::has_collision_exception(const RID& p_excepted_body, bool p_lock) const {
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
 
@@ -605,7 +609,7 @@ bool JoltBody3D::has_collision_exception(const RID& p_excepted_body, bool p_lock
 	return group_filter != nullptr && group_filter->has_exception(p_excepted_body);
 }
 
-TypedArray<RID> JoltBody3D::get_collision_exceptions(bool p_lock) const {
+TypedArray<RID> JoltBodyImpl3D::get_collision_exceptions(bool p_lock) const {
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
 
@@ -629,7 +633,7 @@ TypedArray<RID> JoltBody3D::get_collision_exceptions(bool p_lock) const {
 	return result;
 }
 
-void JoltBody3D::add_area(JoltAreaImpl3D* p_area, bool p_lock) {
+void JoltBodyImpl3D::add_area(JoltAreaImpl3D* p_area, bool p_lock) {
 	areas.ordered_insert(p_area, [](const JoltAreaImpl3D* p_lhs, const JoltAreaImpl3D* p_rhs) {
 		return p_lhs->get_priority() > p_rhs->get_priority();
 	});
@@ -637,13 +641,13 @@ void JoltBody3D::add_area(JoltAreaImpl3D* p_area, bool p_lock) {
 	areas_changed(p_lock);
 }
 
-void JoltBody3D::remove_area(JoltAreaImpl3D* p_area, bool p_lock) {
+void JoltBodyImpl3D::remove_area(JoltAreaImpl3D* p_area, bool p_lock) {
 	areas.erase(p_area);
 
 	areas_changed(p_lock);
 }
 
-void JoltBody3D::integrate_forces(float p_step, bool p_lock) {
+void JoltBodyImpl3D::integrate_forces(float p_step, bool p_lock) {
 	const JoltWritableBody3D jolt_body = space->write_body(jolt_id, p_lock);
 	ERR_FAIL_COND(jolt_body.is_invalid());
 
@@ -679,7 +683,7 @@ void JoltBody3D::integrate_forces(float p_step, bool p_lock) {
 	jolt_body->AddTorque(to_jolt(constant_torque));
 }
 
-void JoltBody3D::call_queries() {
+void JoltBodyImpl3D::call_queries() {
 	if (force_integration_callback.is_valid()) {
 		static thread_local Array arguments = []() {
 			Array array;
@@ -706,7 +710,7 @@ void JoltBody3D::call_queries() {
 	}
 }
 
-void JoltBody3D::pre_step(float p_step) {
+void JoltBodyImpl3D::pre_step(float p_step) {
 	JoltCollisionObject3D::pre_step(p_step);
 
 	if (is_rigid() && !is_sleeping(false)) {
@@ -716,7 +720,7 @@ void JoltBody3D::pre_step(float p_step) {
 	contact_count = 0;
 }
 
-JoltPhysicsDirectBodyState3D* JoltBody3D::get_direct_state() {
+JoltPhysicsDirectBodyState3D* JoltBodyImpl3D::get_direct_state() {
 	if (direct_state == nullptr) {
 		direct_state = memnew(JoltPhysicsDirectBodyState3D(this));
 	}
@@ -724,7 +728,7 @@ JoltPhysicsDirectBodyState3D* JoltBody3D::get_direct_state() {
 	return direct_state;
 }
 
-void JoltBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
+void JoltBodyImpl3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
 	if (p_mode == mode) {
 		return;
 	}
@@ -759,7 +763,7 @@ void JoltBody3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
 	mode_changed(false);
 }
 
-bool JoltBody3D::is_ccd_enabled(bool p_lock) const {
+bool JoltBodyImpl3D::is_ccd_enabled(bool p_lock) const {
 	if (space == nullptr) {
 		return jolt_settings->mMotionQuality == JPH::EMotionQuality::LinearCast;
 	}
@@ -769,7 +773,7 @@ bool JoltBody3D::is_ccd_enabled(bool p_lock) const {
 	return body_iface.GetMotionQuality(jolt_id) == JPH::EMotionQuality::LinearCast;
 }
 
-void JoltBody3D::set_ccd_enabled(bool p_enabled, bool p_lock) {
+void JoltBodyImpl3D::set_ccd_enabled(bool p_enabled, bool p_lock) {
 	const JPH::EMotionQuality motion_quality = p_enabled
 		? JPH::EMotionQuality::LinearCast
 		: JPH::EMotionQuality::Discrete;
@@ -784,21 +788,21 @@ void JoltBody3D::set_ccd_enabled(bool p_enabled, bool p_lock) {
 	body_iface.SetMotionQuality(jolt_id, motion_quality);
 }
 
-void JoltBody3D::set_mass(float p_mass, bool p_lock) {
+void JoltBodyImpl3D::set_mass(float p_mass, bool p_lock) {
 	if (p_mass != mass) {
 		mass = p_mass;
 		update_mass_properties(p_lock);
 	}
 }
 
-void JoltBody3D::set_inertia(const Vector3& p_inertia, bool p_lock) {
+void JoltBodyImpl3D::set_inertia(const Vector3& p_inertia, bool p_lock) {
 	if (p_inertia != inertia) {
 		inertia = p_inertia;
 		update_mass_properties(p_lock);
 	}
 }
 
-float JoltBody3D::get_bounce(bool p_lock) const {
+float JoltBodyImpl3D::get_bounce(bool p_lock) const {
 	if (space == nullptr) {
 		return jolt_settings->mRestitution;
 	}
@@ -809,7 +813,7 @@ float JoltBody3D::get_bounce(bool p_lock) const {
 	return body->GetRestitution();
 }
 
-void JoltBody3D::set_bounce(float p_bounce, bool p_lock) {
+void JoltBodyImpl3D::set_bounce(float p_bounce, bool p_lock) {
 	if (p_bounce < 0.0f || p_bounce > 1.0f) {
 		WARN_PRINT(
 			"Bounce values less than 0 or greater than 1 are not supported by Godot Jolt. "
@@ -830,7 +834,7 @@ void JoltBody3D::set_bounce(float p_bounce, bool p_lock) {
 	body->SetRestitution(p_bounce);
 }
 
-float JoltBody3D::get_friction(bool p_lock) const {
+float JoltBodyImpl3D::get_friction(bool p_lock) const {
 	if (space == nullptr) {
 		return jolt_settings->mFriction;
 	}
@@ -841,7 +845,7 @@ float JoltBody3D::get_friction(bool p_lock) const {
 	return body->GetFriction();
 }
 
-void JoltBody3D::set_friction(float p_friction, bool p_lock) {
+void JoltBodyImpl3D::set_friction(float p_friction, bool p_lock) {
 	if (p_friction < 0.0f) {
 		WARN_PRINT(
 			"Friction values less than 0 are not supported by Godot Jolt. "
@@ -862,7 +866,7 @@ void JoltBody3D::set_friction(float p_friction, bool p_lock) {
 	body->SetRestitution(p_friction);
 }
 
-float JoltBody3D::get_gravity_scale(bool p_lock) const {
+float JoltBodyImpl3D::get_gravity_scale(bool p_lock) const {
 	if (space == nullptr) {
 		return jolt_settings->mGravityFactor;
 	}
@@ -873,7 +877,7 @@ float JoltBody3D::get_gravity_scale(bool p_lock) const {
 	return body->GetMotionPropertiesUnchecked()->GetGravityFactor();
 }
 
-void JoltBody3D::set_gravity_scale(float p_scale, bool p_lock) {
+void JoltBodyImpl3D::set_gravity_scale(float p_scale, bool p_lock) {
 	if (space == nullptr) {
 		jolt_settings->mGravityFactor = p_scale;
 		return;
@@ -887,7 +891,7 @@ void JoltBody3D::set_gravity_scale(float p_scale, bool p_lock) {
 	motion_changed(false);
 }
 
-void JoltBody3D::set_linear_damp(float p_damp, bool p_lock) {
+void JoltBodyImpl3D::set_linear_damp(float p_damp, bool p_lock) {
 	if (p_damp < 0.0f) {
 		WARN_PRINT(
 			"Linear damp values less than 0 are not supported by Godot Jolt. "
@@ -906,7 +910,7 @@ void JoltBody3D::set_linear_damp(float p_damp, bool p_lock) {
 	update_damp(p_lock);
 }
 
-void JoltBody3D::set_angular_damp(float p_damp, bool p_lock) {
+void JoltBodyImpl3D::set_angular_damp(float p_damp, bool p_lock) {
 	if (p_damp < 0.0f) {
 		WARN_PRINT(
 			"Angular damp values less than 0 are not supported by Godot Jolt. "
@@ -925,7 +929,7 @@ void JoltBody3D::set_angular_damp(float p_damp, bool p_lock) {
 	update_damp(p_lock);
 }
 
-float JoltBody3D::get_total_linear_damp(bool p_lock) const {
+float JoltBodyImpl3D::get_total_linear_damp(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
@@ -934,7 +938,7 @@ float JoltBody3D::get_total_linear_damp(bool p_lock) const {
 	return body->GetMotionPropertiesUnchecked()->GetLinearDamping();
 }
 
-float JoltBody3D::get_total_angular_damp(bool p_lock) const {
+float JoltBodyImpl3D::get_total_angular_damp(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
@@ -943,11 +947,15 @@ float JoltBody3D::get_total_angular_damp(bool p_lock) const {
 	return body->GetMotionPropertiesUnchecked()->GetAngularDamping();
 }
 
-bool JoltBody3D::is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const {
+bool JoltBodyImpl3D::is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const {
 	return (locked_axes & (uint32_t)p_axis) != 0;
 }
 
-void JoltBody3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock_axis, bool p_lock) {
+void JoltBodyImpl3D::set_axis_lock(
+	PhysicsServer3D::BodyAxis p_axis,
+	bool p_lock_axis,
+	bool p_lock
+) {
 	const uint32_t previous_locked_axes = locked_axes;
 
 	if (p_lock_axis) {
@@ -961,7 +969,7 @@ void JoltBody3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock_axi
 	}
 }
 
-JPH::EMotionType JoltBody3D::get_motion_type() const {
+JPH::EMotionType JoltBodyImpl3D::get_motion_type() const {
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {
 			return JPH::EMotionType::Static;
@@ -979,7 +987,7 @@ JPH::EMotionType JoltBody3D::get_motion_type() const {
 	}
 }
 
-void JoltBody3D::create_in_space() {
+void JoltBodyImpl3D::create_in_space() {
 	create_begin();
 
 	jolt_settings->mAllowDynamicOrKinematic = true;
@@ -1002,7 +1010,7 @@ void JoltBody3D::create_in_space() {
 	body->SetCollisionGroup(JPH::CollisionGroup(nullptr, group_id, sub_group_id));
 }
 
-JPH::MassProperties JoltBody3D::calculate_mass_properties(const JPH::Shape& p_shape) const {
+JPH::MassProperties JoltBodyImpl3D::calculate_mass_properties(const JPH::Shape& p_shape) const {
 	const bool calculate_mass = mass <= 0;
 	const bool calculate_inertia = inertia.x <= 0 || inertia.y <= 0 || inertia.z <= 0;
 
@@ -1021,11 +1029,11 @@ JPH::MassProperties JoltBody3D::calculate_mass_properties(const JPH::Shape& p_sh
 	return mass_properties;
 }
 
-JPH::MassProperties JoltBody3D::calculate_mass_properties() const {
+JPH::MassProperties JoltBodyImpl3D::calculate_mass_properties() const {
 	return calculate_mass_properties(*jolt_shape);
 }
 
-void JoltBody3D::update_mass_properties(bool p_lock) {
+void JoltBodyImpl3D::update_mass_properties(bool p_lock) {
 	if (space == nullptr) {
 		return;
 	}
@@ -1036,7 +1044,7 @@ void JoltBody3D::update_mass_properties(bool p_lock) {
 	body->GetMotionPropertiesUnchecked()->SetMassProperties(calculate_mass_properties());
 }
 
-void JoltBody3D::update_damp(bool p_lock) {
+void JoltBodyImpl3D::update_damp(bool p_lock) {
 	if (space == nullptr) {
 		return;
 	}
@@ -1102,7 +1110,7 @@ void JoltBody3D::update_damp(bool p_lock) {
 	motion_properties.SetAngularDamping(total_angular_damp);
 }
 
-void JoltBody3D::update_axes_constraint(bool p_lock) {
+void JoltBodyImpl3D::update_axes_constraint(bool p_lock) {
 	if (space == nullptr) {
 		return;
 	}
@@ -1149,47 +1157,47 @@ void JoltBody3D::update_axes_constraint(bool p_lock) {
 	space->add_joint(axes_constraint);
 }
 
-void JoltBody3D::destroy_axes_constraint() {
+void JoltBodyImpl3D::destroy_axes_constraint() {
 	if (space != nullptr && axes_constraint != nullptr) {
 		space->remove_joint(axes_constraint);
 		axes_constraint = nullptr;
 	}
 }
 
-void JoltBody3D::mode_changed(bool p_lock) {
+void JoltBodyImpl3D::mode_changed(bool p_lock) {
 	update_object_layer(p_lock);
 	update_axes_constraint(p_lock);
 	wake_up(p_lock);
 }
 
-void JoltBody3D::shapes_built(bool p_lock) {
+void JoltBodyImpl3D::shapes_built(bool p_lock) {
 	update_mass_properties(p_lock);
 	wake_up(p_lock);
 }
 
-void JoltBody3D::space_changing([[maybe_unused]] bool p_lock) {
+void JoltBodyImpl3D::space_changing([[maybe_unused]] bool p_lock) {
 	destroy_axes_constraint();
 }
 
-void JoltBody3D::space_changed(bool p_lock) {
+void JoltBodyImpl3D::space_changed(bool p_lock) {
 	update_axes_constraint();
 	areas_changed(p_lock);
 }
 
-void JoltBody3D::areas_changed(bool p_lock) {
+void JoltBodyImpl3D::areas_changed(bool p_lock) {
 	update_damp(p_lock);
 	wake_up(p_lock);
 }
 
-void JoltBody3D::transform_changed(bool p_lock) {
+void JoltBodyImpl3D::transform_changed(bool p_lock) {
 	wake_up(p_lock);
 }
 
-void JoltBody3D::motion_changed(bool p_lock) {
+void JoltBodyImpl3D::motion_changed(bool p_lock) {
 	wake_up(p_lock);
 }
 
-void JoltBody3D::axis_lock_changed(bool p_lock) {
+void JoltBodyImpl3D::axis_lock_changed(bool p_lock) {
 	update_axes_constraint(p_lock);
 	wake_up(p_lock);
 }

--- a/src/objects/jolt_body_3d.cpp
+++ b/src/objects/jolt_body_3d.cpp
@@ -629,15 +629,15 @@ TypedArray<RID> JoltBody3D::get_collision_exceptions(bool p_lock) const {
 	return result;
 }
 
-void JoltBody3D::add_area(JoltArea3D* p_area, bool p_lock) {
-	areas.ordered_insert(p_area, [](const JoltArea3D* p_lhs, const JoltArea3D* p_rhs) {
+void JoltBody3D::add_area(JoltAreaImpl3D* p_area, bool p_lock) {
+	areas.ordered_insert(p_area, [](const JoltAreaImpl3D* p_lhs, const JoltAreaImpl3D* p_rhs) {
 		return p_lhs->get_priority() > p_rhs->get_priority();
 	});
 
 	areas_changed(p_lock);
 }
 
-void JoltBody3D::remove_area(JoltArea3D* p_area, bool p_lock) {
+void JoltBody3D::remove_area(JoltAreaImpl3D* p_area, bool p_lock) {
 	areas.erase(p_area);
 
 	areas_changed(p_lock);
@@ -653,7 +653,7 @@ void JoltBody3D::integrate_forces(float p_step, bool p_lock) {
 
 	bool gravity_done = false;
 
-	for (const JoltArea3D* area : areas) {
+	for (const JoltAreaImpl3D* area : areas) {
 		gravity_done = integrate(gravity, area->get_gravity_mode(), [&]() {
 			return area->compute_gravity(position);
 		});
@@ -1047,7 +1047,7 @@ void JoltBody3D::update_damp(bool p_lock) {
 	bool linear_damp_done = linear_damp_mode == PhysicsServer3D::BODY_DAMP_MODE_REPLACE;
 	bool angular_damp_done = angular_damp_mode == PhysicsServer3D::BODY_DAMP_MODE_REPLACE;
 
-	for (const JoltArea3D* area : areas) {
+	for (const JoltAreaImpl3D* area : areas) {
 		if (!linear_damp_done) {
 			linear_damp_done = integrate(total_linear_damp, area->get_linear_damp_mode(), [&]() {
 				return area->get_linear_damp();
@@ -1065,7 +1065,7 @@ void JoltBody3D::update_damp(bool p_lock) {
 		}
 	}
 
-	const JoltArea3D* default_area = space->get_default_area();
+	const JoltAreaImpl3D* default_area = space->get_default_area();
 
 	if (!linear_damp_done) {
 		total_linear_damp += default_area->get_linear_damp();

--- a/src/objects/jolt_body_3d.cpp
+++ b/src/objects/jolt_body_3d.cpp
@@ -711,7 +711,7 @@ void JoltBodyImpl3D::call_queries() {
 }
 
 void JoltBodyImpl3D::pre_step(float p_step) {
-	JoltCollisionObject3D::pre_step(p_step);
+	JoltObjectImpl3D::pre_step(p_step);
 
 	if (is_rigid() && !is_sleeping(false)) {
 		integrate_forces(p_step, false);

--- a/src/objects/jolt_body_3d.hpp
+++ b/src/objects/jolt_body_3d.hpp
@@ -5,7 +5,7 @@
 
 class JoltAreaImpl3D;
 
-class JoltBodyImpl3D final : public JoltCollisionObject3D {
+class JoltBodyImpl3D final : public JoltObjectImpl3D {
 public:
 	using DampMode = PhysicsServer3D::BodyDampMode;
 

--- a/src/objects/jolt_body_3d.hpp
+++ b/src/objects/jolt_body_3d.hpp
@@ -5,7 +5,7 @@
 
 class JoltAreaImpl3D;
 
-class JoltBody3D final : public JoltCollisionObject3D {
+class JoltBodyImpl3D final : public JoltCollisionObject3D {
 public:
 	using DampMode = PhysicsServer3D::BodyDampMode;
 
@@ -31,7 +31,7 @@ public:
 		Vector3 impulse;
 	};
 
-	~JoltBody3D() override;
+	~JoltBodyImpl3D() override;
 
 	Variant get_state(PhysicsServer3D::BodyState p_state);
 
@@ -95,7 +95,7 @@ public:
 	bool generates_contacts() const override { return !contacts.is_empty(); }
 
 	void add_contact(
-		const JoltBody3D* p_collider,
+		const JoltBodyImpl3D* p_collider,
 		float p_depth,
 		int32_t p_shape_index,
 		int32_t p_collider_shape_index,

--- a/src/objects/jolt_body_3d.hpp
+++ b/src/objects/jolt_body_3d.hpp
@@ -3,7 +3,7 @@
 #include "objects/jolt_collision_object_3d.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
 
-class JoltArea3D;
+class JoltAreaImpl3D;
 
 class JoltBody3D final : public JoltCollisionObject3D {
 public:
@@ -142,9 +142,9 @@ public:
 
 	TypedArray<RID> get_collision_exceptions(bool p_lock = true) const;
 
-	void add_area(JoltArea3D* p_area, bool p_lock = true);
+	void add_area(JoltAreaImpl3D* p_area, bool p_lock = true);
 
-	void remove_area(JoltArea3D* p_area, bool p_lock = true);
+	void remove_area(JoltAreaImpl3D* p_area, bool p_lock = true);
 
 	void integrate_forces(float p_step, bool p_lock = true);
 
@@ -259,7 +259,7 @@ private:
 
 	LocalVector<Contact> contacts;
 
-	LocalVector<JoltArea3D*> areas;
+	LocalVector<JoltAreaImpl3D*> areas;
 
 	Variant force_integration_userdata;
 

--- a/src/objects/jolt_collision_object_3d.cpp
+++ b/src/objects/jolt_collision_object_3d.cpp
@@ -6,7 +6,7 @@
 #include "spaces/jolt_layer_mapper.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
-JoltCollisionObject3D::JoltCollisionObject3D() {
+JoltObjectImpl3D::JoltObjectImpl3D() {
 	jolt_settings->mAllowSleeping = true;
 	jolt_settings->mFriction = 1.0f;
 	jolt_settings->mRestitution = 0.0f;
@@ -15,15 +15,15 @@ JoltCollisionObject3D::JoltCollisionObject3D() {
 	jolt_settings->mGravityFactor = 1.0f;
 }
 
-JoltCollisionObject3D::~JoltCollisionObject3D() {
+JoltObjectImpl3D::~JoltObjectImpl3D() {
 	delete_safely(jolt_settings);
 }
 
-GodotObject* JoltCollisionObject3D::get_instance() const {
+GodotObject* JoltObjectImpl3D::get_instance() const {
 	return internal::gde_interface->object_get_instance_from_id(instance_id);
 }
 
-Object* JoltCollisionObject3D::get_instance_unsafe() const {
+Object* JoltObjectImpl3D::get_instance_unsafe() const {
 	// HACK(mihe): This is being deliberately and incorrectly cast to a godot-cpp `Object` when in
 	// reality it's a Godot `Object`. This is meant to be used in places where an `Object` is
 	// returned through a parameter, such as in `PhysicsServer3DExtensionRayResult`, because
@@ -33,11 +33,11 @@ Object* JoltCollisionObject3D::get_instance_unsafe() const {
 	return reinterpret_cast<Object*>(get_instance());
 }
 
-Object* JoltCollisionObject3D::get_instance_wrapped() const {
+Object* JoltObjectImpl3D::get_instance_wrapped() const {
 	return ObjectDB::get_instance(instance_id);
 }
 
-void JoltCollisionObject3D::set_space(JoltSpace3D* p_space, bool p_lock) {
+void JoltObjectImpl3D::set_space(JoltSpace3D* p_space, bool p_lock) {
 	if (space == p_space) {
 		return;
 	}
@@ -64,7 +64,7 @@ void JoltCollisionObject3D::set_space(JoltSpace3D* p_space, bool p_lock) {
 	space_changed(p_lock);
 }
 
-void JoltCollisionObject3D::set_collision_layer(uint32_t p_layer, bool p_lock) {
+void JoltObjectImpl3D::set_collision_layer(uint32_t p_layer, bool p_lock) {
 	if (p_layer == collision_layer) {
 		return;
 	}
@@ -74,7 +74,7 @@ void JoltCollisionObject3D::set_collision_layer(uint32_t p_layer, bool p_lock) {
 	collision_layer_changed(p_lock);
 }
 
-void JoltCollisionObject3D::set_collision_mask(uint32_t p_mask, bool p_lock) {
+void JoltObjectImpl3D::set_collision_mask(uint32_t p_mask, bool p_lock) {
 	if (p_mask == collision_mask) {
 		return;
 	}
@@ -84,7 +84,7 @@ void JoltCollisionObject3D::set_collision_mask(uint32_t p_mask, bool p_lock) {
 	collision_mask_changed(p_lock);
 }
 
-Transform3D JoltCollisionObject3D::get_transform_unscaled(bool p_lock) const {
+Transform3D JoltObjectImpl3D::get_transform_unscaled(bool p_lock) const {
 	if (space == nullptr) {
 		return {to_godot(jolt_settings->mRotation), to_godot(jolt_settings->mPosition)};
 	}
@@ -95,11 +95,11 @@ Transform3D JoltCollisionObject3D::get_transform_unscaled(bool p_lock) const {
 	return {to_godot(body->GetRotation()), to_godot(body->GetPosition())};
 }
 
-Transform3D JoltCollisionObject3D::get_transform_scaled(bool p_lock) const {
+Transform3D JoltObjectImpl3D::get_transform_scaled(bool p_lock) const {
 	return get_transform_unscaled(p_lock).scaled_local(scale);
 }
 
-void JoltCollisionObject3D::set_transform(Transform3D p_transform, bool p_lock) {
+void JoltObjectImpl3D::set_transform(Transform3D p_transform, bool p_lock) {
 	Vector3 new_scale;
 	Math::decompose(p_transform, new_scale);
 
@@ -130,7 +130,7 @@ void JoltCollisionObject3D::set_transform(Transform3D p_transform, bool p_lock) 
 	transform_changed(p_lock);
 }
 
-Basis JoltCollisionObject3D::get_basis(bool p_lock) const {
+Basis JoltObjectImpl3D::get_basis(bool p_lock) const {
 	if (space == nullptr) {
 		return to_godot(jolt_settings->mRotation);
 	}
@@ -141,7 +141,7 @@ Basis JoltCollisionObject3D::get_basis(bool p_lock) const {
 	return to_godot(body->GetRotation());
 }
 
-Vector3 JoltCollisionObject3D::get_position(bool p_lock) const {
+Vector3 JoltObjectImpl3D::get_position(bool p_lock) const {
 	if (space == nullptr) {
 		return to_godot(jolt_settings->mPosition);
 	}
@@ -152,7 +152,7 @@ Vector3 JoltCollisionObject3D::get_position(bool p_lock) const {
 	return to_godot(body->GetPosition());
 }
 
-Vector3 JoltCollisionObject3D::get_center_of_mass(bool p_lock) const {
+Vector3 JoltObjectImpl3D::get_center_of_mass(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
@@ -161,13 +161,13 @@ Vector3 JoltCollisionObject3D::get_center_of_mass(bool p_lock) const {
 	return to_godot(body->GetCenterOfMassPosition());
 }
 
-Vector3 JoltCollisionObject3D::get_center_of_mass_local(bool p_lock) const {
+Vector3 JoltObjectImpl3D::get_center_of_mass_local(bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	return get_transform_scaled(p_lock).xform_inv(get_center_of_mass(p_lock));
 }
 
-Vector3 JoltCollisionObject3D::get_linear_velocity(bool p_lock) const {
+Vector3 JoltObjectImpl3D::get_linear_velocity(bool p_lock) const {
 	if (space == nullptr) {
 		return to_godot(jolt_settings->mLinearVelocity);
 	}
@@ -178,7 +178,7 @@ Vector3 JoltCollisionObject3D::get_linear_velocity(bool p_lock) const {
 	return to_godot(body->GetLinearVelocity());
 }
 
-Vector3 JoltCollisionObject3D::get_angular_velocity(bool p_lock) const {
+Vector3 JoltObjectImpl3D::get_angular_velocity(bool p_lock) const {
 	if (space == nullptr) {
 		return to_godot(jolt_settings->mAngularVelocity);
 	}
@@ -189,8 +189,7 @@ Vector3 JoltCollisionObject3D::get_angular_velocity(bool p_lock) const {
 	return to_godot(body->GetAngularVelocity());
 }
 
-Vector3 JoltCollisionObject3D::get_velocity_at_position(const Vector3& p_position, bool p_lock)
-	const {
+Vector3 JoltObjectImpl3D::get_velocity_at_position(const Vector3& p_position, bool p_lock) const {
 	ERR_FAIL_NULL_D(space);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
@@ -199,7 +198,7 @@ Vector3 JoltCollisionObject3D::get_velocity_at_position(const Vector3& p_positio
 	return to_godot(body->GetPointVelocity(to_jolt(p_position)));
 }
 
-JPH::ShapeRefC JoltCollisionObject3D::try_build_shape() {
+JPH::ShapeRefC JoltObjectImpl3D::try_build_shape() {
 	int32_t built_shape_count = 0;
 	const JoltShapeInstance3D* last_built_shape = nullptr;
 
@@ -255,7 +254,7 @@ JPH::ShapeRefC JoltCollisionObject3D::try_build_shape() {
 	return result;
 }
 
-void JoltCollisionObject3D::build_shape(bool p_lock) {
+void JoltObjectImpl3D::build_shape(bool p_lock) {
 	if (space == nullptr) {
 		shapes_built(p_lock);
 		return;
@@ -282,7 +281,7 @@ void JoltCollisionObject3D::build_shape(bool p_lock) {
 	shapes_built(false);
 }
 
-void JoltCollisionObject3D::add_shape(
+void JoltObjectImpl3D::add_shape(
 	JoltShape3D* p_shape,
 	Transform3D p_transform,
 	bool p_disabled,
@@ -296,7 +295,7 @@ void JoltCollisionObject3D::add_shape(
 	shapes_changed(p_lock);
 }
 
-void JoltCollisionObject3D::remove_shape(const JoltShape3D* p_shape, bool p_lock) {
+void JoltObjectImpl3D::remove_shape(const JoltShape3D* p_shape, bool p_lock) {
 	shapes.erase_if([&](const JoltShapeInstance3D& p_instance) {
 		return p_instance.get_shape() == p_shape;
 	});
@@ -304,7 +303,7 @@ void JoltCollisionObject3D::remove_shape(const JoltShape3D* p_shape, bool p_lock
 	shapes_changed(p_lock);
 }
 
-void JoltCollisionObject3D::remove_shape(int32_t p_index, bool p_lock) {
+void JoltObjectImpl3D::remove_shape(int32_t p_index, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
 	shapes.remove_at(p_index);
@@ -312,13 +311,13 @@ void JoltCollisionObject3D::remove_shape(int32_t p_index, bool p_lock) {
 	shapes_changed(p_lock);
 }
 
-JoltShape3D* JoltCollisionObject3D::get_shape(int32_t p_index) const {
+JoltShape3D* JoltObjectImpl3D::get_shape(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].get_shape();
 }
 
-void JoltCollisionObject3D::set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock) {
+void JoltObjectImpl3D::set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
 	shapes[p_index] = JoltShapeInstance3D(this, p_shape);
@@ -326,57 +325,53 @@ void JoltCollisionObject3D::set_shape(int32_t p_index, JoltShape3D* p_shape, boo
 	shapes_changed(p_lock);
 }
 
-void JoltCollisionObject3D::clear_shapes(bool p_lock) {
+void JoltObjectImpl3D::clear_shapes(bool p_lock) {
 	shapes.clear();
 
 	shapes_changed(p_lock);
 }
 
-int32_t JoltCollisionObject3D::find_shape_index(uint32_t p_shape_instance_id) const {
+int32_t JoltObjectImpl3D::find_shape_index(uint32_t p_shape_instance_id) const {
 	return shapes.find_if([&](const JoltShapeInstance3D& p_shape) {
 		return p_shape.get_id() == p_shape_instance_id;
 	});
 }
 
-int32_t JoltCollisionObject3D::find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const {
+int32_t JoltObjectImpl3D::find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const {
 	ERR_FAIL_NULL_V(jolt_shape, -1);
 
 	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
 }
 
-JoltShape3D* JoltCollisionObject3D::find_shape(uint32_t p_shape_instance_id) const {
+JoltShape3D* JoltObjectImpl3D::find_shape(uint32_t p_shape_instance_id) const {
 	const int32_t shape_index = find_shape_index(p_shape_instance_id);
 	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
 }
 
-JoltShape3D* JoltCollisionObject3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
+JoltShape3D* JoltObjectImpl3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
 	const int32_t shape_index = find_shape_index(p_sub_shape_id);
 	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
 }
 
-Transform3D JoltCollisionObject3D::get_shape_transform_unscaled(int32_t p_index) const {
+Transform3D JoltObjectImpl3D::get_shape_transform_unscaled(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].get_transform_unscaled();
 }
 
-Transform3D JoltCollisionObject3D::get_shape_transform_scaled(int32_t p_index) const {
+Transform3D JoltObjectImpl3D::get_shape_transform_scaled(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].get_transform_scaled();
 }
 
-Vector3 JoltCollisionObject3D::get_shape_scale(int32_t p_index) const {
+Vector3 JoltObjectImpl3D::get_shape_scale(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].get_scale();
 }
 
-void JoltCollisionObject3D::set_shape_transform(
-	int32_t p_index,
-	Transform3D p_transform,
-	bool p_lock
-) {
+void JoltObjectImpl3D::set_shape_transform(int32_t p_index, Transform3D p_transform, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
 	Vector3 new_scale;
@@ -394,13 +389,13 @@ void JoltCollisionObject3D::set_shape_transform(
 	shapes_changed(p_lock);
 }
 
-bool JoltCollisionObject3D::is_shape_disabled(int32_t p_index) const {
+bool JoltObjectImpl3D::is_shape_disabled(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].is_disabled();
 }
 
-void JoltCollisionObject3D::set_shape_disabled(int32_t p_index, bool p_disabled, bool p_lock) {
+void JoltObjectImpl3D::set_shape_disabled(int32_t p_index, bool p_disabled, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
 	JoltShapeInstance3D& shape = shapes[p_index];
@@ -418,30 +413,30 @@ void JoltCollisionObject3D::set_shape_disabled(int32_t p_index, bool p_disabled,
 	shapes_changed(p_lock);
 }
 
-void JoltCollisionObject3D::add_to_space(bool p_lock) {
+void JoltObjectImpl3D::add_to_space(bool p_lock) {
 	// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or less
 	// impossible to have a body be sleeping when created, so we default to always starting out as
 	// active.
 	space->get_body_iface(p_lock).AddBody(jolt_id, JPH::EActivation::Activate);
 }
 
-void JoltCollisionObject3D::remove_from_space(bool p_lock) {
+void JoltObjectImpl3D::remove_from_space(bool p_lock) {
 	space->get_body_iface(p_lock).RemoveBody(jolt_id);
 }
 
-void JoltCollisionObject3D::destroy_in_space(bool p_lock) {
+void JoltObjectImpl3D::destroy_in_space(bool p_lock) {
 	space->get_body_iface(p_lock).DestroyBody(jolt_id);
 
 	jolt_id = {};
 }
 
-void JoltCollisionObject3D::pre_step([[maybe_unused]] float p_step) { }
+void JoltObjectImpl3D::pre_step([[maybe_unused]] float p_step) { }
 
-void JoltCollisionObject3D::post_step([[maybe_unused]] float p_step) {
+void JoltObjectImpl3D::post_step([[maybe_unused]] float p_step) {
 	previous_jolt_shape = nullptr;
 }
 
-JPH::ObjectLayer JoltCollisionObject3D::get_object_layer() const {
+JPH::ObjectLayer JoltObjectImpl3D::get_object_layer() const {
 	if (space == nullptr) {
 		return jolt_settings->mObjectLayer;
 	}
@@ -449,7 +444,7 @@ JPH::ObjectLayer JoltCollisionObject3D::get_object_layer() const {
 	return space->map_to_object_layer(get_broad_phase_layer(), collision_layer, collision_mask);
 }
 
-void JoltCollisionObject3D::create_begin() {
+void JoltObjectImpl3D::create_begin() {
 	jolt_shape = try_build_shape();
 
 	if (jolt_shape == nullptr) {
@@ -461,7 +456,7 @@ void JoltCollisionObject3D::create_begin() {
 	jolt_settings->SetShape(jolt_shape);
 }
 
-JPH::Body* JoltCollisionObject3D::create_end() {
+JPH::Body* JoltObjectImpl3D::create_end() {
 	ON_SCOPE_EXIT {
 		delete_safely(jolt_settings);
 	};
@@ -485,7 +480,7 @@ JPH::Body* JoltCollisionObject3D::create_end() {
 	return body;
 }
 
-void JoltCollisionObject3D::update_object_layer(bool p_lock) {
+void JoltObjectImpl3D::update_object_layer(bool p_lock) {
 	if (space == nullptr) {
 		return;
 	}
@@ -493,14 +488,14 @@ void JoltCollisionObject3D::update_object_layer(bool p_lock) {
 	space->get_body_iface(p_lock).SetObjectLayer(jolt_id, get_object_layer());
 }
 
-void JoltCollisionObject3D::collision_layer_changed(bool p_lock) {
+void JoltObjectImpl3D::collision_layer_changed(bool p_lock) {
 	update_object_layer(p_lock);
 }
 
-void JoltCollisionObject3D::collision_mask_changed(bool p_lock) {
+void JoltObjectImpl3D::collision_mask_changed(bool p_lock) {
 	update_object_layer(p_lock);
 }
 
-void JoltCollisionObject3D::shapes_changed(bool p_lock) {
+void JoltObjectImpl3D::shapes_changed(bool p_lock) {
 	build_shape(p_lock);
 }

--- a/src/objects/jolt_collision_object_3d.cpp
+++ b/src/objects/jolt_collision_object_3d.cpp
@@ -268,7 +268,7 @@ void JoltObjectImpl3D::build_shape(bool p_lock) {
 	jolt_shape = try_build_shape();
 
 	if (jolt_shape == nullptr) {
-		jolt_shape = new JoltEmptyShape();
+		jolt_shape = new JoltCustomEmptyShape();
 	}
 
 	if (jolt_shape == previous_jolt_shape) {
@@ -448,7 +448,7 @@ void JoltObjectImpl3D::create_begin() {
 	jolt_shape = try_build_shape();
 
 	if (jolt_shape == nullptr) {
-		jolt_shape = new JoltEmptyShape();
+		jolt_shape = new JoltCustomEmptyShape();
 	}
 
 	jolt_settings->mObjectLayer = get_object_layer();

--- a/src/objects/jolt_collision_object_3d.cpp
+++ b/src/objects/jolt_collision_object_3d.cpp
@@ -216,7 +216,7 @@ JPH::ShapeRefC JoltObjectImpl3D::try_build_shape() {
 	JPH::ShapeRefC result;
 
 	if (built_shape_count == 1) {
-		result = JoltShape3D::with_transform(
+		result = JoltShapeImpl3D::with_transform(
 			last_built_shape->get_jolt_ref(),
 			last_built_shape->get_transform_unscaled(),
 			last_built_shape->get_scale()
@@ -224,7 +224,7 @@ JPH::ShapeRefC JoltObjectImpl3D::try_build_shape() {
 	} else {
 		int32_t shape_index = 0;
 
-		result = JoltShape3D::as_compound([&](auto&& p_add_shape) {
+		result = JoltShapeImpl3D::as_compound([&](auto&& p_add_shape) {
 			if (shape_index >= shapes.size()) {
 				return false;
 			}
@@ -244,11 +244,11 @@ JPH::ShapeRefC JoltObjectImpl3D::try_build_shape() {
 	}
 
 	if (has_custom_center_of_mass()) {
-		result = JoltShape3D::with_center_of_mass(result, get_center_of_mass_custom());
+		result = JoltShapeImpl3D::with_center_of_mass(result, get_center_of_mass_custom());
 	}
 
 	if (scale != Vector3(1.0f, 1.0f, 1.0f)) {
-		result = JoltShape3D::with_scale(result, scale);
+		result = JoltShapeImpl3D::with_scale(result, scale);
 	}
 
 	return result;
@@ -282,7 +282,7 @@ void JoltObjectImpl3D::build_shape(bool p_lock) {
 }
 
 void JoltObjectImpl3D::add_shape(
-	JoltShape3D* p_shape,
+	JoltShapeImpl3D* p_shape,
 	Transform3D p_transform,
 	bool p_disabled,
 	bool p_lock
@@ -295,7 +295,7 @@ void JoltObjectImpl3D::add_shape(
 	shapes_changed(p_lock);
 }
 
-void JoltObjectImpl3D::remove_shape(const JoltShape3D* p_shape, bool p_lock) {
+void JoltObjectImpl3D::remove_shape(const JoltShapeImpl3D* p_shape, bool p_lock) {
 	shapes.erase_if([&](const JoltShapeInstance3D& p_instance) {
 		return p_instance.get_shape() == p_shape;
 	});
@@ -311,13 +311,13 @@ void JoltObjectImpl3D::remove_shape(int32_t p_index, bool p_lock) {
 	shapes_changed(p_lock);
 }
 
-JoltShape3D* JoltObjectImpl3D::get_shape(int32_t p_index) const {
+JoltShapeImpl3D* JoltObjectImpl3D::get_shape(int32_t p_index) const {
 	ERR_FAIL_INDEX_D(p_index, shapes.size());
 
 	return shapes[p_index].get_shape();
 }
 
-void JoltObjectImpl3D::set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock) {
+void JoltObjectImpl3D::set_shape(int32_t p_index, JoltShapeImpl3D* p_shape, bool p_lock) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
 	shapes[p_index] = JoltShapeInstance3D(this, p_shape);
@@ -343,12 +343,12 @@ int32_t JoltObjectImpl3D::find_shape_index(const JPH::SubShapeID& p_sub_shape_id
 	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
 }
 
-JoltShape3D* JoltObjectImpl3D::find_shape(uint32_t p_shape_instance_id) const {
+JoltShapeImpl3D* JoltObjectImpl3D::find_shape(uint32_t p_shape_instance_id) const {
 	const int32_t shape_index = find_shape_index(p_shape_instance_id);
 	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
 }
 
-JoltShape3D* JoltObjectImpl3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
+JoltShapeImpl3D* JoltObjectImpl3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
 	const int32_t shape_index = find_shape_index(p_sub_shape_id);
 	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
 }

--- a/src/objects/jolt_collision_object_3d.hpp
+++ b/src/objects/jolt_collision_object_3d.hpp
@@ -5,11 +5,11 @@
 class JoltSpace3D;
 class JoltShape3D;
 
-class JoltCollisionObject3D {
+class JoltObjectImpl3D {
 public:
-	JoltCollisionObject3D();
+	JoltObjectImpl3D();
 
-	virtual ~JoltCollisionObject3D() = 0;
+	virtual ~JoltObjectImpl3D() = 0;
 
 	RID get_rid() const { return rid; }
 

--- a/src/objects/jolt_collision_object_3d.hpp
+++ b/src/objects/jolt_collision_object_3d.hpp
@@ -2,8 +2,8 @@
 
 #include "shapes/jolt_shape_instance_3d.hpp"
 
-class JoltSpace3D;
 class JoltShapeImpl3D;
+class JoltSpace3D;
 
 class JoltObjectImpl3D {
 public:

--- a/src/objects/jolt_collision_object_3d.hpp
+++ b/src/objects/jolt_collision_object_3d.hpp
@@ -3,7 +3,7 @@
 #include "shapes/jolt_shape_instance_3d.hpp"
 
 class JoltSpace3D;
-class JoltShape3D;
+class JoltShapeImpl3D;
 
 class JoltObjectImpl3D {
 public:
@@ -70,19 +70,19 @@ public:
 	const JPH::Shape* get_previous_jolt_shape() const { return previous_jolt_shape; }
 
 	void add_shape(
-		JoltShape3D* p_shape,
+		JoltShapeImpl3D* p_shape,
 		Transform3D p_transform,
 		bool p_disabled,
 		bool p_lock = true
 	);
 
-	void remove_shape(const JoltShape3D* p_shape, bool p_lock = true);
+	void remove_shape(const JoltShapeImpl3D* p_shape, bool p_lock = true);
 
 	void remove_shape(int32_t p_index, bool p_lock = true);
 
-	JoltShape3D* get_shape(int32_t p_index) const;
+	JoltShapeImpl3D* get_shape(int32_t p_index) const;
 
-	void set_shape(int32_t p_index, JoltShape3D* p_shape, bool p_lock = true);
+	void set_shape(int32_t p_index, JoltShapeImpl3D* p_shape, bool p_lock = true);
 
 	void clear_shapes(bool p_lock = true);
 
@@ -92,9 +92,9 @@ public:
 
 	int32_t find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const;
 
-	JoltShape3D* find_shape(uint32_t p_shape_instance_id) const;
+	JoltShapeImpl3D* find_shape(uint32_t p_shape_instance_id) const;
 
-	JoltShape3D* find_shape(const JPH::SubShapeID& p_sub_shape_id) const;
+	JoltShapeImpl3D* find_shape(const JPH::SubShapeID& p_sub_shape_id) const;
 
 	Transform3D get_shape_transform_unscaled(int32_t p_index) const;
 
@@ -119,7 +119,7 @@ public:
 	virtual bool generates_contacts() const = 0;
 
 protected:
-	friend class JoltShape3D;
+	friend class JoltShapeImpl3D;
 
 	virtual JPH::BroadPhaseLayer get_broad_phase_layer() const = 0;
 

--- a/src/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.cpp
@@ -4,7 +4,7 @@
 #include "spaces/jolt_physics_direct_space_state_3d.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
-JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D* p_body)
+JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBodyImpl3D* p_body)
 	: body(p_body) { }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_total_gravity() const {

--- a/src/objects/jolt_physics_direct_body_state_3d.hpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltBody3D;
+class JoltBodyImpl3D;
 
 class JoltPhysicsDirectBodyState3D final : public PhysicsDirectBodyState3DExtension {
 	GDCLASS_NO_WARN(JoltPhysicsDirectBodyState3D, PhysicsDirectBodyState3DExtension)
@@ -12,7 +12,7 @@ private:
 public:
 	JoltPhysicsDirectBodyState3D() = default;
 
-	explicit JoltPhysicsDirectBodyState3D(JoltBody3D* p_body);
+	explicit JoltPhysicsDirectBodyState3D(JoltBodyImpl3D* p_body);
 
 	Vector3 _get_total_gravity() const override;
 
@@ -105,5 +105,5 @@ public:
 	PhysicsDirectSpaceState3D* _get_space_state() override;
 
 private:
-	JoltBody3D* body = nullptr;
+	JoltBodyImpl3D* body = nullptr;
 };

--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -66,7 +66,7 @@ void jolt_initialize() {
 
 	JoltCustomEmptyShape::register_type();
 	JoltRayShape::register_type();
-	JoltOverrideUserDataShape::register_type();
+	JoltCustomUserDataShape::register_type();
 }
 
 void jolt_deinitialize() {

--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -65,7 +65,7 @@ void jolt_initialize() {
 	JPH::RegisterTypes();
 
 	JoltCustomEmptyShape::register_type();
-	JoltRayShape::register_type();
+	JoltCustomRayShape::register_type();
 	JoltCustomUserDataShape::register_type();
 }
 

--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -64,7 +64,7 @@ void jolt_initialize() {
 
 	JPH::RegisterTypes();
 
-	JoltEmptyShape::register_type();
+	JoltCustomEmptyShape::register_type();
 	JoltRayShape::register_type();
 	JoltOverrideUserDataShape::register_type();
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1353,8 +1353,8 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	ERR_FAIL_NULL(space);
 
 	JoltJoint3D* new_joint = body_b != nullptr
-		? memnew(JoltHingeJoint3D(space, body_a, body_b, p_hinge_a, p_hinge_b))
-		: memnew(JoltHingeJoint3D(space, body_a, p_hinge_a, p_hinge_b));
+		? memnew(JoltHingeJointImpl3D(space, body_a, body_b, p_hinge_a, p_hinge_b))
+		: memnew(JoltHingeJointImpl3D(space, body_a, p_hinge_a, p_hinge_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1386,7 +1386,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_param(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
-	auto* hinge_joint = static_cast<JoltHingeJoint3D*>(joint);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
 
 	return hinge_joint->set_param(p_param, p_value);
 }
@@ -1397,7 +1397,7 @@ double JoltPhysicsServer3D::_hinge_joint_get_param(const RID& p_joint, HingeJoin
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
-	const auto* hinge_joint = static_cast<const JoltHingeJoint3D*>(joint);
+	const auto* hinge_joint = static_cast<const JoltHingeJointImpl3D*>(joint);
 
 	return hinge_joint->get_param(p_param);
 }
@@ -1411,7 +1411,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_flag(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
-	auto* hinge_joint = static_cast<JoltHingeJoint3D*>(joint);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
 
 	return hinge_joint->set_flag(p_flag, p_enabled);
 }
@@ -1421,7 +1421,7 @@ bool JoltPhysicsServer3D::_hinge_joint_get_flag(const RID& p_joint, HingeJointFl
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
-	const auto* hinge_joint = static_cast<const JoltHingeJoint3D*>(joint);
+	const auto* hinge_joint = static_cast<const JoltHingeJointImpl3D*>(joint);
 
 	return hinge_joint->get_flag(p_flag);
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -15,63 +15,63 @@
 #include "spaces/jolt_space_3d.hpp"
 
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
-	JoltShape3D* shape = memnew(JoltWorldBoundaryShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltWorldBoundaryShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_separation_ray_shape_create() {
-	JoltShape3D* shape = memnew(JoltSeparationRayShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltSeparationRayShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_sphere_shape_create() {
-	JoltShape3D* shape = memnew(JoltSphereShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltSphereShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_box_shape_create() {
-	JoltShape3D* shape = memnew(JoltBoxShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltBoxShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_capsule_shape_create() {
-	JoltShape3D* shape = memnew(JoltCapsuleShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltCapsuleShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_cylinder_shape_create() {
-	JoltShape3D* shape = memnew(JoltCylinderShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltCylinderShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_convex_polygon_shape_create() {
-	JoltShape3D* shape = memnew(JoltConvexPolygonShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltConvexPolygonShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_concave_polygon_shape_create() {
-	JoltShape3D* shape = memnew(JoltConcavePolygonShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltConcavePolygonShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
 }
 
 RID JoltPhysicsServer3D::_heightmap_shape_create() {
-	JoltShape3D* shape = memnew(JoltHeightMapShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltHeightMapShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;
@@ -82,7 +82,7 @@ RID JoltPhysicsServer3D::_custom_shape_create() {
 }
 
 void JoltPhysicsServer3D::_shape_set_data(const RID& p_shape, const Variant& p_data) {
-	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	shape->set_data(p_data);
@@ -96,28 +96,28 @@ void JoltPhysicsServer3D::_shape_set_custom_solver_bias(
 }
 
 PhysicsServer3D::ShapeType JoltPhysicsServer3D::_shape_get_type(const RID& p_shape) const {
-	const JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	const JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_D(shape);
 
 	return shape->get_type();
 }
 
 Variant JoltPhysicsServer3D::_shape_get_data(const RID& p_shape) const {
-	const JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	const JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_D(shape);
 
 	return shape->get_data();
 }
 
 void JoltPhysicsServer3D::_shape_set_margin(const RID& p_shape, double p_margin) {
-	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	shape->set_margin((float)p_margin);
 }
 
 double JoltPhysicsServer3D::_shape_get_margin(const RID& p_shape) const {
-	const JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	const JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_D(shape);
 
 	return (double)shape->get_margin();
@@ -263,7 +263,7 @@ void JoltPhysicsServer3D::_area_add_shape(
 	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
-	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	area->add_shape(shape, p_transform, p_disabled);
@@ -277,7 +277,7 @@ void JoltPhysicsServer3D::_area_set_shape(
 	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
-	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	area->set_shape(p_shape_idx, shape);
@@ -305,7 +305,7 @@ RID JoltPhysicsServer3D::_area_get_shape(const RID& p_area, int32_t p_shape_idx)
 	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
-	const JoltShape3D* shape = area->get_shape(p_shape_idx);
+	const JoltShapeImpl3D* shape = area->get_shape(p_shape_idx);
 	ERR_FAIL_NULL_D(shape);
 
 	return shape->get_rid();
@@ -516,7 +516,7 @@ void JoltPhysicsServer3D::_body_add_shape(
 	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	body->add_shape(shape, p_transform, p_disabled);
@@ -530,7 +530,7 @@ void JoltPhysicsServer3D::_body_set_shape(
 	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
 	body->set_shape(p_shape_idx, shape);
@@ -558,7 +558,7 @@ RID JoltPhysicsServer3D::_body_get_shape(const RID& p_body, int32_t p_shape_idx)
 	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
-	const JoltShape3D* shape = body->get_shape(p_shape_idx);
+	const JoltShapeImpl3D* shape = body->get_shape(p_shape_idx);
 	ERR_FAIL_NULL_D(shape);
 
 	return shape->get_rid();
@@ -1665,7 +1665,7 @@ bool JoltPhysicsServer3D::_joint_is_disabled_collisions_between_bodies(const RID
 }
 
 void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
-	if (JoltShape3D* shape = shape_owner.get_or_null(p_rid)) {
+	if (JoltShapeImpl3D* shape = shape_owner.get_or_null(p_rid)) {
 		free_shape(shape);
 	} else if (JoltBodyImpl3D* body = body_owner.get_or_null(p_rid)) {
 		free_body(body);
@@ -1760,7 +1760,7 @@ void JoltPhysicsServer3D::free_body(JoltBodyImpl3D* p_body) {
 	memdelete_safely(p_body);
 }
 
-void JoltPhysicsServer3D::free_shape(JoltShape3D* p_shape) {
+void JoltPhysicsServer3D::free_shape(JoltShapeImpl3D* p_shape) {
 	ERR_FAIL_NULL(p_shape);
 
 	p_shape->remove_self();

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -134,7 +134,7 @@ RID JoltPhysicsServer3D::_space_create() {
 	space->set_rid(rid);
 
 	const RID default_area_rid = area_create();
-	JoltArea3D* default_area = area_owner.get_or_null(default_area_rid);
+	JoltAreaImpl3D* default_area = area_owner.get_or_null(default_area_rid);
 	ERR_FAIL_NULL_D(default_area);
 	space->set_default_area(default_area);
 	default_area->set_space(space);
@@ -221,14 +221,14 @@ int32_t JoltPhysicsServer3D::_space_get_contact_count([[maybe_unused]] const RID
 }
 
 RID JoltPhysicsServer3D::_area_create() {
-	JoltArea3D* area = memnew(JoltArea3D);
+	JoltAreaImpl3D* area = memnew(JoltAreaImpl3D);
 	RID rid = area_owner.make_rid(area);
 	area->set_rid(rid);
 	return rid;
 }
 
 void JoltPhysicsServer3D::_area_set_space(const RID& p_area, const RID& p_space) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	JoltSpace3D* space = nullptr;
@@ -242,7 +242,7 @@ void JoltPhysicsServer3D::_area_set_space(const RID& p_area, const RID& p_space)
 }
 
 RID JoltPhysicsServer3D::_area_get_space(const RID& p_area) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	const JoltSpace3D* space = area->get_space();
@@ -260,7 +260,7 @@ void JoltPhysicsServer3D::_area_add_shape(
 	const Transform3D& p_transform,
 	bool p_disabled
 ) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
@@ -274,7 +274,7 @@ void JoltPhysicsServer3D::_area_set_shape(
 	int32_t p_shape_idx,
 	const RID& p_shape
 ) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
@@ -288,21 +288,21 @@ void JoltPhysicsServer3D::_area_set_shape_transform(
 	int32_t p_shape_idx,
 	const Transform3D& p_transform
 ) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_shape_transform(p_shape_idx, p_transform);
 }
 
 int32_t JoltPhysicsServer3D::_area_get_shape_count(const RID& p_area) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_shape_count();
 }
 
 RID JoltPhysicsServer3D::_area_get_shape(const RID& p_area, int32_t p_shape_idx) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	const JoltShape3D* shape = area->get_shape(p_shape_idx);
@@ -313,21 +313,21 @@ RID JoltPhysicsServer3D::_area_get_shape(const RID& p_area, int32_t p_shape_idx)
 
 Transform3D JoltPhysicsServer3D::_area_get_shape_transform(const RID& p_area, int32_t p_shape_idx)
 	const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_shape_transform_scaled(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_area_remove_shape(const RID& p_area, int32_t p_shape_idx) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->remove_shape(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_area_clear_shapes(const RID& p_area) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->clear_shapes();
@@ -338,21 +338,21 @@ void JoltPhysicsServer3D::_area_set_shape_disabled(
 	int32_t p_shape_idx,
 	bool p_disabled
 ) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
 void JoltPhysicsServer3D::_area_attach_object_instance_id(const RID& p_area, uint64_t p_id) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_instance_id(ObjectID(p_id));
 }
 
 uint64_t JoltPhysicsServer3D::_area_get_object_instance_id(const RID& p_area) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_instance_id();
@@ -370,63 +370,63 @@ void JoltPhysicsServer3D::_area_set_param(
 		area_rid = space->get_default_area()->get_rid();
 	}
 
-	JoltArea3D* area = area_owner.get_or_null(area_rid);
+	JoltAreaImpl3D* area = area_owner.get_or_null(area_rid);
 	ERR_FAIL_NULL(area);
 
 	area->set_param(p_param, p_value);
 }
 
 void JoltPhysicsServer3D::_area_set_transform(const RID& p_area, const Transform3D& p_transform) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	return area->set_transform(p_transform);
 }
 
 Variant JoltPhysicsServer3D::_area_get_param(const RID& p_area, AreaParameter p_param) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_param(p_param);
 }
 
 Transform3D JoltPhysicsServer3D::_area_get_transform(const RID& p_area) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_transform_scaled();
 }
 
 void JoltPhysicsServer3D::_area_set_collision_mask(const RID& p_area, uint32_t p_mask) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_collision_mask(p_mask);
 }
 
 uint32_t JoltPhysicsServer3D::_area_get_collision_mask(const RID& p_area) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_collision_mask();
 }
 
 void JoltPhysicsServer3D::_area_set_collision_layer(const RID& p_area, uint32_t p_layer) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_collision_layer(p_layer);
 }
 
 uint32_t JoltPhysicsServer3D::_area_get_collision_layer(const RID& p_area) const {
-	const JoltArea3D* area = area_owner.get_or_null(p_area);
+	const JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_D(area);
 
 	return area->get_collision_layer();
 }
 
 void JoltPhysicsServer3D::_area_set_monitorable(const RID& p_area, bool p_monitorable) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_monitorable(p_monitorable);
@@ -436,7 +436,7 @@ void JoltPhysicsServer3D::_area_set_monitor_callback(
 	const RID& p_area,
 	const Callable& p_callback
 ) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_body_monitor_callback(p_callback);
@@ -446,14 +446,14 @@ void JoltPhysicsServer3D::_area_set_area_monitor_callback(
 	const RID& p_area,
 	const Callable& p_callback
 ) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_area_monitor_callback(p_callback);
 }
 
 void JoltPhysicsServer3D::_area_set_ray_pickable(const RID& p_area, bool p_enable) {
-	JoltArea3D* area = area_owner.get_or_null(p_area);
+	JoltAreaImpl3D* area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	area->set_ray_pickable(p_enable);
@@ -1671,7 +1671,7 @@ void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 		free_body(body);
 	} else if (JoltJointImpl3D* joint = joint_owner.get_or_null(p_rid)) {
 		free_joint(joint);
-	} else if (JoltArea3D* area = area_owner.get_or_null(p_rid)) {
+	} else if (JoltAreaImpl3D* area = area_owner.get_or_null(p_rid)) {
 		free_area(area);
 	} else if (JoltSpace3D* space = space_owner.get_or_null(p_rid)) {
 		free_space(space);
@@ -1744,7 +1744,7 @@ void JoltPhysicsServer3D::free_space(JoltSpace3D* p_space) {
 	memdelete_safely(p_space);
 }
 
-void JoltPhysicsServer3D::free_area(JoltArea3D* p_area) {
+void JoltPhysicsServer3D::free_area(JoltAreaImpl3D* p_area) {
 	ERR_FAIL_NULL(p_area);
 
 	p_area->set_space(nullptr);

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -64,7 +64,7 @@ RID JoltPhysicsServer3D::_convex_polygon_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_concave_polygon_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltConcavePolygonShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltConcavePolygonShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -36,7 +36,7 @@ RID JoltPhysicsServer3D::_sphere_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_box_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltBoxShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltBoxShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1220,18 +1220,18 @@ bool JoltPhysicsServer3D::_soft_body_is_point_pinned(
 }
 
 RID JoltPhysicsServer3D::_joint_create() {
-	JoltJoint3D* joint = memnew(JoltJoint3D);
+	JoltJointImpl3D* joint = memnew(JoltJointImpl3D);
 	RID rid = joint_owner.make_rid(joint);
 	joint->set_rid(rid);
 	return rid;
 }
 
 void JoltPhysicsServer3D::_joint_clear(const RID& p_joint) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	if (joint->get_type() != JOINT_TYPE_MAX) {
-		JoltJoint3D* empty_joint = memnew(JoltJoint3D);
+		JoltJointImpl3D* empty_joint = memnew(JoltJointImpl3D);
 		empty_joint->set_rid(joint->get_rid());
 
 		memdelete_safely(joint);
@@ -1246,7 +1246,7 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	const RID& p_body_b,
 	const Vector3& p_local_b
 ) {
-	JoltJoint3D* old_joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
 	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
@@ -1258,7 +1258,7 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	JoltSpace3D* space = body_a->get_space();
 	ERR_FAIL_NULL(space);
 
-	JoltJoint3D* new_joint = body_b != nullptr
+	JoltJointImpl3D* new_joint = body_b != nullptr
 		? memnew(JoltPinJoint3D(space, body_a, body_b, p_local_a, p_local_b))
 		: memnew(JoltPinJoint3D(space, body_a, p_local_a, p_local_b));
 
@@ -1274,7 +1274,7 @@ void JoltPhysicsServer3D::_pin_joint_set_param(
 	PinJointParam p_param,
 	double p_value
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
@@ -1284,7 +1284,7 @@ void JoltPhysicsServer3D::_pin_joint_set_param(
 }
 
 double JoltPhysicsServer3D::_pin_joint_get_param(const RID& p_joint, PinJointParam p_param) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
@@ -1294,7 +1294,7 @@ double JoltPhysicsServer3D::_pin_joint_get_param(const RID& p_joint, PinJointPar
 }
 
 void JoltPhysicsServer3D::_pin_joint_set_local_a(const RID& p_joint, const Vector3& p_local_a) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
@@ -1304,7 +1304,7 @@ void JoltPhysicsServer3D::_pin_joint_set_local_a(const RID& p_joint, const Vecto
 }
 
 Vector3 JoltPhysicsServer3D::_pin_joint_get_local_a(const RID& p_joint) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
@@ -1314,7 +1314,7 @@ Vector3 JoltPhysicsServer3D::_pin_joint_get_local_a(const RID& p_joint) const {
 }
 
 void JoltPhysicsServer3D::_pin_joint_set_local_b(const RID& p_joint, const Vector3& p_local_b) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
@@ -1324,7 +1324,7 @@ void JoltPhysicsServer3D::_pin_joint_set_local_b(const RID& p_joint, const Vecto
 }
 
 Vector3 JoltPhysicsServer3D::_pin_joint_get_local_b(const RID& p_joint) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
@@ -1340,7 +1340,7 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	const RID& p_body_b,
 	const Transform3D& p_hinge_b
 ) {
-	JoltJoint3D* old_joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
 	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
@@ -1352,7 +1352,7 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	JoltSpace3D* space = body_a->get_space();
 	ERR_FAIL_NULL(space);
 
-	JoltJoint3D* new_joint = body_b != nullptr
+	JoltJointImpl3D* new_joint = body_b != nullptr
 		? memnew(JoltHingeJointImpl3D(space, body_a, body_b, p_hinge_a, p_hinge_b))
 		: memnew(JoltHingeJointImpl3D(space, body_a, p_hinge_a, p_hinge_b));
 
@@ -1382,7 +1382,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_param(
 	HingeJointParam p_param,
 	double p_value
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
@@ -1393,7 +1393,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_param(
 
 double JoltPhysicsServer3D::_hinge_joint_get_param(const RID& p_joint, HingeJointParam p_param)
 	const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
@@ -1407,7 +1407,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_flag(
 	HingeJointFlag p_flag,
 	bool p_enabled
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
@@ -1417,7 +1417,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_flag(
 }
 
 bool JoltPhysicsServer3D::_hinge_joint_get_flag(const RID& p_joint, HingeJointFlag p_flag) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
@@ -1433,7 +1433,7 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	const RID& p_body_b,
 	const Transform3D& p_local_ref_b
 ) {
-	JoltJoint3D* old_joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
 	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
@@ -1445,7 +1445,7 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	JoltSpace3D* space = body_a->get_space();
 	ERR_FAIL_NULL(space);
 
-	JoltJoint3D* new_joint = body_b != nullptr
+	JoltJointImpl3D* new_joint = body_b != nullptr
 		? memnew(JoltSliderJoint3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
 		: memnew(JoltSliderJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
@@ -1461,7 +1461,7 @@ void JoltPhysicsServer3D::_slider_joint_set_param(
 	SliderJointParam p_param,
 	double p_value
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_SLIDER);
@@ -1472,7 +1472,7 @@ void JoltPhysicsServer3D::_slider_joint_set_param(
 
 double JoltPhysicsServer3D::_slider_joint_get_param(const RID& p_joint, SliderJointParam p_param)
 	const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_SLIDER);
@@ -1488,7 +1488,7 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	const RID& p_body_b,
 	const Transform3D& p_local_ref_b
 ) {
-	JoltJoint3D* old_joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
 	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
@@ -1500,7 +1500,7 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	JoltSpace3D* space = body_a->get_space();
 	ERR_FAIL_NULL(space);
 
-	JoltJoint3D* new_joint = body_b != nullptr
+	JoltJointImpl3D* new_joint = body_b != nullptr
 		? memnew(JoltConeTwistJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
 		: memnew(JoltConeTwistJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
@@ -1516,7 +1516,7 @@ void JoltPhysicsServer3D::_cone_twist_joint_set_param(
 	ConeTwistJointParam p_param,
 	double p_value
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_CONE_TWIST);
@@ -1529,7 +1529,7 @@ double JoltPhysicsServer3D::_cone_twist_joint_get_param(
 	const RID& p_joint,
 	ConeTwistJointParam p_param
 ) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_CONE_TWIST);
@@ -1545,7 +1545,7 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	const RID& p_body_b,
 	const Transform3D& p_local_ref_b
 ) {
-	JoltJoint3D* old_joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
 	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
@@ -1557,7 +1557,7 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	JoltSpace3D* space = body_a->get_space();
 	ERR_FAIL_NULL(space);
 
-	JoltJoint3D* new_joint = body_b != nullptr
+	JoltJointImpl3D* new_joint = body_b != nullptr
 		? memnew(JoltGeneric6DOFJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
 		: memnew(JoltGeneric6DOFJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
@@ -1574,7 +1574,7 @@ void JoltPhysicsServer3D::_generic_6dof_joint_set_param(
 	PhysicsServer3D::G6DOFJointAxisParam p_param,
 	double p_value
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
@@ -1588,7 +1588,7 @@ double JoltPhysicsServer3D::_generic_6dof_joint_get_param(
 	Vector3::Axis p_axis,
 	PhysicsServer3D::G6DOFJointAxisParam p_param
 ) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
@@ -1603,7 +1603,7 @@ void JoltPhysicsServer3D::_generic_6dof_joint_set_flag(
 	PhysicsServer3D::G6DOFJointAxisFlag p_flag,
 	bool p_enable
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
@@ -1617,7 +1617,7 @@ bool JoltPhysicsServer3D::_generic_6dof_joint_get_flag(
 	Vector3::Axis p_axis,
 	PhysicsServer3D::G6DOFJointAxisFlag p_flag
 ) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
@@ -1627,21 +1627,21 @@ bool JoltPhysicsServer3D::_generic_6dof_joint_get_flag(
 }
 
 PhysicsServer3D::JointType JoltPhysicsServer3D::_joint_get_type(const RID& p_joint) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	return joint->get_type();
 }
 
 void JoltPhysicsServer3D::_joint_set_solver_priority(const RID& p_joint, int32_t p_priority) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	joint->set_solver_priority(p_priority);
 }
 
 int32_t JoltPhysicsServer3D::_joint_get_solver_priority(const RID& p_joint) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	return joint->get_solver_priority();
@@ -1651,14 +1651,14 @@ void JoltPhysicsServer3D::_joint_disable_collisions_between_bodies(
 	const RID& p_joint,
 	bool p_disable
 ) {
-	JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
 	joint->set_collision_disabled(p_disable);
 }
 
 bool JoltPhysicsServer3D::_joint_is_disabled_collisions_between_bodies(const RID& p_joint) const {
-	const JoltJoint3D* joint = joint_owner.get_or_null(p_joint);
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	return joint->is_collision_disabled();
@@ -1669,7 +1669,7 @@ void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 		free_shape(shape);
 	} else if (JoltBody3D* body = body_owner.get_or_null(p_rid)) {
 		free_body(body);
-	} else if (JoltJoint3D* joint = joint_owner.get_or_null(p_rid)) {
+	} else if (JoltJointImpl3D* joint = joint_owner.get_or_null(p_rid)) {
 		free_joint(joint);
 	} else if (JoltArea3D* area = area_owner.get_or_null(p_rid)) {
 		free_area(area);
@@ -1768,7 +1768,7 @@ void JoltPhysicsServer3D::free_shape(JoltShape3D* p_shape) {
 	memdelete_safely(p_shape);
 }
 
-void JoltPhysicsServer3D::free_joint(JoltJoint3D* p_joint) {
+void JoltPhysicsServer3D::free_joint(JoltJointImpl3D* p_joint) {
 	ERR_FAIL_NULL(p_joint);
 
 	joint_owner.free(p_joint->get_rid());

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1558,8 +1558,8 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	ERR_FAIL_NULL(space);
 
 	JoltJoint3D* new_joint = body_b != nullptr
-		? memnew(JoltGeneric6DOFJoint3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltGeneric6DOFJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltGeneric6DOFJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltGeneric6DOFJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1578,7 +1578,7 @@ void JoltPhysicsServer3D::_generic_6dof_joint_set_param(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
-	auto* g6dof_joint = static_cast<JoltGeneric6DOFJoint3D*>(joint);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
 
 	return g6dof_joint->set_param(p_axis, p_param, p_value);
 }
@@ -1592,7 +1592,7 @@ double JoltPhysicsServer3D::_generic_6dof_joint_get_param(
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
-	const auto* g6dof_joint = static_cast<const JoltGeneric6DOFJoint3D*>(joint);
+	const auto* g6dof_joint = static_cast<const JoltGeneric6DOFJointImpl3D*>(joint);
 
 	return g6dof_joint->get_param(p_axis, p_param);
 }
@@ -1607,7 +1607,7 @@ void JoltPhysicsServer3D::_generic_6dof_joint_set_flag(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
-	auto* g6dof_joint = static_cast<JoltGeneric6DOFJoint3D*>(joint);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
 
 	return g6dof_joint->set_flag(p_axis, p_flag, p_enable);
 }
@@ -1621,7 +1621,7 @@ bool JoltPhysicsServer3D::_generic_6dof_joint_get_flag(
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
-	const auto* g6dof_joint = static_cast<const JoltGeneric6DOFJoint3D*>(joint);
+	const auto* g6dof_joint = static_cast<const JoltGeneric6DOFJointImpl3D*>(joint);
 
 	return g6dof_joint->get_flag(p_axis, p_flag);
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -15,7 +15,7 @@
 #include "spaces/jolt_space_3d.hpp"
 
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltWorldBoundaryShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltWorldBoundaryShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1501,8 +1501,8 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	ERR_FAIL_NULL(space);
 
 	JoltJoint3D* new_joint = body_b != nullptr
-		? memnew(JoltConeTwistJoint3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltConeTwistJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltConeTwistJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltConeTwistJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1520,7 +1520,7 @@ void JoltPhysicsServer3D::_cone_twist_joint_set_param(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_CONE_TWIST);
-	auto* cone_twist_joint = static_cast<JoltConeTwistJoint3D*>(joint);
+	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
 
 	return cone_twist_joint->set_param(p_param, p_value);
 }
@@ -1533,7 +1533,7 @@ double JoltPhysicsServer3D::_cone_twist_joint_get_param(
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_CONE_TWIST);
-	const auto* cone_twist_joint = static_cast<const JoltConeTwistJoint3D*>(joint);
+	const auto* cone_twist_joint = static_cast<const JoltConeTwistJointImpl3D*>(joint);
 
 	return cone_twist_joint->get_param(p_param);
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1446,8 +1446,8 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	ERR_FAIL_NULL(space);
 
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltSliderJoint3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltSliderJoint3D(space, body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltSliderJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltSliderJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1465,7 +1465,7 @@ void JoltPhysicsServer3D::_slider_joint_set_param(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_SLIDER);
-	auto* slider_joint = static_cast<JoltSliderJoint3D*>(joint);
+	auto* slider_joint = static_cast<JoltSliderJointImpl3D*>(joint);
 
 	return slider_joint->set_param(p_param, p_value);
 }
@@ -1476,7 +1476,7 @@ double JoltPhysicsServer3D::_slider_joint_get_param(const RID& p_joint, SliderJo
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_SLIDER);
-	const auto* slider_joint = static_cast<const JoltSliderJoint3D*>(joint);
+	const auto* slider_joint = static_cast<const JoltSliderJointImpl3D*>(joint);
 
 	return slider_joint->get_param(p_param);
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -22,7 +22,7 @@ RID JoltPhysicsServer3D::_world_boundary_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_separation_ray_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltSeparationRayShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltSeparationRayShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -460,14 +460,14 @@ void JoltPhysicsServer3D::_area_set_ray_pickable(const RID& p_area, bool p_enabl
 }
 
 RID JoltPhysicsServer3D::_body_create() {
-	JoltBody3D* body = memnew(JoltBody3D);
+	JoltBodyImpl3D* body = memnew(JoltBodyImpl3D);
 	RID rid = body_owner.make_rid(body);
 	body->set_rid(rid);
 	return rid;
 }
 
 void JoltPhysicsServer3D::_body_set_space(const RID& p_body, const RID& p_space) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	JoltSpace3D* space = nullptr;
@@ -481,7 +481,7 @@ void JoltPhysicsServer3D::_body_set_space(const RID& p_body, const RID& p_space)
 }
 
 RID JoltPhysicsServer3D::_body_get_space(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	const JoltSpace3D* space = body->get_space();
@@ -494,14 +494,14 @@ RID JoltPhysicsServer3D::_body_get_space(const RID& p_body) const {
 }
 
 void JoltPhysicsServer3D::_body_set_mode(const RID& p_body, BodyMode p_mode) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_mode(p_mode);
 }
 
 PhysicsServer3D::BodyMode JoltPhysicsServer3D::_body_get_mode(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_mode();
@@ -513,7 +513,7 @@ void JoltPhysicsServer3D::_body_add_shape(
 	const Transform3D& p_transform,
 	bool p_disabled
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
@@ -527,7 +527,7 @@ void JoltPhysicsServer3D::_body_set_shape(
 	int32_t p_shape_idx,
 	const RID& p_shape
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	JoltShape3D* shape = shape_owner.get_or_null(p_shape);
@@ -541,21 +541,21 @@ void JoltPhysicsServer3D::_body_set_shape_transform(
 	int32_t p_shape_idx,
 	const Transform3D& p_transform
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_shape_transform(p_shape_idx, p_transform);
 }
 
 int32_t JoltPhysicsServer3D::_body_get_shape_count(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_shape_count();
 }
 
 RID JoltPhysicsServer3D::_body_get_shape(const RID& p_body, int32_t p_shape_idx) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	const JoltShape3D* shape = body->get_shape(p_shape_idx);
@@ -566,21 +566,21 @@ RID JoltPhysicsServer3D::_body_get_shape(const RID& p_body, int32_t p_shape_idx)
 
 Transform3D JoltPhysicsServer3D::_body_get_shape_transform(const RID& p_body, int32_t p_shape_idx)
 	const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_shape_transform_scaled(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_body_remove_shape(const RID& p_body, int32_t p_shape_idx) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->remove_shape(p_shape_idx);
 }
 
 void JoltPhysicsServer3D::_body_clear_shapes(const RID& p_body) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->clear_shapes();
@@ -591,21 +591,21 @@ void JoltPhysicsServer3D::_body_set_shape_disabled(
 	int32_t p_shape_idx,
 	bool p_disabled
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
 void JoltPhysicsServer3D::_body_attach_object_instance_id(const RID& p_body, uint64_t p_id) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_instance_id(ObjectID(p_id));
 }
 
 uint64_t JoltPhysicsServer3D::_body_get_object_instance_id(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_instance_id();
@@ -615,56 +615,56 @@ void JoltPhysicsServer3D::_body_set_enable_continuous_collision_detection(
 	const RID& p_body,
 	bool p_enable
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_ccd_enabled(p_enable);
 }
 
 bool JoltPhysicsServer3D::_body_is_continuous_collision_detection_enabled(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->is_ccd_enabled();
 }
 
 void JoltPhysicsServer3D::_body_set_collision_layer(const RID& p_body, uint32_t p_layer) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_collision_layer(p_layer);
 }
 
 uint32_t JoltPhysicsServer3D::_body_get_collision_layer(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_collision_layer();
 }
 
 void JoltPhysicsServer3D::_body_set_collision_mask(const RID& p_body, uint32_t p_mask) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_collision_mask(p_mask);
 }
 
 uint32_t JoltPhysicsServer3D::_body_get_collision_mask(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_collision_mask();
 }
 
 void JoltPhysicsServer3D::_body_set_collision_priority(const RID& p_body, double p_priority) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_collision_priority((float)p_priority);
 }
 
 double JoltPhysicsServer3D::_body_get_collision_priority(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return (double)body->get_collision_priority();
@@ -689,21 +689,21 @@ void JoltPhysicsServer3D::_body_set_param(
 	BodyParameter p_param,
 	const Variant& p_value
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_param(p_param, p_value);
 }
 
 Variant JoltPhysicsServer3D::_body_get_param(const RID& p_body, BodyParameter p_param) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_param(p_param);
 }
 
 void JoltPhysicsServer3D::_body_reset_mass_properties(const RID& p_body) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->reset_mass_properties();
@@ -714,21 +714,21 @@ void JoltPhysicsServer3D::_body_set_state(
 	BodyState p_state,
 	const Variant& p_value
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_state(p_state, p_value);
 }
 
 Variant JoltPhysicsServer3D::_body_get_state(const RID& p_body, BodyState p_state) const {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_state(p_state);
 }
 
 void JoltPhysicsServer3D::_body_apply_central_impulse(const RID& p_body, const Vector3& p_impulse) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->apply_central_impulse(p_impulse);
@@ -739,21 +739,21 @@ void JoltPhysicsServer3D::_body_apply_impulse(
 	const Vector3& p_impulse,
 	const Vector3& p_position
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->apply_impulse(p_impulse, p_position);
 }
 
 void JoltPhysicsServer3D::_body_apply_torque_impulse(const RID& p_body, const Vector3& p_impulse) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->apply_torque_impulse(p_impulse);
 }
 
 void JoltPhysicsServer3D::_body_apply_central_force(const RID& p_body, const Vector3& p_force) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->apply_central_force(p_force);
@@ -764,14 +764,14 @@ void JoltPhysicsServer3D::_body_apply_force(
 	const Vector3& p_force,
 	const Vector3& p_position
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->apply_force(p_force, p_position);
 }
 
 void JoltPhysicsServer3D::_body_apply_torque(const RID& p_body, const Vector3& p_torque) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->apply_torque(p_torque);
@@ -781,7 +781,7 @@ void JoltPhysicsServer3D::_body_add_constant_central_force(
 	const RID& p_body,
 	const Vector3& p_force
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_constant_central_force(p_force);
@@ -792,42 +792,42 @@ void JoltPhysicsServer3D::_body_add_constant_force(
 	const Vector3& p_force,
 	const Vector3& p_position
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_constant_force(p_force, p_position);
 }
 
 void JoltPhysicsServer3D::_body_add_constant_torque(const RID& p_body, const Vector3& p_torque) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_constant_torque(p_torque);
 }
 
 void JoltPhysicsServer3D::_body_set_constant_force(const RID& p_body, const Vector3& p_force) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_constant_force(p_force);
 }
 
 Vector3 JoltPhysicsServer3D::_body_get_constant_force(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_constant_force();
 }
 
 void JoltPhysicsServer3D::_body_set_constant_torque(const RID& p_body, const Vector3& p_torque) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_constant_torque(p_torque);
 }
 
 Vector3 JoltPhysicsServer3D::_body_get_constant_torque(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_constant_torque();
@@ -837,21 +837,21 @@ void JoltPhysicsServer3D::_body_set_axis_velocity(
 	const RID& p_body,
 	const Vector3& p_axis_velocity
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_axis_velocity(p_axis_velocity);
 }
 
 void JoltPhysicsServer3D::_body_set_axis_lock(const RID& p_body, BodyAxis p_axis, bool p_lock) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_axis_lock(p_axis, p_lock);
 }
 
 bool JoltPhysicsServer3D::_body_is_axis_locked(const RID& p_body, BodyAxis p_axis) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->is_axis_locked(p_axis);
@@ -861,7 +861,7 @@ void JoltPhysicsServer3D::_body_add_collision_exception(
 	const RID& p_body,
 	const RID& p_excepted_body
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->add_collision_exception(p_excepted_body);
@@ -871,28 +871,28 @@ void JoltPhysicsServer3D::_body_remove_collision_exception(
 	const RID& p_body,
 	const RID& p_excepted_body
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->remove_collision_exception(p_excepted_body);
 }
 
 TypedArray<RID> JoltPhysicsServer3D::_body_get_collision_exceptions(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_collision_exceptions();
 }
 
 void JoltPhysicsServer3D::_body_set_max_contacts_reported(const RID& p_body, int32_t p_amount) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	return body->set_max_contacts_reported(p_amount);
 }
 
 int32_t JoltPhysicsServer3D::_body_get_max_contacts_reported(const RID& p_body) const {
-	const JoltBody3D* body = body_owner.get_or_null(p_body);
+	const JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_max_contacts_reported();
@@ -930,7 +930,7 @@ void JoltPhysicsServer3D::_body_set_state_sync_callback(
 	const RID& p_body,
 	const Callable& p_callable
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_state_sync_callback(p_callable);
@@ -941,14 +941,14 @@ void JoltPhysicsServer3D::_body_set_force_integration_callback(
 	const Callable& p_callable,
 	const Variant& p_userdata
 ) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_force_integration_callback(p_callable, p_userdata);
 }
 
 void JoltPhysicsServer3D::_body_set_ray_pickable(const RID& p_body, bool p_enable) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_ray_pickable(p_enable);
@@ -963,7 +963,7 @@ bool JoltPhysicsServer3D::_body_test_motion(
 	bool p_collide_separation_ray,
 	PhysicsServer3DExtensionMotionResult* p_result
 ) const {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	JoltSpace3D* space = body->get_space();
@@ -981,7 +981,7 @@ bool JoltPhysicsServer3D::_body_test_motion(
 }
 
 PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(const RID& p_body) {
-	JoltBody3D* body = body_owner.get_or_null(p_body);
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_D(body);
 
 	return body->get_direct_state();
@@ -1249,10 +1249,10 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
-	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
+	JoltBodyImpl3D* body_a = body_owner.get_or_null(p_body_a);
 	ERR_FAIL_NULL(body_a);
 
-	JoltBody3D* body_b = body_owner.get_or_null(p_body_b);
+	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltSpace3D* space = body_a->get_space();
@@ -1343,10 +1343,10 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
-	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
+	JoltBodyImpl3D* body_a = body_owner.get_or_null(p_body_a);
 	ERR_FAIL_NULL(body_a);
 
-	JoltBody3D* body_b = body_owner.get_or_null(p_body_b);
+	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltSpace3D* space = body_a->get_space();
@@ -1436,10 +1436,10 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
-	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
+	JoltBodyImpl3D* body_a = body_owner.get_or_null(p_body_a);
 	ERR_FAIL_NULL(body_a);
 
-	JoltBody3D* body_b = body_owner.get_or_null(p_body_b);
+	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltSpace3D* space = body_a->get_space();
@@ -1491,10 +1491,10 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
-	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
+	JoltBodyImpl3D* body_a = body_owner.get_or_null(p_body_a);
 	ERR_FAIL_NULL(body_a);
 
-	JoltBody3D* body_b = body_owner.get_or_null(p_body_b);
+	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltSpace3D* space = body_a->get_space();
@@ -1548,10 +1548,10 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	JoltJointImpl3D* old_joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(old_joint);
 
-	JoltBody3D* body_a = body_owner.get_or_null(p_body_a);
+	JoltBodyImpl3D* body_a = body_owner.get_or_null(p_body_a);
 	ERR_FAIL_NULL(body_a);
 
-	JoltBody3D* body_b = body_owner.get_or_null(p_body_b);
+	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltSpace3D* space = body_a->get_space();
@@ -1667,7 +1667,7 @@ bool JoltPhysicsServer3D::_joint_is_disabled_collisions_between_bodies(const RID
 void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 	if (JoltShape3D* shape = shape_owner.get_or_null(p_rid)) {
 		free_shape(shape);
-	} else if (JoltBody3D* body = body_owner.get_or_null(p_rid)) {
+	} else if (JoltBodyImpl3D* body = body_owner.get_or_null(p_rid)) {
 		free_body(body);
 	} else if (JoltJointImpl3D* joint = joint_owner.get_or_null(p_rid)) {
 		free_joint(joint);
@@ -1752,7 +1752,7 @@ void JoltPhysicsServer3D::free_area(JoltAreaImpl3D* p_area) {
 	memdelete_safely(p_area);
 }
 
-void JoltPhysicsServer3D::free_body(JoltBody3D* p_body) {
+void JoltPhysicsServer3D::free_body(JoltBodyImpl3D* p_body) {
 	ERR_FAIL_NULL(p_body);
 
 	p_body->set_space(nullptr);

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -29,7 +29,7 @@ RID JoltPhysicsServer3D::_separation_ray_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_sphere_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltSphereShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltSphereShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -57,7 +57,7 @@ RID JoltPhysicsServer3D::_cylinder_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_convex_polygon_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltConvexPolygonShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltConvexPolygonShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1259,8 +1259,8 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	ERR_FAIL_NULL(space);
 
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltPinJoint3D(space, body_a, body_b, p_local_a, p_local_b))
-		: memnew(JoltPinJoint3D(space, body_a, p_local_a, p_local_b));
+		? memnew(JoltPinJointImpl3D(space, body_a, body_b, p_local_a, p_local_b))
+		: memnew(JoltPinJointImpl3D(space, body_a, p_local_a, p_local_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1278,7 +1278,7 @@ void JoltPhysicsServer3D::_pin_joint_set_param(
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
-	auto* pin_joint = static_cast<JoltPinJoint3D*>(joint);
+	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
 
 	pin_joint->set_param(p_param, p_value);
 }
@@ -1288,7 +1288,7 @@ double JoltPhysicsServer3D::_pin_joint_get_param(const RID& p_joint, PinJointPar
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
-	const auto* pin_joint = static_cast<const JoltPinJoint3D*>(joint);
+	const auto* pin_joint = static_cast<const JoltPinJointImpl3D*>(joint);
 
 	return pin_joint->get_param(p_param);
 }
@@ -1298,7 +1298,7 @@ void JoltPhysicsServer3D::_pin_joint_set_local_a(const RID& p_joint, const Vecto
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
-	auto* pin_joint = static_cast<JoltPinJoint3D*>(joint);
+	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
 
 	pin_joint->set_local_a(p_local_a);
 }
@@ -1308,7 +1308,7 @@ Vector3 JoltPhysicsServer3D::_pin_joint_get_local_a(const RID& p_joint) const {
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
-	const auto* pin_joint = static_cast<const JoltPinJoint3D*>(joint);
+	const auto* pin_joint = static_cast<const JoltPinJointImpl3D*>(joint);
 
 	return pin_joint->get_local_a();
 }
@@ -1318,7 +1318,7 @@ void JoltPhysicsServer3D::_pin_joint_set_local_b(const RID& p_joint, const Vecto
 	ERR_FAIL_NULL(joint);
 
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
-	auto* pin_joint = static_cast<JoltPinJoint3D*>(joint);
+	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
 
 	pin_joint->set_local_b(p_local_b);
 }
@@ -1328,7 +1328,7 @@ Vector3 JoltPhysicsServer3D::_pin_joint_get_local_b(const RID& p_joint) const {
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
-	const auto* pin_joint = static_cast<const JoltPinJoint3D*>(joint);
+	const auto* pin_joint = static_cast<const JoltPinJointImpl3D*>(joint);
 
 	return pin_joint->get_local_b();
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -50,7 +50,7 @@ RID JoltPhysicsServer3D::_capsule_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_cylinder_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltCylinderShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltCylinderShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -71,7 +71,7 @@ RID JoltPhysicsServer3D::_concave_polygon_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_heightmap_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltHeightMapShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltHeightMapShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -43,7 +43,7 @@ RID JoltPhysicsServer3D::_box_shape_create() {
 }
 
 RID JoltPhysicsServer3D::_capsule_shape_create() {
-	JoltShapeImpl3D* shape = memnew(JoltCapsuleShape3D);
+	JoltShapeImpl3D* shape = memnew(JoltCapsuleShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -3,7 +3,7 @@
 class JoltArea3D;
 class JoltBody3D;
 class JoltJobSystem;
-class JoltJoint3D;
+class JoltJointImpl3D;
 class JoltShape3D;
 class JoltSpace3D;
 
@@ -555,7 +555,7 @@ public:
 
 	void free_shape(JoltShape3D* p_shape);
 
-	void free_joint(JoltJoint3D* p_joint);
+	void free_joint(JoltJointImpl3D* p_joint);
 
 	JoltSpace3D* get_space(const RID& p_rid) const { return space_owner.get_or_null(p_rid); }
 
@@ -565,7 +565,7 @@ public:
 
 	JoltShape3D* get_shape(const RID& p_rid) const { return shape_owner.get_or_null(p_rid); }
 
-	JoltJoint3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
+	JoltJointImpl3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
@@ -576,7 +576,7 @@ private:
 
 	mutable RID_PtrOwner<JoltShape3D> shape_owner;
 
-	mutable RID_PtrOwner<JoltJoint3D> joint_owner;
+	mutable RID_PtrOwner<JoltJointImpl3D> joint_owner;
 
 	HashSet<JoltSpace3D*> active_spaces;
 

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 class JoltAreaImpl3D;
-class JoltBody3D;
+class JoltBodyImpl3D;
 class JoltJobSystem;
 class JoltJointImpl3D;
 class JoltShape3D;
@@ -551,7 +551,7 @@ public:
 
 	void free_area(JoltAreaImpl3D* p_area);
 
-	void free_body(JoltBody3D* p_body);
+	void free_body(JoltBodyImpl3D* p_body);
 
 	void free_shape(JoltShape3D* p_shape);
 
@@ -561,7 +561,7 @@ public:
 
 	JoltAreaImpl3D* get_area(const RID& p_rid) const { return area_owner.get_or_null(p_rid); }
 
-	JoltBody3D* get_body(const RID& p_rid) const { return body_owner.get_or_null(p_rid); }
+	JoltBodyImpl3D* get_body(const RID& p_rid) const { return body_owner.get_or_null(p_rid); }
 
 	JoltShape3D* get_shape(const RID& p_rid) const { return shape_owner.get_or_null(p_rid); }
 
@@ -572,7 +572,7 @@ private:
 
 	mutable RID_PtrOwner<JoltAreaImpl3D> area_owner;
 
-	mutable RID_PtrOwner<JoltBody3D> body_owner;
+	mutable RID_PtrOwner<JoltBodyImpl3D> body_owner;
 
 	mutable RID_PtrOwner<JoltShape3D> shape_owner;
 

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltArea3D;
+class JoltAreaImpl3D;
 class JoltBody3D;
 class JoltJobSystem;
 class JoltJointImpl3D;
@@ -549,7 +549,7 @@ public:
 
 	void free_space(JoltSpace3D* p_space);
 
-	void free_area(JoltArea3D* p_area);
+	void free_area(JoltAreaImpl3D* p_area);
 
 	void free_body(JoltBody3D* p_body);
 
@@ -559,7 +559,7 @@ public:
 
 	JoltSpace3D* get_space(const RID& p_rid) const { return space_owner.get_or_null(p_rid); }
 
-	JoltArea3D* get_area(const RID& p_rid) const { return area_owner.get_or_null(p_rid); }
+	JoltAreaImpl3D* get_area(const RID& p_rid) const { return area_owner.get_or_null(p_rid); }
 
 	JoltBody3D* get_body(const RID& p_rid) const { return body_owner.get_or_null(p_rid); }
 
@@ -570,7 +570,7 @@ public:
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 
-	mutable RID_PtrOwner<JoltArea3D> area_owner;
+	mutable RID_PtrOwner<JoltAreaImpl3D> area_owner;
 
 	mutable RID_PtrOwner<JoltBody3D> body_owner;
 

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -4,7 +4,7 @@ class JoltAreaImpl3D;
 class JoltBodyImpl3D;
 class JoltJobSystem;
 class JoltJointImpl3D;
-class JoltShape3D;
+class JoltShapeImpl3D;
 class JoltSpace3D;
 
 class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
@@ -553,7 +553,7 @@ public:
 
 	void free_body(JoltBodyImpl3D* p_body);
 
-	void free_shape(JoltShape3D* p_shape);
+	void free_shape(JoltShapeImpl3D* p_shape);
 
 	void free_joint(JoltJointImpl3D* p_joint);
 
@@ -563,7 +563,7 @@ public:
 
 	JoltBodyImpl3D* get_body(const RID& p_rid) const { return body_owner.get_or_null(p_rid); }
 
-	JoltShape3D* get_shape(const RID& p_rid) const { return shape_owner.get_or_null(p_rid); }
+	JoltShapeImpl3D* get_shape(const RID& p_rid) const { return shape_owner.get_or_null(p_rid); }
 
 	JoltJointImpl3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
 
@@ -574,7 +574,7 @@ private:
 
 	mutable RID_PtrOwner<JoltBodyImpl3D> body_owner;
 
-	mutable RID_PtrOwner<JoltShape3D> shape_owner;
+	mutable RID_PtrOwner<JoltShapeImpl3D> shape_owner;
 
 	mutable RID_PtrOwner<JoltJointImpl3D> joint_owner;
 

--- a/src/shapes/jolt_empty_shape.cpp
+++ b/src/shapes/jolt_empty_shape.cpp
@@ -3,7 +3,7 @@
 namespace {
 
 JPH::Shape* construct_empty() {
-	return new JoltEmptyShape();
+	return new JoltCustomEmptyShape();
 }
 
 void collide_noop(
@@ -34,15 +34,15 @@ void cast_noop(
 
 } // namespace
 
-JPH::ShapeSettings::ShapeResult JoltEmptyShapeSettings::Create() const {
+JPH::ShapeSettings::ShapeResult JoltCustomEmptyShapeSettings::Create() const {
 	if (mCachedResult.IsEmpty()) {
-		new JoltEmptyShape(*this, mCachedResult);
+		new JoltCustomEmptyShape(*this, mCachedResult);
 	}
 
 	return mCachedResult;
 }
 
-void JoltEmptyShape::register_type() {
+void JoltCustomEmptyShape::register_type() {
 	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JoltShapeSubType::EMPTY);
 
 	shape_functions.mConstruct = construct_empty;

--- a/src/shapes/jolt_empty_shape.cpp
+++ b/src/shapes/jolt_empty_shape.cpp
@@ -43,26 +43,34 @@ JPH::ShapeSettings::ShapeResult JoltCustomEmptyShapeSettings::Create() const {
 }
 
 void JoltCustomEmptyShape::register_type() {
-	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JoltShapeSubType::EMPTY);
+	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JoltCustomShapeSubType::EMPTY);
 
 	shape_functions.mConstruct = construct_empty;
 	shape_functions.mColor = JPH::Color::sBlack;
 
 	for (const JPH::EShapeSubType sub_type : JPH::sAllSubShapeTypes) {
 		JPH::CollisionDispatch::sRegisterCollideShape(
-			JoltShapeSubType::EMPTY,
+			JoltCustomShapeSubType::EMPTY,
 			sub_type,
 			collide_noop
 		);
 
 		JPH::CollisionDispatch::sRegisterCollideShape(
 			sub_type,
-			JoltShapeSubType::EMPTY,
+			JoltCustomShapeSubType::EMPTY,
 			collide_noop
 		);
 
-		JPH::CollisionDispatch::sRegisterCastShape(JoltShapeSubType::EMPTY, sub_type, cast_noop);
+		JPH::CollisionDispatch::sRegisterCastShape(
+			JoltCustomShapeSubType::EMPTY,
+			sub_type,
+			cast_noop
+		);
 
-		JPH::CollisionDispatch::sRegisterCastShape(sub_type, JoltShapeSubType::EMPTY, cast_noop);
+		JPH::CollisionDispatch::sRegisterCastShape(
+			sub_type,
+			JoltCustomShapeSubType::EMPTY,
+			cast_noop
+		);
 	}
 }

--- a/src/shapes/jolt_empty_shape.hpp
+++ b/src/shapes/jolt_empty_shape.hpp
@@ -2,21 +2,21 @@
 
 #include "shapes/jolt_shape_type.hpp"
 
-class JoltEmptyShapeSettings final : public JPH::ShapeSettings {
+class JoltCustomEmptyShapeSettings final : public JPH::ShapeSettings {
 public:
-	JoltEmptyShapeSettings() = default;
+	JoltCustomEmptyShapeSettings() = default;
 
 	ShapeResult Create() const override;
 };
 
-class JoltEmptyShape final : public JPH::Shape {
+class JoltCustomEmptyShape final : public JPH::Shape {
 public:
 	static void register_type();
 
-	JoltEmptyShape()
+	JoltCustomEmptyShape()
 		: Shape(JoltShapeType::EMPTY, JoltShapeSubType::EMPTY) { }
 
-	JoltEmptyShape(const JoltEmptyShapeSettings& p_settings, ShapeResult& p_result)
+	JoltCustomEmptyShape(const JoltCustomEmptyShapeSettings& p_settings, ShapeResult& p_result)
 		: Shape(JoltShapeType::EMPTY, JoltShapeSubType::EMPTY, p_settings, p_result) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);

--- a/src/shapes/jolt_empty_shape.hpp
+++ b/src/shapes/jolt_empty_shape.hpp
@@ -14,10 +14,10 @@ public:
 	static void register_type();
 
 	JoltCustomEmptyShape()
-		: Shape(JoltShapeType::EMPTY, JoltShapeSubType::EMPTY) { }
+		: Shape(JoltCustomShapeType::EMPTY, JoltCustomShapeSubType::EMPTY) { }
 
 	JoltCustomEmptyShape(const JoltCustomEmptyShapeSettings& p_settings, ShapeResult& p_result)
-		: Shape(JoltShapeType::EMPTY, JoltShapeSubType::EMPTY, p_settings, p_result) {
+		: Shape(JoltCustomShapeType::EMPTY, JoltCustomShapeSubType::EMPTY, p_settings, p_result) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);
 		}

--- a/src/shapes/jolt_motion_shape.cpp
+++ b/src/shapes/jolt_motion_shape.cpp
@@ -28,7 +28,7 @@ private:
 
 } // namespace
 
-JPH::AABox JoltMotionShape::GetLocalBounds() const {
+JPH::AABox JoltCustomMotionShape::GetLocalBounds() const {
 	JPH::AABox aabb = inner_shape.GetLocalBounds();
 	JPH::AABox aabb_translated = aabb;
 	aabb_translated.Translate(motion);
@@ -37,7 +37,7 @@ JPH::AABox JoltMotionShape::GetLocalBounds() const {
 	return aabb;
 }
 
-const JPH::ConvexShape::Support* JoltMotionShape::GetSupportFunction(
+const JPH::ConvexShape::Support* JoltCustomMotionShape::GetSupportFunction(
 	JPH::ConvexShape::ESupportMode p_mode,
 	JPH::ConvexShape::SupportBuffer& p_buffer,
 	JPH::Vec3Arg p_scale

--- a/src/shapes/jolt_motion_shape.hpp
+++ b/src/shapes/jolt_motion_shape.hpp
@@ -2,10 +2,10 @@
 
 #include "shapes/jolt_shape_type.hpp"
 
-class JoltMotionShape final : public JPH::ConvexShape {
+class JoltCustomMotionShape final : public JPH::ConvexShape {
 public:
 	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-	explicit JoltMotionShape(const JPH::ConvexShape& p_shape)
+	explicit JoltCustomMotionShape(const JPH::ConvexShape& p_shape)
 		: JPH::ConvexShape(JoltShapeSubType::MOTION)
 		, inner_shape(p_shape) { }
 

--- a/src/shapes/jolt_motion_shape.hpp
+++ b/src/shapes/jolt_motion_shape.hpp
@@ -6,7 +6,7 @@ class JoltCustomMotionShape final : public JPH::ConvexShape {
 public:
 	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 	explicit JoltCustomMotionShape(const JPH::ConvexShape& p_shape)
-		: JPH::ConvexShape(JoltShapeSubType::MOTION)
+		: JPH::ConvexShape(JoltCustomShapeSubType::MOTION)
 		, inner_shape(p_shape) { }
 
 	bool MustBeStatic() const override { return false; }

--- a/src/shapes/jolt_override_user_data_shape.cpp
+++ b/src/shapes/jolt_override_user_data_shape.cpp
@@ -3,7 +3,7 @@
 namespace {
 
 JPH::Shape* construct_override_user_data() {
-	return new JoltOverrideUserDataShape();
+	return new JoltCustomUserDataShape();
 }
 
 void collide_override_user_data_vs_shape(
@@ -21,7 +21,7 @@ void collide_override_user_data_vs_shape(
 ) {
 	ERR_FAIL_COND(p_shape1->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
 
-	const auto* shape1 = static_cast<const JoltOverrideUserDataShape*>(p_shape1);
+	const auto* shape1 = static_cast<const JoltCustomUserDataShape*>(p_shape1);
 
 	JPH::CollisionDispatch::sCollideShapeVsShape(
 		shape1->GetInnerShape(),
@@ -53,7 +53,7 @@ void collide_shape_vs_override_user_data(
 ) {
 	ERR_FAIL_COND(p_shape2->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
 
-	const auto* shape2 = static_cast<const JoltOverrideUserDataShape*>(p_shape2);
+	const auto* shape2 = static_cast<const JoltCustomUserDataShape*>(p_shape2);
 
 	JPH::CollisionDispatch::sCollideShapeVsShape(
 		p_shape1,
@@ -83,7 +83,7 @@ void cast_override_user_data_vs_shape(
 ) {
 	ERR_FAIL_COND(p_shape_cast.mShape->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
 
-	const auto* shape = static_cast<const JoltOverrideUserDataShape*>(p_shape_cast.mShape);
+	const auto* shape = static_cast<const JoltCustomUserDataShape*>(p_shape_cast.mShape);
 
 	const JPH::ShapeCast shape_cast(
 		shape->GetInnerShape(),
@@ -118,7 +118,7 @@ void cast_shape_vs_override_user_data(
 ) {
 	ERR_FAIL_COND(p_shape->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
 
-	const auto* shape = static_cast<const JoltOverrideUserDataShape*>(p_shape);
+	const auto* shape = static_cast<const JoltCustomUserDataShape*>(p_shape);
 
 	JPH::CollisionDispatch::sCastShapeVsShapeLocalSpace(
 		p_shape_cast,
@@ -135,15 +135,15 @@ void cast_shape_vs_override_user_data(
 
 } // namespace
 
-JPH::ShapeSettings::ShapeResult JoltOverrideUserDataShapeSettings::Create() const {
+JPH::ShapeSettings::ShapeResult JoltCustomUserDataShapeSettings::Create() const {
 	if (mCachedResult.IsEmpty()) {
-		new JoltOverrideUserDataShape(*this, mCachedResult);
+		new JoltCustomUserDataShape(*this, mCachedResult);
 	}
 
 	return mCachedResult;
 }
 
-void JoltOverrideUserDataShape::register_type() {
+void JoltCustomUserDataShape::register_type() {
 	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(
 		JoltShapeSubType::OVERRIDE_USER_DATA
 	);

--- a/src/shapes/jolt_override_user_data_shape.cpp
+++ b/src/shapes/jolt_override_user_data_shape.cpp
@@ -19,7 +19,7 @@ void collide_override_user_data_vs_shape(
 	JPH::CollideShapeCollector& p_collector,
 	const JPH::ShapeFilter& p_shape_filter
 ) {
-	ERR_FAIL_COND(p_shape1->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
+	ERR_FAIL_COND(p_shape1->GetSubType() != JoltCustomShapeSubType::OVERRIDE_USER_DATA);
 
 	const auto* shape1 = static_cast<const JoltCustomUserDataShape*>(p_shape1);
 
@@ -51,7 +51,7 @@ void collide_shape_vs_override_user_data(
 	JPH::CollideShapeCollector& p_collector,
 	const JPH::ShapeFilter& p_shape_filter
 ) {
-	ERR_FAIL_COND(p_shape2->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
+	ERR_FAIL_COND(p_shape2->GetSubType() != JoltCustomShapeSubType::OVERRIDE_USER_DATA);
 
 	const auto* shape2 = static_cast<const JoltCustomUserDataShape*>(p_shape2);
 
@@ -81,7 +81,7 @@ void cast_override_user_data_vs_shape(
 	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
 	JPH::CastShapeCollector& p_collector
 ) {
-	ERR_FAIL_COND(p_shape_cast.mShape->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
+	ERR_FAIL_COND(p_shape_cast.mShape->GetSubType() != JoltCustomShapeSubType::OVERRIDE_USER_DATA);
 
 	const auto* shape = static_cast<const JoltCustomUserDataShape*>(p_shape_cast.mShape);
 
@@ -116,7 +116,7 @@ void cast_shape_vs_override_user_data(
 	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
 	JPH::CastShapeCollector& p_collector
 ) {
-	ERR_FAIL_COND(p_shape->GetSubType() != JoltShapeSubType::OVERRIDE_USER_DATA);
+	ERR_FAIL_COND(p_shape->GetSubType() != JoltCustomShapeSubType::OVERRIDE_USER_DATA);
 
 	const auto* shape = static_cast<const JoltCustomUserDataShape*>(p_shape);
 
@@ -145,7 +145,7 @@ JPH::ShapeSettings::ShapeResult JoltCustomUserDataShapeSettings::Create() const 
 
 void JoltCustomUserDataShape::register_type() {
 	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(
-		JoltShapeSubType::OVERRIDE_USER_DATA
+		JoltCustomShapeSubType::OVERRIDE_USER_DATA
 	);
 
 	shape_functions.mConstruct = construct_override_user_data;
@@ -153,26 +153,26 @@ void JoltCustomUserDataShape::register_type() {
 
 	for (const JPH::EShapeSubType sub_type : JPH::sAllSubShapeTypes) {
 		JPH::CollisionDispatch::sRegisterCollideShape(
-			JoltShapeSubType::OVERRIDE_USER_DATA,
+			JoltCustomShapeSubType::OVERRIDE_USER_DATA,
 			sub_type,
 			collide_override_user_data_vs_shape
 		);
 
 		JPH::CollisionDispatch::sRegisterCollideShape(
 			sub_type,
-			JoltShapeSubType::OVERRIDE_USER_DATA,
+			JoltCustomShapeSubType::OVERRIDE_USER_DATA,
 			collide_shape_vs_override_user_data
 		);
 
 		JPH::CollisionDispatch::sRegisterCastShape(
-			JoltShapeSubType::OVERRIDE_USER_DATA,
+			JoltCustomShapeSubType::OVERRIDE_USER_DATA,
 			sub_type,
 			cast_override_user_data_vs_shape
 		);
 
 		JPH::CollisionDispatch::sRegisterCastShape(
 			sub_type,
-			JoltShapeSubType::OVERRIDE_USER_DATA,
+			JoltCustomShapeSubType::OVERRIDE_USER_DATA,
 			cast_shape_vs_override_user_data
 		);
 	}

--- a/src/shapes/jolt_override_user_data_shape.hpp
+++ b/src/shapes/jolt_override_user_data_shape.hpp
@@ -14,13 +14,13 @@ public:
 	static void register_type();
 
 	JoltCustomUserDataShape()
-		: DecoratedShape(JoltShapeSubType::OVERRIDE_USER_DATA) { }
+		: DecoratedShape(JoltCustomShapeSubType::OVERRIDE_USER_DATA) { }
 
 	JoltCustomUserDataShape(
 		const JoltCustomUserDataShapeSettings& p_settings,
 		ShapeResult& p_result
 	)
-		: DecoratedShape(JoltShapeSubType::OVERRIDE_USER_DATA, p_settings, p_result) {
+		: DecoratedShape(JoltCustomShapeSubType::OVERRIDE_USER_DATA, p_settings, p_result) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);
 		}

--- a/src/shapes/jolt_override_user_data_shape.hpp
+++ b/src/shapes/jolt_override_user_data_shape.hpp
@@ -2,22 +2,22 @@
 
 #include "shapes/jolt_shape_type.hpp"
 
-class JoltOverrideUserDataShapeSettings final : public JPH::DecoratedShapeSettings {
+class JoltCustomUserDataShapeSettings final : public JPH::DecoratedShapeSettings {
 public:
 	using JPH::DecoratedShapeSettings::DecoratedShapeSettings;
 
 	ShapeResult Create() const override;
 };
 
-class JoltOverrideUserDataShape final : public JPH::DecoratedShape {
+class JoltCustomUserDataShape final : public JPH::DecoratedShape {
 public:
 	static void register_type();
 
-	JoltOverrideUserDataShape()
+	JoltCustomUserDataShape()
 		: DecoratedShape(JoltShapeSubType::OVERRIDE_USER_DATA) { }
 
-	JoltOverrideUserDataShape(
-		const JoltOverrideUserDataShapeSettings& p_settings,
+	JoltCustomUserDataShape(
+		const JoltCustomUserDataShapeSettings& p_settings,
 		ShapeResult& p_result
 	)
 		: DecoratedShape(JoltShapeSubType::OVERRIDE_USER_DATA, p_settings, p_result) {

--- a/src/shapes/jolt_ray_shape.cpp
+++ b/src/shapes/jolt_ray_shape.cpp
@@ -4,9 +4,9 @@
 
 namespace {
 
-class JoltRayConvexSupport final : public JPH::ConvexShape::Support {
+class JoltCustomRayShapeSupport final : public JPH::ConvexShape::Support {
 public:
-	explicit JoltRayConvexSupport(float p_length)
+	explicit JoltCustomRayShapeSupport(float p_length)
 		: length(p_length) { }
 
 	JPH::Vec3 GetSupport(JPH::Vec3Arg p_direction) const override {
@@ -23,10 +23,10 @@ private:
 	float length = 0.0f;
 };
 
-static_assert(sizeof(JoltRayConvexSupport) <= sizeof(JPH::ConvexShape::SupportBuffer));
+static_assert(sizeof(JoltCustomRayShapeSupport) <= sizeof(JPH::ConvexShape::SupportBuffer));
 
 JPH::Shape* construct_ray() {
-	return new JoltRayShape();
+	return new JoltCustomRayShape();
 }
 
 void collide_ray_vs_shape(
@@ -44,7 +44,7 @@ void collide_ray_vs_shape(
 ) {
 	ERR_FAIL_COND(p_shape1->GetSubType() != JoltShapeSubType::RAY);
 
-	const auto* shape1 = static_cast<const JoltRayShape*>(p_shape1);
+	const auto* shape1 = static_cast<const JoltCustomRayShape*>(p_shape1);
 
 	const float margin = p_collide_shape_settings.mMaxSeparationDistance;
 	const float ray_length = shape1->length;
@@ -147,15 +147,15 @@ void cast_noop(
 
 } // namespace
 
-JPH::ShapeSettings::ShapeResult JoltRayShapeSettings::Create() const {
+JPH::ShapeSettings::ShapeResult JoltCustomRayShapeSettings::Create() const {
 	if (mCachedResult.IsEmpty()) {
-		new JoltRayShape(*this, mCachedResult);
+		new JoltCustomRayShape(*this, mCachedResult);
 	}
 
 	return mCachedResult;
 }
 
-void JoltRayShape::register_type() {
+void JoltCustomRayShape::register_type() {
 	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JoltShapeSubType::RAY);
 
 	shape_functions.mConstruct = construct_ray;
@@ -198,13 +198,13 @@ void JoltRayShape::register_type() {
 	);
 }
 
-JPH::AABox JoltRayShape::GetLocalBounds() const {
+JPH::AABox JoltCustomRayShape::GetLocalBounds() const {
 	return {JPH::Vec3::sZero(), JPH::Vec3(0.0f, 0.0f, length)};
 }
 
 #ifdef JPH_DEBUG_RENDERER
 
-void JoltRayShape::Draw(
+void JoltCustomRayShape::Draw(
 	JPH::DebugRenderer* p_renderer,
 	JPH::RMat44Arg p_center_of_mass_transform,
 	JPH::Vec3Arg p_scale,
@@ -222,10 +222,10 @@ void JoltRayShape::Draw(
 
 #endif // JPH_DEBUG_RENDERER
 
-const JPH::ConvexShape::Support* JoltRayShape::GetSupportFunction(
+const JPH::ConvexShape::Support* JoltCustomRayShape::GetSupportFunction(
 	[[maybe_unused]] JPH::ConvexShape::ESupportMode p_mode,
 	JPH::ConvexShape::SupportBuffer& p_buffer,
 	JPH::Vec3Arg p_scale
 ) const {
-	return new (&p_buffer) JoltRayConvexSupport(p_scale.GetZ() * length);
+	return new (&p_buffer) JoltCustomRayShapeSupport(p_scale.GetZ() * length);
 }

--- a/src/shapes/jolt_ray_shape.cpp
+++ b/src/shapes/jolt_ray_shape.cpp
@@ -42,7 +42,7 @@ void collide_ray_vs_shape(
 	JPH::CollideShapeCollector& p_collector,
 	[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter
 ) {
-	ERR_FAIL_COND(p_shape1->GetSubType() != JoltShapeSubType::RAY);
+	ERR_FAIL_COND(p_shape1->GetSubType() != JoltCustomShapeSubType::RAY);
 
 	const auto* shape1 = static_cast<const JoltCustomRayShape*>(p_shape1);
 
@@ -156,7 +156,7 @@ JPH::ShapeSettings::ShapeResult JoltCustomRayShapeSettings::Create() const {
 }
 
 void JoltCustomRayShape::register_type() {
-	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JoltShapeSubType::RAY);
+	JPH::ShapeFunctions& shape_functions = JPH::ShapeFunctions::sGet(JoltCustomShapeSubType::RAY);
 
 	shape_functions.mConstruct = construct_ray;
 	shape_functions.mColor = JPH::Color::sDarkRed;
@@ -174,26 +174,26 @@ void JoltCustomRayShape::register_type() {
 
 	for (const JPH::EShapeSubType concrete_sub_type : concrete_sub_types) {
 		JPH::CollisionDispatch::sRegisterCollideShape(
-			JoltShapeSubType::RAY,
+			JoltCustomShapeSubType::RAY,
 			concrete_sub_type,
 			collide_ray_vs_shape
 		);
 
 		JPH::CollisionDispatch::sRegisterCollideShape(
 			concrete_sub_type,
-			JoltShapeSubType::RAY,
+			JoltCustomShapeSubType::RAY,
 			JPH::CollisionDispatch::sReversedCollideShape
 		);
 	}
 
 	JPH::CollisionDispatch::sRegisterCollideShape(
-		JoltShapeSubType::RAY,
-		JoltShapeSubType::RAY,
+		JoltCustomShapeSubType::RAY,
+		JoltCustomShapeSubType::RAY,
 		collide_noop
 	);
 	JPH::CollisionDispatch::sRegisterCastShape(
-		JoltShapeSubType::RAY,
-		JoltShapeSubType::RAY,
+		JoltCustomShapeSubType::RAY,
+		JoltCustomShapeSubType::RAY,
 		cast_noop
 	);
 }

--- a/src/shapes/jolt_ray_shape.hpp
+++ b/src/shapes/jolt_ray_shape.hpp
@@ -29,13 +29,13 @@ public:
 	static void register_type();
 
 	JoltCustomRayShape()
-		: JPH::ConvexShape(JoltShapeSubType::RAY) { }
+		: JPH::ConvexShape(JoltCustomShapeSubType::RAY) { }
 
 	JoltCustomRayShape(
 		const JoltCustomRayShapeSettings& p_settings,
 		JPH::Shape::ShapeResult& p_result
 	)
-		: JPH::ConvexShape(JoltShapeSubType::RAY, p_settings, p_result)
+		: JPH::ConvexShape(JoltCustomShapeSubType::RAY, p_settings, p_result)
 		, material(p_settings.material)
 		, length(p_settings.length)
 		, slide_on_slope(p_settings.slide_on_slope) {
@@ -49,7 +49,7 @@ public:
 		bool p_slide_on_slope,
 		const JPH::PhysicsMaterial* p_material = nullptr
 	)
-		: JPH::ConvexShape(JoltShapeSubType::RAY)
+		: JPH::ConvexShape(JoltCustomShapeSubType::RAY)
 		, material(p_material)
 		, length(p_length)
 		, slide_on_slope(p_slide_on_slope) { }

--- a/src/shapes/jolt_ray_shape.hpp
+++ b/src/shapes/jolt_ray_shape.hpp
@@ -2,11 +2,11 @@
 
 #include "shapes/jolt_shape_type.hpp"
 
-class JoltRayShapeSettings final : public JPH::ConvexShapeSettings {
+class JoltCustomRayShapeSettings final : public JPH::ConvexShapeSettings {
 public:
-	JoltRayShapeSettings() = default;
+	JoltCustomRayShapeSettings() = default;
 
-	JoltRayShapeSettings(
+	JoltCustomRayShapeSettings(
 		float p_length,
 		bool p_slide_on_slope,
 		const JPH::PhysicsMaterial* p_material = nullptr
@@ -24,14 +24,17 @@ public:
 	bool slide_on_slope = false;
 };
 
-class JoltRayShape final : public JPH::ConvexShape {
+class JoltCustomRayShape final : public JPH::ConvexShape {
 public:
 	static void register_type();
 
-	JoltRayShape()
+	JoltCustomRayShape()
 		: JPH::ConvexShape(JoltShapeSubType::RAY) { }
 
-	JoltRayShape(const JoltRayShapeSettings& p_settings, JPH::Shape::ShapeResult& p_result)
+	JoltCustomRayShape(
+		const JoltCustomRayShapeSettings& p_settings,
+		JPH::Shape::ShapeResult& p_result
+	)
 		: JPH::ConvexShape(JoltShapeSubType::RAY, p_settings, p_result)
 		, material(p_settings.material)
 		, length(p_settings.length)
@@ -41,7 +44,7 @@ public:
 		}
 	}
 
-	JoltRayShape(
+	JoltCustomRayShape(
 		float p_length,
 		bool p_slide_on_slope,
 		const JPH::PhysicsMaterial* p_material = nullptr

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -187,14 +187,14 @@ JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::build() const {
 	);
 }
 
-Variant JoltSeparationRayShape3D::get_data() const {
+Variant JoltSeparationRayShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["length"] = length;
 	data["slide_on_slope"] = slide_on_slope;
 	return data;
 }
 
-void JoltSeparationRayShape3D::set_data(const Variant& p_data) {
+void JoltSeparationRayShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -215,11 +215,11 @@ void JoltSeparationRayShape3D::set_data(const Variant& p_data) {
 	slide_on_slope = maybe_slide_on_slope;
 }
 
-String JoltSeparationRayShape3D::to_string() const {
+String JoltSeparationRayShapeImpl3D::to_string() const {
 	return vformat("{length=%f slide_on_slope=%s}", length, slide_on_slope);
 }
 
-JPH::ShapeRefC JoltSeparationRayShape3D::build() const {
+JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 	ERR_FAIL_COND_D_MSG(
 		length <= 0.0f,
 		vformat(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -291,11 +291,11 @@ JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltBoxShape3D::get_data() const {
+Variant JoltBoxShapeImpl3D::get_data() const {
 	return half_extents;
 }
 
-void JoltBoxShape3D::set_data(const Variant& p_data) {
+void JoltBoxShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -307,7 +307,7 @@ void JoltBoxShape3D::set_data(const Variant& p_data) {
 	half_extents = p_data;
 }
 
-void JoltBoxShape3D::set_margin(float p_margin) {
+void JoltBoxShapeImpl3D::set_margin(float p_margin) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -317,11 +317,11 @@ void JoltBoxShape3D::set_margin(float p_margin) {
 	margin = p_margin;
 }
 
-String JoltBoxShape3D::to_string() const {
+String JoltBoxShapeImpl3D::to_string() const {
 	return vformat("{half_extents=%v margin=%f}", half_extents, margin);
 }
 
-JPH::ShapeRefC JoltBoxShape3D::build() const {
+JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
 	const float shortest_axis = half_extents[half_extents.min_axis_index()];
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -141,7 +141,7 @@ JPH::ShapeRefC JoltShapeImpl3D::with_center_of_mass(
 }
 
 JPH::ShapeRefC JoltShapeImpl3D::with_user_data(const JPH::Shape* p_shape, uint64_t p_user_data) {
-	JoltOverrideUserDataShapeSettings shape_settings(p_shape);
+	JoltCustomUserDataShapeSettings shape_settings(p_shape);
 	shape_settings.mUserData = (JPH::uint64)p_user_data;
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -6,11 +6,11 @@
 
 JoltShape3D::~JoltShape3D() = default;
 
-void JoltShape3D::add_owner(JoltCollisionObject3D* p_owner) {
+void JoltShape3D::add_owner(JoltObjectImpl3D* p_owner) {
 	ref_counts_by_owner[p_owner]++;
 }
 
-void JoltShape3D::remove_owner(JoltCollisionObject3D* p_owner) {
+void JoltShape3D::remove_owner(JoltObjectImpl3D* p_owner) {
 	if (--ref_counts_by_owner[p_owner] <= 0) {
 		ref_counts_by_owner.erase(p_owner);
 	}

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -4,19 +4,19 @@
 #include "shapes/jolt_override_user_data_shape.hpp"
 #include "shapes/jolt_ray_shape.hpp"
 
-JoltShape3D::~JoltShape3D() = default;
+JoltShapeImpl3D::~JoltShapeImpl3D() = default;
 
-void JoltShape3D::add_owner(JoltObjectImpl3D* p_owner) {
+void JoltShapeImpl3D::add_owner(JoltObjectImpl3D* p_owner) {
 	ref_counts_by_owner[p_owner]++;
 }
 
-void JoltShape3D::remove_owner(JoltObjectImpl3D* p_owner) {
+void JoltShapeImpl3D::remove_owner(JoltObjectImpl3D* p_owner) {
 	if (--ref_counts_by_owner[p_owner] <= 0) {
 		ref_counts_by_owner.erase(p_owner);
 	}
 }
 
-void JoltShape3D::remove_self(bool p_lock) {
+void JoltShapeImpl3D::remove_self(bool p_lock) {
 	// `remove_owner` will be called when we `remove_shape`, so we need to copy the map since the
 	// iterator would be invalidated from underneath us
 	const auto ref_counts_by_owner_copy = ref_counts_by_owner;
@@ -26,7 +26,7 @@ void JoltShape3D::remove_self(bool p_lock) {
 	}
 }
 
-JPH::ShapeRefC JoltShape3D::try_build() {
+JPH::ShapeRefC JoltShapeImpl3D::try_build() {
 	if (jolt_ref == nullptr) {
 		jolt_ref = build();
 	}
@@ -34,7 +34,7 @@ JPH::ShapeRefC JoltShape3D::try_build() {
 	return jolt_ref;
 }
 
-JPH::ShapeRefC JoltShape3D::with_scale(const JPH::Shape* p_shape, const Vector3& p_scale) {
+JPH::ShapeRefC JoltShapeImpl3D::with_scale(const JPH::Shape* p_shape, const Vector3& p_scale) {
 	ERR_FAIL_NULL_D(p_shape);
 
 	const JPH::ScaledShapeSettings shape_settings(p_shape, to_jolt(p_scale));
@@ -53,7 +53,7 @@ JPH::ShapeRefC JoltShape3D::with_scale(const JPH::Shape* p_shape, const Vector3&
 	return shape_result.Get();
 }
 
-JPH::ShapeRefC JoltShape3D::with_basis_origin(
+JPH::ShapeRefC JoltShapeImpl3D::with_basis_origin(
 	const JPH::Shape* p_shape,
 	const Basis& p_basis,
 	const Vector3& p_origin
@@ -82,7 +82,7 @@ JPH::ShapeRefC JoltShape3D::with_basis_origin(
 	return shape_result.Get();
 }
 
-JPH::ShapeRefC JoltShape3D::with_transform(
+JPH::ShapeRefC JoltShapeImpl3D::with_transform(
 	const JPH::Shape* p_shape,
 	const Transform3D& p_transform,
 	const Vector3& p_scale
@@ -102,7 +102,7 @@ JPH::ShapeRefC JoltShape3D::with_transform(
 	return shape;
 }
 
-JPH::ShapeRefC JoltShape3D::with_center_of_mass_offset(
+JPH::ShapeRefC JoltShapeImpl3D::with_center_of_mass_offset(
 	const JPH::Shape* p_shape,
 	const Vector3& p_offset
 ) {
@@ -124,7 +124,7 @@ JPH::ShapeRefC JoltShape3D::with_center_of_mass_offset(
 	return shape_result.Get();
 }
 
-JPH::ShapeRefC JoltShape3D::with_center_of_mass(
+JPH::ShapeRefC JoltShapeImpl3D::with_center_of_mass(
 	const JPH::Shape* p_shape,
 	const Vector3& p_center_of_mass
 ) {
@@ -140,7 +140,7 @@ JPH::ShapeRefC JoltShape3D::with_center_of_mass(
 	return with_center_of_mass_offset(p_shape, center_of_mass_offset);
 }
 
-JPH::ShapeRefC JoltShape3D::with_user_data(const JPH::Shape* p_shape, uint64_t p_user_data) {
+JPH::ShapeRefC JoltShapeImpl3D::with_user_data(const JPH::Shape* p_shape, uint64_t p_user_data) {
 	JoltOverrideUserDataShapeSettings shape_settings(p_shape);
 	shape_settings.mUserData = (JPH::uint64)p_user_data;
 
@@ -158,7 +158,7 @@ JPH::ShapeRefC JoltShape3D::with_user_data(const JPH::Shape* p_shape, uint64_t p
 	return shape_result.Get();
 }
 
-void JoltShape3D::invalidated(bool p_lock) {
+void JoltShapeImpl3D::invalidated(bool p_lock) {
 	for (const auto& [owner, ref_count] : ref_counts_by_owner) {
 		owner->shapes_changed(p_lock);
 	}

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -245,11 +245,11 @@ JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltSphereShape3D::get_data() const {
+Variant JoltSphereShapeImpl3D::get_data() const {
 	return radius;
 }
 
-void JoltSphereShape3D::set_data(const Variant& p_data) {
+void JoltSphereShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -261,11 +261,11 @@ void JoltSphereShape3D::set_data(const Variant& p_data) {
 	radius = p_data;
 }
 
-String JoltSphereShape3D::to_string() const {
+String JoltSphereShapeImpl3D::to_string() const {
 	return vformat("{radius=%f}", radius);
 }
 
-JPH::ShapeRefC JoltSphereShape3D::build() const {
+JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
 	ERR_FAIL_COND_D_MSG(
 		radius <= 0.0f,
 		vformat(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -575,14 +575,14 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltConcavePolygonShape3D::get_data() const {
+Variant JoltConcavePolygonShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["faces"] = faces;
 	data["backface_collision"] = backface_collision;
 	return data;
 }
 
-void JoltConcavePolygonShape3D::set_data(const Variant& p_data) {
+void JoltConcavePolygonShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -603,11 +603,11 @@ void JoltConcavePolygonShape3D::set_data(const Variant& p_data) {
 	backface_collision = maybe_backface_collision;
 }
 
-String JoltConcavePolygonShape3D::to_string() const {
+String JoltConcavePolygonShapeImpl3D::to_string() const {
 	return vformat("{vertex_count=%d}", faces.size());
 }
 
-JPH::ShapeRefC JoltConcavePolygonShape3D::build() const {
+JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 	const auto vertex_count = (int32_t)faces.size();
 	const int32_t face_count = vertex_count / 3;
 	const int32_t excess_vertex_count = vertex_count % 3;

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -507,11 +507,11 @@ JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltConvexPolygonShape3D::get_data() const {
+Variant JoltConvexPolygonShapeImpl3D::get_data() const {
 	return vertices;
 }
 
-void JoltConvexPolygonShape3D::set_data(const Variant& p_data) {
+void JoltConvexPolygonShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -523,7 +523,7 @@ void JoltConvexPolygonShape3D::set_data(const Variant& p_data) {
 	vertices = p_data;
 }
 
-void JoltConvexPolygonShape3D::set_margin(float p_margin) {
+void JoltConvexPolygonShapeImpl3D::set_margin(float p_margin) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -533,11 +533,11 @@ void JoltConvexPolygonShape3D::set_margin(float p_margin) {
 	margin = p_margin;
 }
 
-String JoltConvexPolygonShape3D::to_string() const {
+String JoltConvexPolygonShapeImpl3D::to_string() const {
 	return vformat("{vertex_count=%d margin=%f}", vertices.size(), margin);
 }
 
-JPH::ShapeRefC JoltConvexPolygonShape3D::build() const {
+JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 	const auto vertex_count = (int32_t)vertices.size();
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -677,7 +677,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltHeightMapShape3D::get_data() const {
+Variant JoltHeightMapShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["width"] = width;
 	data["depth"] = depth;
@@ -685,7 +685,7 @@ Variant JoltHeightMapShape3D::get_data() const {
 	return data;
 }
 
-void JoltHeightMapShape3D::set_data(const Variant& p_data) {
+void JoltHeightMapShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -710,11 +710,11 @@ void JoltHeightMapShape3D::set_data(const Variant& p_data) {
 	depth = maybe_depth;
 }
 
-String JoltHeightMapShape3D::to_string() const {
+String JoltHeightMapShapeImpl3D::to_string() const {
 	return vformat("{height_count=%d width=%d depth=%d}", heights.size(), width, depth);
 }
 
-JPH::ShapeRefC JoltHeightMapShape3D::build() const {
+JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 	const auto height_count = (int32_t)heights.size();
 
 	// NOTE(mihe): This somewhat arbitrary limit depends on what the block size is set to, which by

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -229,7 +229,7 @@ JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 		)
 	);
 
-	const JoltRayShapeSettings shape_settings(length, slide_on_slope);
+	const JoltCustomRayShapeSettings shape_settings(length, slide_on_slope);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -428,14 +428,14 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltCylinderShape3D::get_data() const {
+Variant JoltCylinderShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["height"] = height;
 	data["radius"] = radius;
 	return data;
 }
 
-void JoltCylinderShape3D::set_data(const Variant& p_data) {
+void JoltCylinderShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -456,7 +456,7 @@ void JoltCylinderShape3D::set_data(const Variant& p_data) {
 	radius = maybe_radius;
 }
 
-void JoltCylinderShape3D::set_margin(float p_margin) {
+void JoltCylinderShapeImpl3D::set_margin(float p_margin) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -466,11 +466,11 @@ void JoltCylinderShape3D::set_margin(float p_margin) {
 	margin = p_margin;
 }
 
-String JoltCylinderShape3D::to_string() const {
+String JoltCylinderShapeImpl3D::to_string() const {
 	return vformat("{height=%f radius=%f margin=%f}", height, radius, margin);
 }
 
-JPH::ShapeRefC JoltCylinderShape3D::build() const {
+JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
 	ERR_FAIL_COND_D_MSG(
 		height < margin * 2.0f,
 		vformat(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -349,14 +349,14 @@ JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
 	return shape_result.Get();
 }
 
-Variant JoltCapsuleShape3D::get_data() const {
+Variant JoltCapsuleShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["height"] = height;
 	data["radius"] = radius;
 	return data;
 }
 
-void JoltCapsuleShape3D::set_data(const Variant& p_data) {
+void JoltCapsuleShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -377,11 +377,11 @@ void JoltCapsuleShape3D::set_data(const Variant& p_data) {
 	radius = maybe_radius;
 }
 
-String JoltCapsuleShape3D::to_string() const {
+String JoltCapsuleShapeImpl3D::to_string() const {
 	return vformat("{height=%f radius=%f}", height, radius);
 }
 
-JPH::ShapeRefC JoltCapsuleShape3D::build() const {
+JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 	ERR_FAIL_COND_D_MSG(
 		radius <= 0.0f,
 		vformat(

--- a/src/shapes/jolt_shape_3d.cpp
+++ b/src/shapes/jolt_shape_3d.cpp
@@ -164,11 +164,11 @@ void JoltShapeImpl3D::invalidated(bool p_lock) {
 	}
 }
 
-Variant JoltWorldBoundaryShape3D::get_data() const {
+Variant JoltWorldBoundaryShapeImpl3D::get_data() const {
 	return plane;
 }
 
-void JoltWorldBoundaryShape3D::set_data(const Variant& p_data) {
+void JoltWorldBoundaryShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
 		invalidated();
 	};
@@ -180,7 +180,7 @@ void JoltWorldBoundaryShape3D::set_data(const Variant& p_data) {
 	plane = p_data;
 }
 
-JPH::ShapeRefC JoltWorldBoundaryShape3D::build() const {
+JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::build() const {
 	ERR_FAIL_D_MSG(
 		"WorldBoundaryShape3D is not supported by Godot Jolt. "
 		"Consider using one or more reasonably sized BoxShape3D instead."

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -77,7 +77,7 @@ protected:
 	JPH::ShapeRefC jolt_ref;
 };
 
-class JoltWorldBoundaryShape3D final : public JoltShapeImpl3D {
+class JoltWorldBoundaryShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_WORLD_BOUNDARY; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -265,7 +265,7 @@ private:
 	bool backface_collision = false;
 };
 
-class JoltHeightMapShape3D final : public JoltShapeImpl3D {
+class JoltHeightMapShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_HEIGHTMAP; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -241,7 +241,7 @@ private:
 	float margin = 0.04f;
 };
 
-class JoltConcavePolygonShape3D final : public JoltShapeImpl3D {
+class JoltConcavePolygonShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CONCAVE_POLYGON; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -97,7 +97,7 @@ private:
 	Plane plane;
 };
 
-class JoltSeparationRayShape3D final : public JoltShapeImpl3D {
+class JoltSeparationRayShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_SEPARATION_RAY; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -2,11 +2,11 @@
 
 class JoltObjectImpl3D;
 
-class JoltShape3D {
+class JoltShapeImpl3D {
 public:
 	using ShapeType = PhysicsServer3D::ShapeType;
 
-	virtual ~JoltShape3D() = 0;
+	virtual ~JoltShapeImpl3D() = 0;
 
 	RID get_rid() const { return rid; }
 
@@ -77,7 +77,7 @@ protected:
 	JPH::ShapeRefC jolt_ref;
 };
 
-class JoltWorldBoundaryShape3D final : public JoltShape3D {
+class JoltWorldBoundaryShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_WORLD_BOUNDARY; }
 
@@ -97,7 +97,7 @@ private:
 	Plane plane;
 };
 
-class JoltSeparationRayShape3D final : public JoltShape3D {
+class JoltSeparationRayShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_SEPARATION_RAY; }
 
@@ -121,7 +121,7 @@ private:
 	bool slide_on_slope = false;
 };
 
-class JoltSphereShape3D final : public JoltShape3D {
+class JoltSphereShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_SPHERE; }
 
@@ -143,7 +143,7 @@ private:
 	float radius = 0.0f;
 };
 
-class JoltBoxShape3D final : public JoltShape3D {
+class JoltBoxShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_BOX; }
 
@@ -167,7 +167,7 @@ private:
 	float margin = 0.04f;
 };
 
-class JoltCapsuleShape3D final : public JoltShape3D {
+class JoltCapsuleShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CAPSULE; }
 
@@ -191,7 +191,7 @@ private:
 	float radius = 0.0f;
 };
 
-class JoltCylinderShape3D final : public JoltShape3D {
+class JoltCylinderShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CYLINDER; }
 
@@ -217,7 +217,7 @@ private:
 	float margin = 0.04f;
 };
 
-class JoltConvexPolygonShape3D final : public JoltShape3D {
+class JoltConvexPolygonShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CONVEX_POLYGON; }
 
@@ -241,7 +241,7 @@ private:
 	float margin = 0.04f;
 };
 
-class JoltConcavePolygonShape3D final : public JoltShape3D {
+class JoltConcavePolygonShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CONCAVE_POLYGON; }
 
@@ -265,7 +265,7 @@ private:
 	bool backface_collision = false;
 };
 
-class JoltHeightMapShape3D final : public JoltShape3D {
+class JoltHeightMapShape3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_HEIGHTMAP; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -191,7 +191,7 @@ private:
 	float radius = 0.0f;
 };
 
-class JoltCylinderShape3D final : public JoltShapeImpl3D {
+class JoltCylinderShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CYLINDER; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -167,7 +167,7 @@ private:
 	float margin = 0.04f;
 };
 
-class JoltCapsuleShape3D final : public JoltShapeImpl3D {
+class JoltCapsuleShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CAPSULE; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltCollisionObject3D;
+class JoltObjectImpl3D;
 
 class JoltShape3D {
 public:
@@ -12,9 +12,9 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
-	void add_owner(JoltCollisionObject3D* p_owner);
+	void add_owner(JoltObjectImpl3D* p_owner);
 
-	void remove_owner(JoltCollisionObject3D* p_owner);
+	void remove_owner(JoltObjectImpl3D* p_owner);
 
 	void remove_self(bool p_lock = true);
 
@@ -70,7 +70,7 @@ protected:
 
 	virtual void invalidated(bool p_lock = true);
 
-	HashMap<JoltCollisionObject3D*, int32_t> ref_counts_by_owner;
+	HashMap<JoltObjectImpl3D*, int32_t> ref_counts_by_owner;
 
 	RID rid;
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -217,7 +217,7 @@ private:
 	float margin = 0.04f;
 };
 
-class JoltConvexPolygonShape3D final : public JoltShapeImpl3D {
+class JoltConvexPolygonShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_CONVEX_POLYGON; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -143,7 +143,7 @@ private:
 	float radius = 0.0f;
 };
 
-class JoltBoxShape3D final : public JoltShapeImpl3D {
+class JoltBoxShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_BOX; }
 

--- a/src/shapes/jolt_shape_3d.hpp
+++ b/src/shapes/jolt_shape_3d.hpp
@@ -121,7 +121,7 @@ private:
 	bool slide_on_slope = false;
 };
 
-class JoltSphereShape3D final : public JoltShapeImpl3D {
+class JoltSphereShapeImpl3D final : public JoltShapeImpl3D {
 public:
 	ShapeType get_type() const override { return ShapeType::SHAPE_SPHERE; }
 

--- a/src/shapes/jolt_shape_3d.inl
+++ b/src/shapes/jolt_shape_3d.inl
@@ -1,7 +1,7 @@
 #pragma once
 
 template<typename TCallable>
-JPH::ShapeRefC JoltShape3D::as_compound(TCallable&& p_callable) {
+JPH::ShapeRefC JoltShapeImpl3D::as_compound(TCallable&& p_callable) {
 	JPH::StaticCompoundShapeSettings shape_settings;
 
 	auto add_shape = [&](JPH::ShapeRefC p_shape,

--- a/src/shapes/jolt_shape_instance_3d.cpp
+++ b/src/shapes/jolt_shape_instance_3d.cpp
@@ -4,7 +4,7 @@
 
 JoltShapeInstance3D::JoltShapeInstance3D(
 	JoltObjectImpl3D* p_parent,
-	JoltShape3D* p_shape,
+	JoltShapeImpl3D* p_shape,
 	const Transform3D& p_transform,
 	const Vector3& p_scale,
 	bool p_disabled
@@ -45,7 +45,7 @@ bool JoltShapeInstance3D::try_build() {
 		}
 	}
 
-	jolt_ref = JoltShape3D::with_user_data(maybe_new_shape, (uint64_t)id);
+	jolt_ref = JoltShapeImpl3D::with_user_data(maybe_new_shape, (uint64_t)id);
 
 	return true;
 }

--- a/src/shapes/jolt_shape_instance_3d.cpp
+++ b/src/shapes/jolt_shape_instance_3d.cpp
@@ -3,7 +3,7 @@
 #include "shapes/jolt_shape_3d.hpp"
 
 JoltShapeInstance3D::JoltShapeInstance3D(
-	JoltCollisionObject3D* p_parent,
+	JoltObjectImpl3D* p_parent,
 	JoltShape3D* p_shape,
 	const Transform3D& p_transform,
 	const Vector3& p_scale,

--- a/src/shapes/jolt_shape_instance_3d.hpp
+++ b/src/shapes/jolt_shape_instance_3d.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 class JoltObjectImpl3D;
-class JoltShape3D;
+class JoltShapeImpl3D;
 
 class JoltShapeInstance3D {
 public:
 	JoltShapeInstance3D(
 		JoltObjectImpl3D* p_parent,
-		JoltShape3D* p_shape,
+		JoltShapeImpl3D* p_shape,
 		const Transform3D& p_transform = {},
 		const Vector3& p_scale = {1.0f, 1.0f, 1.0f},
 		bool p_disabled = false
@@ -21,7 +21,7 @@ public:
 
 	uint32_t get_id() const { return id; }
 
-	JoltShape3D* get_shape() const { return shape; }
+	JoltShapeImpl3D* get_shape() const { return shape; }
 
 	const JPH::Shape* get_jolt_ref() const { return jolt_ref; }
 
@@ -62,7 +62,7 @@ private:
 
 	JoltObjectImpl3D* parent = nullptr;
 
-	JoltShape3D* shape = nullptr;
+	JoltShapeImpl3D* shape = nullptr;
 
 	uint32_t id = next_id++;
 

--- a/src/shapes/jolt_shape_instance_3d.hpp
+++ b/src/shapes/jolt_shape_instance_3d.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-class JoltCollisionObject3D;
+class JoltObjectImpl3D;
 class JoltShape3D;
 
 class JoltShapeInstance3D {
 public:
 	JoltShapeInstance3D(
-		JoltCollisionObject3D* p_parent,
+		JoltObjectImpl3D* p_parent,
 		JoltShape3D* p_shape,
 		const Transform3D& p_transform = {},
 		const Vector3& p_scale = {1.0f, 1.0f, 1.0f},
@@ -60,7 +60,7 @@ private:
 
 	JPH::ShapeRefC jolt_ref;
 
-	JoltCollisionObject3D* parent = nullptr;
+	JoltObjectImpl3D* parent = nullptr;
 
 	JoltShape3D* shape = nullptr;
 

--- a/src/shapes/jolt_shape_type.hpp
+++ b/src/shapes/jolt_shape_type.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-namespace JoltShapeType {
+namespace JoltCustomShapeType {
 
 constexpr JPH::EShapeType EMPTY = JPH::EShapeType::User1;
 
-} // namespace JoltShapeType
+} // namespace JoltCustomShapeType
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-namespace JoltShapeSubType {
+namespace JoltCustomShapeSubType {
 
 constexpr JPH::EShapeSubType EMPTY = JPH::EShapeSubType::User1;
 constexpr JPH::EShapeSubType OVERRIDE_USER_DATA = JPH::EShapeSubType::User2;
 constexpr JPH::EShapeSubType RAY = JPH::EShapeSubType::UserConvex1;
 constexpr JPH::EShapeSubType MOTION = JPH::EShapeSubType::UserConvex2;
 
-} // namespace JoltShapeSubType
+} // namespace JoltCustomShapeSubType

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 class JoltAreaImpl3D;
-class JoltBody3D;
+class JoltBodyImpl3D;
 class JoltCollisionObject3D;
 class JoltSpace3D;
 
@@ -156,9 +156,9 @@ public:
 		}
 	}
 
-	JoltBody3D* as_body() const {
+	JoltBodyImpl3D* as_body() const {
 		if (body != nullptr && !body->IsSensor()) {
-			return reinterpret_cast<JoltBody3D*>(body->GetUserData());
+			return reinterpret_cast<JoltBodyImpl3D*>(body->GetUserData());
 		} else {
 			return nullptr;
 		}

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -2,7 +2,7 @@
 
 class JoltAreaImpl3D;
 class JoltBodyImpl3D;
-class JoltCollisionObject3D;
+class JoltObjectImpl3D;
 class JoltSpace3D;
 
 class JoltBodyAccessor3D {
@@ -148,9 +148,9 @@ public:
 
 	bool is_invalid() const { return body == nullptr; }
 
-	JoltCollisionObject3D* as_object() const {
+	JoltObjectImpl3D* as_object() const {
 		if (body != nullptr) {
-			return reinterpret_cast<JoltCollisionObject3D*>(body->GetUserData());
+			return reinterpret_cast<JoltObjectImpl3D*>(body->GetUserData());
 		} else {
 			return nullptr;
 		}

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltArea3D;
+class JoltAreaImpl3D;
 class JoltBody3D;
 class JoltCollisionObject3D;
 class JoltSpace3D;
@@ -164,9 +164,9 @@ public:
 		}
 	}
 
-	JoltArea3D* as_area() const {
+	JoltAreaImpl3D* as_area() const {
 		if (body != nullptr && body->IsSensor()) {
-			return reinterpret_cast<JoltArea3D*>(body->GetUserData());
+			return reinterpret_cast<JoltAreaImpl3D*>(body->GetUserData());
 		} else {
 			return nullptr;
 		}

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -236,8 +236,8 @@ void JoltContactListener3D::flush_area_enters() {
 			continue;
 		}
 
-		JoltArea3D* area1 = jolt_body1.as_area();
-		JoltArea3D* area2 = jolt_body2.as_area();
+		JoltAreaImpl3D* area1 = jolt_body1.as_area();
+		JoltAreaImpl3D* area2 = jolt_body2.as_area();
 
 		if (area1 != nullptr && area2 != nullptr) {
 			if (area2->is_monitorable()) {
@@ -305,8 +305,8 @@ void JoltContactListener3D::flush_area_exits() {
 		const JoltReadableBody3D jolt_body1 = jolt_bodies[0];
 		const JoltReadableBody3D jolt_body2 = jolt_bodies[1];
 
-		JoltArea3D* area1 = jolt_body1.as_area();
-		JoltArea3D* area2 = jolt_body2.as_area();
+		JoltAreaImpl3D* area1 = jolt_body1.as_area();
+		JoltAreaImpl3D* area2 = jolt_body2.as_area();
 
 		const JoltBody3D* body1 = jolt_body1.as_body();
 		const JoltBody3D* body2 = jolt_body2.as_body();

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -16,7 +16,7 @@ JPH::SubShapeIDPair pair_contact(
 
 } // namespace
 
-void JoltContactListener3D::listen_for(JoltCollisionObject3D* p_object) {
+void JoltContactListener3D::listen_for(JoltObjectImpl3D* p_object) {
 	listening_for.insert(p_object->get_jolt_id());
 }
 
@@ -261,7 +261,7 @@ void JoltContactListener3D::flush_area_shifts() {
 	for (const JPH::SubShapeIDPair& shape_pair : area_overlaps) {
 		auto is_shifted = [&](const JPH::BodyID& p_body_id, const JPH::SubShapeID& p_sub_shape_id) {
 			const JoltReadableBody3D jolt_body = space->read_body(p_body_id, false);
-			const JoltCollisionObject3D* object = jolt_body.as_object();
+			const JoltObjectImpl3D* object = jolt_body.as_object();
 			ERR_FAIL_NULL_V(object, false);
 
 			if (object->get_previous_jolt_shape() == nullptr) {

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -171,10 +171,10 @@ void JoltContactListener3D::flush_contacts() {
 			false
 		);
 
-		JoltBody3D* body1 = jolt_bodies[0].as_body();
+		JoltBodyImpl3D* body1 = jolt_bodies[0].as_body();
 		ERR_FAIL_NULL(body1);
 
-		JoltBody3D* body2 = jolt_bodies[1].as_body();
+		JoltBodyImpl3D* body2 = jolt_bodies[1].as_body();
 		ERR_FAIL_NULL(body2);
 
 		const int32_t shape_index1 = body1->find_shape_index(shape_pair.GetSubShapeID1());
@@ -308,8 +308,8 @@ void JoltContactListener3D::flush_area_exits() {
 		JoltAreaImpl3D* area1 = jolt_body1.as_area();
 		JoltAreaImpl3D* area2 = jolt_body2.as_area();
 
-		const JoltBody3D* body1 = jolt_body1.as_body();
-		const JoltBody3D* body2 = jolt_body2.as_body();
+		const JoltBodyImpl3D* body1 = jolt_body1.as_body();
+		const JoltBodyImpl3D* body2 = jolt_body2.as_body();
 
 		if (area1 != nullptr && area2 != nullptr) {
 			area1->area_shape_exited(body_id2, sub_shape_id2, sub_shape_id1);

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltCollisionObject3D;
+class JoltObjectImpl3D;
 class JoltSpace3D;
 
 class JoltContactListener3D final : public JPH::ContactListener {
@@ -56,7 +56,7 @@ public:
 	explicit JoltContactListener3D(JoltSpace3D* p_space)
 		: space(p_space) { }
 
-	void listen_for(JoltCollisionObject3D* p_object);
+	void listen_for(JoltObjectImpl3D* p_object);
 
 	void pre_step();
 

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -9,7 +9,7 @@
 #include "spaces/jolt_broad_phase_layer.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
-JoltMotionFilter3D::JoltMotionFilter3D(const JoltBody3D& p_body, bool p_collide_separation_ray)
+JoltMotionFilter3D::JoltMotionFilter3D(const JoltBodyImpl3D& p_body, bool p_collide_separation_ray)
 	: physics_server(*static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton()))
 	, body(p_body)
 	, collide_separation_ray(p_collide_separation_ray) { }

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -75,7 +75,7 @@ bool JoltMotionFilter3D::ShouldCollide(
 		return true;
 	}
 
-	const auto* motion_shape1 = static_cast<const JoltMotionShape*>(p_shape1);
+	const auto* motion_shape1 = static_cast<const JoltCustomMotionShape*>(p_shape1);
 	const JPH::ConvexShape& actual_shape1 = motion_shape1->get_inner_shape();
 
 	return actual_shape1.GetSubType() != JoltShapeSubType::RAY;

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -78,5 +78,5 @@ bool JoltMotionFilter3D::ShouldCollide(
 	const auto* motion_shape1 = static_cast<const JoltCustomMotionShape*>(p_shape1);
 	const JPH::ConvexShape& actual_shape1 = motion_shape1->get_inner_shape();
 
-	return actual_shape1.GetSubType() != JoltShapeSubType::RAY;
+	return actual_shape1.GetSubType() != JoltCustomShapeSubType::RAY;
 }

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -52,7 +52,7 @@ bool JoltMotionFilter3D::ShouldCollide(const JPH::BodyID& p_body_id) const {
 }
 
 bool JoltMotionFilter3D::ShouldCollideLocked(const JPH::Body& p_body) const {
-	const auto* object = reinterpret_cast<const JoltCollisionObject3D*>(p_body.GetUserData());
+	const auto* object = reinterpret_cast<const JoltObjectImpl3D*>(p_body.GetUserData());
 
 	return !physics_server.body_test_motion_is_excluding_object(object->get_instance_id()) &&
 		!physics_server.body_test_motion_is_excluding_body(object->get_rid());

--- a/src/spaces/jolt_motion_filter_3d.hpp
+++ b/src/spaces/jolt_motion_filter_3d.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 class JoltPhysicsServer3D;
-class JoltBody3D;
+class JoltBodyImpl3D;
 
 class JoltMotionFilter3D final
 	: public JPH::BroadPhaseLayerFilter
@@ -9,7 +9,7 @@ class JoltMotionFilter3D final
 	, public JPH::BodyFilter
 	, public JPH::ShapeFilter {
 public:
-	explicit JoltMotionFilter3D(const JoltBody3D& p_body, bool p_collide_separation_ray = true);
+	explicit JoltMotionFilter3D(const JoltBodyImpl3D& p_body, bool p_collide_separation_ray = true);
 
 	bool ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const override;
 
@@ -32,7 +32,7 @@ public:
 private:
 	const JoltPhysicsServer3D& physics_server;
 
-	const JoltBody3D& body;
+	const JoltBodyImpl3D& body;
 
 	bool collide_separation_ray = false;
 };

--- a/src/spaces/jolt_motion_filter_3d.hpp
+++ b/src/spaces/jolt_motion_filter_3d.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-class JoltPhysicsServer3D;
 class JoltBodyImpl3D;
+class JoltPhysicsServer3D;
 
 class JoltMotionFilter3D final
 	: public JPH::BroadPhaseLayerFilter

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -54,7 +54,7 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	const JPH::SubShapeID& sub_shape_id = hit.mSubShapeID2;
 
 	const JoltReadableBody3D body = space->read_body(body_id);
-	const JoltCollisionObject3D* object = body.as_object();
+	const JoltObjectImpl3D* object = body.as_object();
 	ERR_FAIL_NULL_D(object);
 
 	const JPH::Vec3 position = ray.GetPointOnRay(hit.mFraction);
@@ -101,7 +101,7 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_point(
 		const JPH::CollidePointResult& hit = collector.get_hit(i);
 
 		const JoltReadableBody3D body = space->read_body(hit.mBodyID);
-		const JoltCollisionObject3D* object = body.as_object();
+		const JoltObjectImpl3D* object = body.as_object();
 		ERR_FAIL_NULL_D(object);
 
 		const int32_t shape_index = object->find_shape_index(hit.mSubShapeID2);
@@ -172,7 +172,7 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 		const JPH::CollideShapeResult& hit = collector.get_hit(i);
 
 		const JoltReadableBody3D body = space->read_body(hit.mBodyID2);
-		const JoltCollisionObject3D* object = body.as_object();
+		const JoltObjectImpl3D* object = body.as_object();
 		ERR_FAIL_NULL_D(object);
 
 		const int32_t shape_index = object->find_shape_index(hit.mSubShapeID2);
@@ -369,7 +369,7 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	const JPH::CollideShapeResult& hit = collector.get_hit();
 
 	const JoltReadableBody3D body = space->read_body(hit.mBodyID2);
-	const JoltCollisionObject3D* object = body.as_object();
+	const JoltObjectImpl3D* object = body.as_object();
 	ERR_FAIL_NULL_D(object);
 
 	const int32_t shape_index = object->find_shape_index(hit.mSubShapeID2);
@@ -393,7 +393,7 @@ Vector3 JoltPhysicsDirectSpaceState3D::_get_closest_point_to_object_volume(
 ) const {
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
-	JoltCollisionObject3D* object = physics_server->get_area(p_object);
+	JoltObjectImpl3D* object = physics_server->get_area(p_object);
 
 	if (object == nullptr) {
 		object = physics_server->get_body(p_object);
@@ -911,7 +911,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_collide(
 		const JPH::CollideShapeResult& hit = collector.get_hit(i);
 
 		const JoltReadableBody3D collider_jolt_body = space->read_body(hit.mBodyID2);
-		const JoltCollisionObject3D* collider = collider_jolt_body.as_object();
+		const JoltObjectImpl3D* collider = collider_jolt_body.as_object();
 		ERR_FAIL_NULL_D(collider);
 
 		const Vector3 position = base_offset + to_godot(hit.mContactPointOn2);

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -135,7 +135,7 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
-	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
+	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
 	const JPH::ShapeRefC jolt_shape = shape->try_build();
@@ -210,7 +210,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
-	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
+	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
 	const JPH::ShapeRefC jolt_shape = shape->try_build();
@@ -263,7 +263,7 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
-	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
+	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
 	const JPH::ShapeRefC jolt_shape = shape->try_build();
@@ -329,7 +329,7 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 ) {
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
-	JoltShape3D* shape = physics_server->get_shape(p_shape_rid);
+	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
 	ERR_FAIL_NULL_D(shape);
 
 	const JPH::ShapeRefC jolt_shape = shape->try_build();
@@ -819,7 +819,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
 			continue;
 		}
 
-		JoltShape3D* shape = p_body.get_shape(i);
+		JoltShapeImpl3D* shape = p_body.get_shape(i);
 
 		if (!shape->is_convex()) {
 			continue;

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -598,7 +598,7 @@ bool JoltPhysicsDirectSpaceState3D::cast_motion(
 		return false;
 	}
 
-	JoltMotionShape motion_shape(static_cast<const JPH::ConvexShape&>(p_jolt_shape));
+	JoltCustomMotionShape motion_shape(static_cast<const JPH::ConvexShape&>(p_jolt_shape));
 
 	auto collides = [&](const JPH::Body& p_other_body, float p_fraction) {
 		motion_shape.set_motion(motion_local * p_fraction);

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -483,7 +483,7 @@ Vector3 JoltPhysicsDirectSpaceState3D::_get_closest_point_to_object_volume(
 }
 
 bool JoltPhysicsDirectSpaceState3D::test_body_motion(
-	const JoltBody3D& p_body,
+	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_motion,
 	float p_margin,
@@ -689,7 +689,7 @@ bool JoltPhysicsDirectSpaceState3D::cast_motion(
 }
 
 bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
-	const JoltBody3D& p_body,
+	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_direction,
 	float p_margin,
@@ -744,7 +744,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 			const JPH::CollideShapeResult& hit = collector.get_hit(j);
 
 			const JoltReadableBody3D other_jolt_body = space->read_body(hit.mBodyID2);
-			const JoltBody3D* other_body = other_jolt_body.as_body();
+			const JoltBodyImpl3D* other_body = other_jolt_body.as_body();
 			ERR_CONTINUE(other_body == nullptr);
 
 			combined_priority += other_body->get_collision_priority();
@@ -775,7 +775,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 			}
 
 			const JoltReadableBody3D other_jolt_body = space->read_body(hit.mBodyID2);
-			const JoltBody3D* other_body = other_jolt_body.as_body();
+			const JoltBodyImpl3D* other_body = other_jolt_body.as_body();
 			ERR_CONTINUE(other_body == nullptr);
 
 			const float recovery_distance = penetration_depth * recovery_speed;
@@ -798,7 +798,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 }
 
 bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
-	const JoltBody3D& p_body,
+	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_scale,
 	const Vector3& p_motion,
@@ -862,7 +862,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
 }
 
 bool JoltPhysicsDirectSpaceState3D::body_motion_collide(
-	const JoltBody3D& p_body,
+	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_direction,
 	float p_margin,

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltBody3D;
+class JoltBodyImpl3D;
 class JoltShape3D;
 class JoltSpace3D;
 
@@ -89,7 +89,7 @@ public:
 		const override;
 
 	bool test_body_motion(
-		const JoltBody3D& p_body,
+		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_motion,
 		float p_margin,
@@ -117,7 +117,7 @@ private:
 	) const;
 
 	bool body_motion_recover(
-		const JoltBody3D& p_body,
+		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_direction,
 		float p_margin,
@@ -125,7 +125,7 @@ private:
 	) const;
 
 	bool body_motion_cast(
-		const JoltBody3D& p_body,
+		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_scale,
 		const Vector3& p_motion,
@@ -135,7 +135,7 @@ private:
 	) const;
 
 	bool body_motion_collide(
-		const JoltBody3D& p_body,
+		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_direction,
 		float p_margin,

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 class JoltBodyImpl3D;
-class JoltShape3D;
+class JoltShapeImpl3D;
 class JoltSpace3D;
 
 class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3DExtension {

--- a/src/spaces/jolt_query_filter_3d.cpp
+++ b/src/spaces/jolt_query_filter_3d.cpp
@@ -56,6 +56,6 @@ bool JoltQueryFilter3D::ShouldCollide([[maybe_unused]] const JPH::BodyID& p_body
 
 bool JoltQueryFilter3D::ShouldCollideLocked(const JPH::Body& p_body) const {
 	return !space_state.is_body_excluded_from_query(
-		reinterpret_cast<JoltCollisionObject3D*>(p_body.GetUserData())->get_rid()
+		reinterpret_cast<JoltObjectImpl3D*>(p_body.GetUserData())->get_rid()
 	);
 }

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -130,7 +130,7 @@ void JoltSpace3D::call_queries() {
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (const JPH::Body* body = body_accessor.try_get(i)) {
 			if (body->IsSensor()) {
-				reinterpret_cast<JoltArea3D*>(body->GetUserData())->call_queries();
+				reinterpret_cast<JoltAreaImpl3D*>(body->GetUserData())->call_queries();
 			}
 		}
 	}

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -300,8 +300,7 @@ JoltReadableBody3D JoltSpace3D::read_body(const JPH::BodyID& p_body_id, bool p_l
 	return {*this, p_body_id, p_lock};
 }
 
-JoltReadableBody3D JoltSpace3D::read_body(const JoltCollisionObject3D& p_object, bool p_lock)
-	const {
+JoltReadableBody3D JoltSpace3D::read_body(const JoltObjectImpl3D& p_object, bool p_lock) const {
 	return read_body(p_object.get_jolt_id(), p_lock);
 }
 
@@ -309,8 +308,7 @@ JoltWritableBody3D JoltSpace3D::write_body(const JPH::BodyID& p_body_id, bool p_
 	return {*this, p_body_id, p_lock};
 }
 
-JoltWritableBody3D JoltSpace3D::write_body(const JoltCollisionObject3D& p_object, bool p_lock)
-	const {
+JoltWritableBody3D JoltSpace3D::write_body(const JoltObjectImpl3D& p_object, bool p_lock) const {
 	return write_body(p_object.get_jolt_id(), p_lock);
 }
 
@@ -383,7 +381,7 @@ void JoltSpace3D::pre_step(float p_step) {
 
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (const JPH::Body* jolt_body = body_accessor.try_get(i)) {
-			auto* object = reinterpret_cast<JoltCollisionObject3D*>(jolt_body->GetUserData());
+			auto* object = reinterpret_cast<JoltObjectImpl3D*>(jolt_body->GetUserData());
 
 			object->pre_step(p_step);
 
@@ -405,7 +403,7 @@ void JoltSpace3D::post_step(float p_step) {
 
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (const JPH::Body* jolt_body = body_accessor.try_get(i)) {
-			auto* object = reinterpret_cast<JoltCollisionObject3D*>(jolt_body->GetUserData());
+			auto* object = reinterpret_cast<JoltObjectImpl3D*>(jolt_body->GetUserData());
 
 			object->post_step(p_step);
 		}

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -122,7 +122,7 @@ void JoltSpace3D::call_queries() {
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (const JPH::Body* body = body_accessor.try_get(i)) {
 			if (!body->IsSensor() && !body->IsStatic()) {
-				reinterpret_cast<JoltBody3D*>(body->GetUserData())->call_queries();
+				reinterpret_cast<JoltBodyImpl3D*>(body->GetUserData())->call_queries();
 			}
 		}
 	}

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -342,7 +342,7 @@ void JoltSpace3D::add_joint(JPH::Constraint* p_jolt_ref) {
 	physics_system->AddConstraint(p_jolt_ref);
 }
 
-void JoltSpace3D::add_joint(JoltJoint3D* p_joint) {
+void JoltSpace3D::add_joint(JoltJointImpl3D* p_joint) {
 	add_joint(p_joint->get_jolt_ref());
 }
 
@@ -350,7 +350,7 @@ void JoltSpace3D::remove_joint(JPH::Constraint* p_jolt_ref) {
 	physics_system->RemoveConstraint(p_jolt_ref);
 }
 
-void JoltSpace3D::remove_joint(JoltJoint3D* p_joint) {
+void JoltSpace3D::remove_joint(JoltJointImpl3D* p_joint) {
 	remove_joint(p_joint->get_jolt_ref());
 }
 

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -5,7 +5,7 @@
 class JoltArea3D;
 class JoltCollisionObject3D;
 class JoltContactListener3D;
-class JoltJoint3D;
+class JoltJointImpl3D;
 class JoltLayerMapper;
 class JoltPhysicsDirectSpaceState3D;
 
@@ -82,11 +82,11 @@ public:
 
 	void add_joint(JPH::Constraint* p_jolt_ref);
 
-	void add_joint(JoltJoint3D* p_joint);
+	void add_joint(JoltJointImpl3D* p_joint);
 
 	void remove_joint(JPH::Constraint* p_jolt_ref);
 
-	void remove_joint(JoltJoint3D* p_joint);
+	void remove_joint(JoltJointImpl3D* p_joint);
 
 #ifdef GDJ_CONFIG_EDITOR
 	const PackedVector3Array& get_debug_contacts() const;

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -3,10 +3,10 @@
 #include "spaces/jolt_body_accessor_3d.hpp"
 
 class JoltAreaImpl3D;
-class JoltObjectImpl3D;
 class JoltContactListener3D;
 class JoltJointImpl3D;
 class JoltLayerMapper;
+class JoltObjectImpl3D;
 class JoltPhysicsDirectSpaceState3D;
 
 class JoltSpace3D final {

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -3,7 +3,7 @@
 #include "spaces/jolt_body_accessor_3d.hpp"
 
 class JoltAreaImpl3D;
-class JoltCollisionObject3D;
+class JoltObjectImpl3D;
 class JoltContactListener3D;
 class JoltJointImpl3D;
 class JoltLayerMapper;
@@ -54,11 +54,11 @@ public:
 
 	JoltReadableBody3D read_body(const JPH::BodyID& p_body_id, bool p_lock = true) const;
 
-	JoltReadableBody3D read_body(const JoltCollisionObject3D& p_object, bool p_lock = true) const;
+	JoltReadableBody3D read_body(const JoltObjectImpl3D& p_object, bool p_lock = true) const;
 
 	JoltWritableBody3D write_body(const JPH::BodyID& p_body_id, bool p_lock = true) const;
 
-	JoltWritableBody3D write_body(const JoltCollisionObject3D& p_object, bool p_lock = true) const;
+	JoltWritableBody3D write_body(const JoltObjectImpl3D& p_object, bool p_lock = true) const;
 
 	JoltReadableBodies3D read_bodies(
 		const JPH::BodyID* p_body_ids,

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -2,7 +2,7 @@
 
 #include "spaces/jolt_body_accessor_3d.hpp"
 
-class JoltArea3D;
+class JoltAreaImpl3D;
 class JoltCollisionObject3D;
 class JoltContactListener3D;
 class JoltJointImpl3D;
@@ -74,9 +74,9 @@ public:
 
 	JoltPhysicsDirectSpaceState3D* get_direct_state();
 
-	void set_default_area(JoltArea3D* p_area) { default_area = p_area; }
+	void set_default_area(JoltAreaImpl3D* p_area) { default_area = p_area; }
 
-	JoltArea3D* get_default_area() const { return default_area; }
+	JoltAreaImpl3D* get_default_area() const { return default_area; }
 
 	float get_last_step() const { return last_step; }
 
@@ -119,7 +119,7 @@ private:
 
 	JoltPhysicsDirectSpaceState3D* direct_state = nullptr;
 
-	JoltArea3D* default_area = nullptr;
+	JoltAreaImpl3D* default_area = nullptr;
 
 	float last_step = 0.0f;
 


### PR DESCRIPTION
I painted myself into a bit of a corner by naming classes like `JoltHingeJoint3D` the way I did, since that's ideally the name I would want to give a new Jolt-based node type, which I will likely add for the joints in a not too distant future.

This meant there had to be new names to represent the physics server representation, which in the case of `JoltHingeJoint3D` ended up being `JoltHingeJointImpl3D`. This convention has then been applied to all objects, joints and shapes.

When applying this convention to the shapes there's a third class to take into account as well, which are the custom Jolt shapes. I decided to just call these `JoltCustom*Shape`. So if (for example) we were to add a shape "Foo" we would now instead have `JoltFooShape3D` to represent the resource, `JoltFooShapeImpl3D` to represent the physics server representation and `JoltCustomFooShape` to represent the custom Jolt shape.

I decided to shorten `JoltCollisionObject3D` to `JoltObjectImpl3D`, since the `Collision` part felt a bit redundant in the context of this extension.

There will be a second PR to rename the files, in order to not mess with Git's file rename heuristic too much.