### PR TITLE
Added explicit non-support for shape solver bias

### DIFF
--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -96,11 +96,11 @@ void JoltPhysicsServer3D::_shape_set_data(const RID& p_shape, const Variant& p_d
 	shape->set_data(p_data);
 }
 
-void JoltPhysicsServer3D::_shape_set_custom_solver_bias(
-	[[maybe_unused]] const RID& p_shape,
-	[[maybe_unused]] double p_bias
-) {
-	ERR_FAIL_NOT_IMPL();
+void JoltPhysicsServer3D::_shape_set_custom_solver_bias(const RID& p_shape, double p_bias) {
+	JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL(shape);
+
+	shape->set_solver_bias((float)p_bias);
 }
 
 PhysicsServer3D::ShapeType JoltPhysicsServer3D::_shape_get_type(const RID& p_shape) const {
@@ -131,9 +131,11 @@ double JoltPhysicsServer3D::_shape_get_margin(const RID& p_shape) const {
 	return (double)shape->get_margin();
 }
 
-double JoltPhysicsServer3D::_shape_get_custom_solver_bias([[maybe_unused]] const RID& p_shape
-) const {
-	ERR_FAIL_D_NOT_IMPL();
+double JoltPhysicsServer3D::_shape_get_custom_solver_bias(const RID& p_shape) const {
+	const JoltShapeImpl3D* shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_NULL_D(shape);
+
+	return (double)shape->get_solver_bias();
 }
 
 RID JoltPhysicsServer3D::_space_create() {

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -3,6 +3,12 @@
 #include "objects/jolt_object_impl_3d.hpp"
 #include "shapes/jolt_custom_user_data_shape.hpp"
 
+namespace {
+
+constexpr float DEFAULT_SOLVER_BIAS = 0.0;
+
+} // namespace
+
 JoltShapeImpl3D::~JoltShapeImpl3D() = default;
 
 void JoltShapeImpl3D::add_owner(JoltObjectImpl3D* p_owner) {
@@ -22,6 +28,19 @@ void JoltShapeImpl3D::remove_self(bool p_lock) {
 
 	for (const auto& [owner, ref_count] : ref_counts_by_owner_copy) {
 		owner->remove_shape(this, p_lock);
+	}
+}
+
+float JoltShapeImpl3D::get_solver_bias() const {
+	return DEFAULT_SOLVER_BIAS;
+}
+
+void JoltShapeImpl3D::set_solver_bias(float p_bias) {
+	if (!Math::is_equal_approx(p_bias, DEFAULT_SOLVER_BIAS)) {
+		WARN_PRINT(
+			"Custom solver bias for shapes is not supported by Godot Jolt. "
+			"Any such value will be ignored."
+		);
 	}
 }
 

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -30,6 +30,10 @@ public:
 
 	virtual void set_margin(float p_margin) = 0;
 
+	float get_solver_bias() const;
+
+	void set_solver_bias(float p_bias);
+
 	JPH::ShapeRefC try_build();
 
 	void destroy() { jolt_ref = nullptr; }


### PR DESCRIPTION
This replaces the previous "Not implemented" error message, when trying to set the custom solver bias for shapes, with a more descriptive warning message. It also removes the previous "Not implemented" error message when the solver bias value is just being fetched.