### PR TITLE
Updated CI packaging to allow version tags with status

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: 📦 Package
 on:
   push:
     tags:
-      - v\d+.\d+.\d+
+      - v\d+.\d+.\d+-\w+
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This allows the CI packaging to trigger on version tags that look like `v0.1.0-beta1` as opposed to just `v0.1.0`.