### PR TITLE
Added/changed some project settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ does however allow you to quickly switch between physics engines with very littl
 ## What about determinism?
 
 While Jolt itself offers deterministic simulations, Godot Jolt is not able to make those kinds of
-guarantees. There is a project setting for enabling Jolt's deterministic simulation if you find
-*more* deterministic behavior useful, but it should not be relied upon if determinism is a hard
-requirement.
+guarantees. The simulations may look deterministic, and may even be deterministic, but it should not
+be relied upon if determinism is a hard requirement.
 
 ## What's not supported?
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ does however allow you to quickly switch between physics engines with very littl
 ## What about determinism?
 
 While Jolt itself offers deterministic simulations, Godot Jolt is not able to make those kinds of
-guarantees. The simulations may look deterministic, and may even be deterministic, but it should not
-be relied upon if determinism is a hard requirement.
+guarantees. Simulations in Godot Jolt may look deterministic, and may even be deterministic, but it
+should not be relied upon if determinism is a hard requirement.
 
 ## What's not supported?
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -206,6 +206,22 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>-</td>
     </tr>
     <tr>
+      <td>Continuous CD</td>
+      <td>Movement Threshold</td>
+      <td>
+        Percentage of its inner radius a body must move per step to make use of CCD.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Continuous CD</td>
+      <td>Max Penetration</td>
+      <td>
+        Percentage of its inner radius a body may penetrate another body whilst using CCD.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>Solver</td>
       <td>Velocity Iterations</td>
       <td>The number of solver velocity iterations to run during a physics tick.</td>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -198,11 +198,10 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Kinematic</td>
-      <td>Recovery Speed</td>
+      <td>Recovery Correction</td>
       <td>
-        How much of the penetration to resolve per iteration during things like
+        How much of the penetration to correct per iteration during things like
         <code>move_and_slide</code>.
-        <br><i>(0.0 = 0%, 1.0 = 100%)</i>
       </td>
       <td>-</td>
     </tr>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -246,16 +246,6 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>-</td>
     </tr>
     <tr>
-      <td>Simulation</td>
-      <td>More Deterministic</td>
-      <td>Whether to make the simulation more deterministic.</td>
-      <td>
-        ⚠️ While this makes Jolt itself deterministic when using the same binary, this extension
-        (or Godot itself) might not be. This setting should not be relied upon if determinism is a
-        requirement.
-      </td>
-    </tr>
-    <tr>
       <td>Limits</td>
       <td>Max Linear Velocity</td>
       <td>The maximum linear velocity that a body can reach.</td>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -219,10 +219,9 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Solver</td>
-      <td>Stabilization Factor</td>
+      <td>Position Correction</td>
       <td>
-        How much of the position error to resolve during a physics tick.
-        <br><i>(0.0 = 0%, 1.0 = 100%)</i>
+        How much of the position error to correct during a physics tick.
       </td>
       <td>-</td>
     </tr>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -15,8 +15,6 @@ constexpr char STABILIZATION_FACTOR[] = "physics/jolt_3d/solver/stabilization_fa
 constexpr char CONTACT_DISTANCE[] = "physics/jolt_3d/solver/contact_speculative_distance";
 constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_penetration";
 
-constexpr char MORE_DETERMINISTIC[] = "physics/jolt_3d/simulation/more_deterministic";
-
 constexpr char MAX_LINEAR_VELOCITY[] = "physics/jolt_3d/limits/max_linear_velocity";
 constexpr char MAX_ANGULAR_VELOCITY[] = "physics/jolt_3d/limits/max_angular_velocity";
 constexpr char MAX_BODIES[] = "physics/jolt_3d/limits/max_bodies";
@@ -121,8 +119,6 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 
-	register_setting_plain(MORE_DETERMINISTIC, false);
-
 	register_setting_ranged(MAX_LINEAR_VELOCITY, 500.0f, U"0,500,0.01,or_greater,suffix:m/s");
 	register_setting_ranged(MAX_ANGULAR_VELOCITY, 2700.0f, U"0,2700,0.01,or_greater,suffix:°/s");
 	register_setting_ranged(MAX_BODIES, 10240, U"1,10240,or_greater", true);
