### PR TITLE
Updated godot-cpp to 4.0.3

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 0274efdb07207c01ac15e74a50f875986c62b09b
+	GIT_COMMIT 78f709c74450d5dcfe1a3510dede8d5b67e42502
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@0274efdb07207c01ac15e74a50f875986c62b09b aka `4.0.2-stable` to godot-jolt/godot-cpp@78f709c74450d5dcfe1a3510dede8d5b67e42502 aka `4.0.3-stable` (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/0274efdb07207c01ac15e74a50f875986c62b09b...78f709c74450d5dcfe1a3510dede8d5b67e42502)).