### PR TITLE
Updated Jolt to f340da6a18

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 3d36f7aea85fcea4b0de5404c953e40db0a749ba
+	GIT_COMMIT f340da6a18ef83f86ee46b8d7352c79d467c56d9
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@3d36f7aea85fcea4b0de5404c953e40db0a749ba to godot-jolt/jolt@f340da6a18ef83f86ee46b8d7352c79d467c56d9 (see diff [here](https://github.com/godot-jolt/jolt/compare/3d36f7aea85fcea4b0de5404c953e40db0a749ba...f340da6a18ef83f86ee46b8d7352c79d467c56d9)).

This brings in fixes for warnings emitted when compiling with MSVC 14.36.