### PR TITLE
Fixed issue with contact velocities lagging behind one tick

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -351,7 +351,6 @@ void JoltBodyImpl3D::add_contact(
 	const Vector3& p_normal,
 	const Vector3& p_position,
 	const Vector3& p_collider_position,
-	const Vector3& p_collider_velocity,
 	const Vector3& p_impulse
 ) {
 	const int32_t max_contacts = get_max_contacts_reported();
@@ -386,7 +385,6 @@ void JoltBodyImpl3D::add_contact(
 		contact->normal = p_normal;
 		contact->position = p_position;
 		contact->collider_position = p_collider_position;
-		contact->collider_velocity = p_collider_velocity;
 		contact->impulse = p_impulse;
 	}
 }

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -26,8 +26,6 @@ public:
 
 		Vector3 collider_position;
 
-		Vector3 collider_velocity;
-
 		Vector3 impulse;
 	};
 
@@ -102,7 +100,6 @@ public:
 		const Vector3& p_normal,
 		const Vector3& p_position,
 		const Vector3& p_collider_position,
-		const Vector3& p_collider_velocity,
 		const Vector3& p_impulse
 	);
 

--- a/src/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.cpp
@@ -1,6 +1,7 @@
 #include "jolt_physics_direct_body_state_3d.hpp"
 
 #include "objects/jolt_body_impl_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
 #include "spaces/jolt_physics_direct_space_state_3d.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
@@ -234,7 +235,17 @@ Vector3 JoltPhysicsDirectBodyState3D::_get_contact_collider_velocity_at_position
 ) const {
 	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
-	return body->get_contact(p_contact_idx).collider_velocity;
+
+	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
+
+	const JoltBodyImpl3D::Contact& contact = body->get_contact(p_contact_idx);
+	const JoltBodyImpl3D* collider = physics_server->get_body(contact.collider_rid);
+	ERR_FAIL_NULL_D(collider);
+
+	const Vector3 collider_position = collider->get_position();
+	const Vector3& collider_offset = contact.collider_position;
+
+	return collider->get_velocity_at_position(collider_position + collider_offset);
 }
 
 double JoltPhysicsDirectBodyState3D::_get_step() const {

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -150,13 +150,11 @@ void JoltContactListener3D::update_contacts(
 		contact1.normal = -p_manifold.mWorldSpaceNormal;
 		contact1.point_self = world_point1 - body_position1;
 		contact1.point_other = world_point1 - body_position2;
-		contact1.velocity_other = p_body2.GetPointVelocity(world_point1);
 		contact1.impulse = -combined_impulse;
 
 		contact2.normal = p_manifold.mWorldSpaceNormal;
 		contact2.point_self = world_point2 - body_position2;
 		contact2.point_other = world_point2 - body_position1;
-		contact2.velocity_other = p_body1.GetPointVelocity(world_point2);
 		contact2.impulse = combined_impulse;
 	}
 }
@@ -189,7 +187,6 @@ void JoltContactListener3D::flush_contacts() {
 				to_godot(contact.normal),
 				to_godot(contact.point_self),
 				to_godot(contact.point_other),
-				to_godot(contact.velocity_other),
 				to_godot(contact.impulse)
 			);
 		}
@@ -203,7 +200,6 @@ void JoltContactListener3D::flush_contacts() {
 				to_godot(contact.normal),
 				to_godot(contact.point_self),
 				to_godot(contact.point_other),
-				to_godot(contact.velocity_other),
 				to_godot(contact.impulse)
 			);
 		}

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -31,8 +31,6 @@ class JoltContactListener3D final : public JPH::ContactListener {
 
 		JPH::Vec3 point_other = {};
 
-		JPH::Vec3 velocity_other = {};
-
 		JPH::Vec3 impulse = {};
 	};
 


### PR DESCRIPTION
Fixes #388.

The contact velocities have until now been populated using `JPH::Body::GetPointVelocity` within the contact listener. This turned out to cause the velocity to lag behind one tick, which I'm guessing is because the constraint solving hasn't happened yet at that point, which in turn presumably affects the velocity.

So instead I decided to simply not have the velocities be part of the contacts and instead just get them from the collider as the user requests them.