@@ -178,11 +174,6 @@ float JoltProjectSettings::get_contact_distance() {
 
 float JoltProjectSettings::get_contact_penetration() {
 	static const auto value = get_setting<float>(CONTACT_PENETRATION);
-	return value;
-}
-
-bool JoltProjectSettings::is_more_deterministic() {
-	static const auto value = get_setting<bool>(MORE_DETERMINISTIC);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -11,7 +11,7 @@ constexpr char RECOVERY_CORRECTION[] = "physics/jolt_3d/kinematics/recovery_corr
 
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
 constexpr char VELOCITY_ITERATIONS[] = "physics/jolt_3d/solver/velocity_iterations";
-constexpr char STABILIZATION_FACTOR[] = "physics/jolt_3d/solver/stabilization_factor";
+constexpr char POSITION_CORRECTION[] = "physics/jolt_3d/solver/position_correction";
 constexpr char CONTACT_DISTANCE[] = "physics/jolt_3d/solver/contact_speculative_distance";
 constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_penetration";
 
@@ -115,7 +115,7 @@ void JoltProjectSettings::register_settings() {
 
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
-	register_setting_ranged(STABILIZATION_FACTOR, 0.2f, U"0,1,0.01");
+	register_setting_ranged(POSITION_CORRECTION, 20.0f, U"0,100,0.1,suffix:%");
 	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 
@@ -162,8 +162,8 @@ int32_t JoltProjectSettings::get_position_iterations() {
 	return value;
 }
 
-float JoltProjectSettings::get_stabilization_factor() {
-	static const auto value = get_setting<float>(STABILIZATION_FACTOR);
+float JoltProjectSettings::get_position_correction() {
+	static const auto value = get_setting<float>(POSITION_CORRECTION) / 100.0f;
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -6,6 +6,9 @@ constexpr char SLEEP_ENABLED[] = "physics/jolt_3d/sleep/enabled";
 constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_threshold";
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
+constexpr char CCD_MOVEMENT_THRESHOLD[] = "physics/jolt_3d/continuous_cd/movement_threshold";
+constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetration";
+
 constexpr char RECOVERY_ITERATIONS[] = "physics/jolt_3d/kinematics/recovery_iterations";
 constexpr char RECOVERY_CORRECTION[] = "physics/jolt_3d/kinematics/recovery_correction";
 
@@ -110,6 +113,9 @@ void JoltProjectSettings::register_settings() {
 	register_setting_hinted(SLEEP_VELOCITY_THRESHOLD, 0.03f, U"suffix:m/s");
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
+	register_setting_ranged(CCD_MOVEMENT_THRESHOLD, 75.0f, U"0,100,0.1,suffix:%");
+	register_setting_ranged(CCD_MAX_PENETRATION, 25.0f, U"0,100,0.1,suffix:%");
+
 	register_setting_ranged(RECOVERY_ITERATIONS, 4, U"1,8,or_greater");
 	register_setting_ranged(RECOVERY_CORRECTION, 40.0f, U"0,100,0.1,suffix:%");
 
@@ -139,6 +145,16 @@ float JoltProjectSettings::get_sleep_velocity_threshold() {
 
 float JoltProjectSettings::get_sleep_time_threshold() {
 	static const auto value = get_setting<float>(SLEEP_TIME_THRESHOLD);
+	return value;
+}
+
+float JoltProjectSettings::get_ccd_movement_threshold() {
+	static const auto value = get_setting<float>(CCD_MOVEMENT_THRESHOLD) / 100.0f;
+	return value;
+}
+
+float JoltProjectSettings::get_ccd_max_penetration() {
+	static const auto value = get_setting<float>(CCD_MAX_PENETRATION) / 100.0f;
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -118,13 +118,13 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
 	register_setting_ranged(STABILIZATION_FACTOR, 0.2f, U"0,1,0.01");
-	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.01,or_greater,suffix:m");
-	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.01,or_greater,suffix:m");
+	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.001,or_greater,suffix:m");
+	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 
 	register_setting_plain(MORE_DETERMINISTIC, false);
 
-	register_setting_ranged(MAX_LINEAR_VELOCITY, 500.0f, U"0,500,or_greater,suffix:m/s");
-	register_setting_ranged(MAX_ANGULAR_VELOCITY, 2700.0f, U"0,2700,or_greater,suffix:°/s");
+	register_setting_ranged(MAX_LINEAR_VELOCITY, 500.0f, U"0,500,0.01,or_greater,suffix:m/s");
+	register_setting_ranged(MAX_ANGULAR_VELOCITY, 2700.0f, U"0,2700,0.01,or_greater,suffix:°/s");
 	register_setting_ranged(MAX_BODIES, 10240, U"1,10240,or_greater", true);
 	register_setting_ranged(MAX_PAIRS, 65536, U"8,65536,or_greater");
 	register_setting_ranged(MAX_CONTACTS, 20480, U"8,20480,or_greater");

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -7,7 +7,7 @@ constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_thre
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
 constexpr char RECOVERY_ITERATIONS[] = "physics/jolt_3d/kinematics/recovery_iterations";
-constexpr char RECOVERY_SPEED[] = "physics/jolt_3d/kinematics/recovery_speed";
+constexpr char RECOVERY_CORRECTION[] = "physics/jolt_3d/kinematics/recovery_correction";
 
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
 constexpr char VELOCITY_ITERATIONS[] = "physics/jolt_3d/solver/velocity_iterations";
@@ -111,7 +111,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
 	register_setting_ranged(RECOVERY_ITERATIONS, 4, U"1,8,or_greater");
-	register_setting_ranged(RECOVERY_SPEED, 0.4f, U"0,1,0.01");
+	register_setting_ranged(RECOVERY_CORRECTION, 40.0f, U"0,100,0.1,suffix:%");
 
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
@@ -147,8 +147,8 @@ int32_t JoltProjectSettings::get_kinematic_recovery_iterations() {
 	return value;
 }
 
-float JoltProjectSettings::get_kinematic_recovery_speed() {
-	static const auto value = get_setting<float>(RECOVERY_SPEED);
+float JoltProjectSettings::get_kinematic_recovery_correction() {
+	static const auto value = get_setting<float>(RECOVERY_CORRECTION) / 100.0f;
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -10,6 +10,10 @@ public:
 
 	static float get_sleep_time_threshold();
 
+	static float get_ccd_movement_threshold();
+
+	static float get_ccd_max_penetration();
+
 	static int32_t get_kinematic_recovery_iterations();
 
 	static float get_kinematic_recovery_correction();

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -18,7 +18,7 @@ public:
 
 	static int32_t get_position_iterations();
 
-	static float get_stabilization_factor();
+	static float get_position_correction();
 
 	static float get_contact_distance();
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -12,7 +12,7 @@ public:
 
 	static int32_t get_kinematic_recovery_iterations();
 
-	static float get_kinematic_recovery_speed();
+	static float get_kinematic_recovery_correction();
 
 	static int32_t get_velocity_iterations();
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -24,8 +24,6 @@ public:
 
 	static float get_contact_penetration();
 
-	static bool is_more_deterministic();
-
 	static float get_max_linear_velocity();
 
 	static float get_max_angular_velocity();

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -696,7 +696,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 	Vector3& p_recovery
 ) const {
 	const int32_t recovery_iterations = JoltProjectSettings::get_kinematic_recovery_iterations();
-	const float recovery_speed = JoltProjectSettings::get_kinematic_recovery_speed();
+	const float recovery_correction = JoltProjectSettings::get_kinematic_recovery_correction();
 
 	const JPH::Shape* jolt_shape = p_body.get_jolt_shape();
 
@@ -778,7 +778,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 			const JoltBodyImpl3D* other_body = other_jolt_body.as_body();
 			ERR_CONTINUE(other_body == nullptr);
 
-			const float recovery_distance = penetration_depth * recovery_speed;
+			const float recovery_distance = penetration_depth * recovery_correction;
 			const float other_priority = other_body->get_collision_priority();
 			const float other_priority_normalized = other_priority / average_priority;
 			const float scaled_recovery_distance = recovery_distance * other_priority_normalized;

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -46,7 +46,6 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	settings.mNumPositionSteps = JoltProjectSettings::get_position_iterations();
 	settings.mTimeBeforeSleep = JoltProjectSettings::get_sleep_time_threshold();
 	settings.mPointVelocitySleepThreshold = JoltProjectSettings::get_sleep_velocity_threshold();
-	settings.mDeterministicSimulation = JoltProjectSettings::is_more_deterministic();
 	settings.mAllowSleeping = JoltProjectSettings::is_sleep_enabled();
 
 	physics_system->SetPhysicsSettings(settings);

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -42,6 +42,8 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	settings.mBaumgarte = JoltProjectSettings::get_position_correction();
 	settings.mSpeculativeContactDistance = JoltProjectSettings::get_contact_distance();
 	settings.mPenetrationSlop = JoltProjectSettings::get_contact_penetration();
+	settings.mLinearCastThreshold = JoltProjectSettings::get_ccd_movement_threshold();
+	settings.mLinearCastMaxPenetration = JoltProjectSettings::get_ccd_max_penetration();
 	settings.mNumVelocitySteps = JoltProjectSettings::get_velocity_iterations();
 	settings.mNumPositionSteps = JoltProjectSettings::get_position_iterations();
 	settings.mTimeBeforeSleep = JoltProjectSettings::get_sleep_time_threshold();

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -39,7 +39,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	);
 
 	JPH::PhysicsSettings settings;
-	settings.mBaumgarte = JoltProjectSettings::get_stabilization_factor();
+	settings.mBaumgarte = JoltProjectSettings::get_position_correction();
 	settings.mSpeculativeContactDistance = JoltProjectSettings::get_contact_distance();
 	settings.mPenetrationSlop = JoltProjectSettings::get_contact_penetration();
 	settings.mNumVelocitySteps = JoltProjectSettings::get_velocity_iterations();


### PR DESCRIPTION
Fixes #372.

This PR removes the following project settings:

- "Simulation / More Deterministic"
    - Having it set to `false` affected simulation stability. It's now instead hardcoded to `true`.

This PR changes the following project settings:

- "Kinematics / Recovery Speed" is now called "Recovery Correction"
    - It's now also input as a percentage, as opposed to a factor
- "Solver / Stabilization Factor" is now called "Position Correction"
    - It's now also input as a percentage, as opposed to a factor
- "Solver / Contact Speculative Distance" now has a step size of 0.001 instead of 0.01
- "Solver / Contact Allowed Penetration" now has a step size of 0.001 instead of 0.01
- "Limits / Max Linear Velocity" now has an explicit step size of 0.01
- "Limits / Max Angular Velocity" now has an explicit step size of 0.01

This PR adds the following new project settings:

- "Continuous CD / Movement Threshold"
- "Continuous CD / Max Penetration"