### PR TITLE
Downgraded CI workflows to Ubuntu 20.04

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -4,7 +4,7 @@ inputs:
   toolchain:
     required: true
   version-gcc:
-    default: 12
+    default: 11
   version-llvm:
     default: 15
 

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   clang-format:
     name: Formatting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code
@@ -47,7 +47,7 @@ jobs:
 
   clang-tidy:
     name: Linting (${{ matrix.arch }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     name: "\
       ${{ matrix.platform }}-\
       ${{ matrix.arch }}-\

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -63,7 +63,7 @@ jobs:
           retention-days: 1
 
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -80,6 +80,9 @@ jobs:
         uses: ./.github/actions/setup-linux
         with:
           toolchain: llvm
+
+      - name: List dynamic dependencies
+        run: ldd --version
 
       - name: Configure
         uses: ./.github/actions/cmake-configure
@@ -177,7 +180,7 @@ jobs:
           retention-days: 1
 
   upload:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: [windows, linux, macos]
 
     name: Upload

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ candidate, may be incompatible and is therefore not supported.
 - Linux (x86-64, x86)
 - macOS (x86-64 + Apple Silicon)
 
+Note that Linux support is limited by the version of glibc present on the system, which currently
+has to be the same as (or newer than) what's used by Ubuntu 20.04 (Focal Fossa).
+
 ## How do I get started?
 
 1. Download the [latest release][rls] from GitHub

--- a/scripts/ci_setup_linux.ps1
+++ b/scripts/ci_setup_linux.ps1
@@ -54,13 +54,17 @@ Set-DefaultCommand -Name gcc -Path /usr/bin/gcc-$VersionGcc
 Set-DefaultCommand -Name g++ -Path /usr/bin/g++-$VersionGcc
 
 if ($Toolchain -eq "llvm") {
+	Write-Output "Downloading LLVM installation script..."
+
+	Invoke-WebRequest -Uri https://apt.llvm.org/llvm.sh -OutFile ./llvm.sh
+
+	Write-Output "Making LLVM installation script executable..."
+
+	chmod +x ./llvm.sh
+
 	Write-Output "Installing LLVM $VersionLlvm..."
 
-	apt install --quiet --yes `
-		clang-$VersionLlvm `
-		clang-format-$VersionLlvm `
-		clang-tidy-$VersionLlvm `
-		lld-$VersionLlvm
+	./llvm.sh $VersionLlvm all
 
 	Write-Output "Setting LLVM $VersionLlvm as the default..."
 


### PR DESCRIPTION
Related to #378.

This downgrades the CI workflows from Ubuntu 22.04 (Jammy Jellyfish) to Ubuntu 20.04 (Focal Fossa).

This is an effort to provide broader support for Linux. The default toolchains in most (all?) Linux distros will tie you to a minimum version of glibc, so we're forced to use an earlier version of Ubuntu to provide support for distros like Debian ("bullseye") stable, which is on the same version of glibc as Ubuntu 20.04.