### PR TITLE
Added support for custom integrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Changed the direction of `Generic6DOFJoint` angular motors to match Godot Physics
 
+### Added
+
+- Added support for custom integrators
+
 ## [0.1.0] - 2023-05-24
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ should not be relied upon if determinism is a hard requirement.
 - `SoftBody3D` is not supported
 - `WorldBoundaryShape3D` is not supported
 - `StaticBody3D` does not support "constant velocities"
-- Custom integrators are not supported
 - The physics server is not thread-safe (yet)
 - Memory usage is not reflected in Godot's performance monitors (yet)
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -54,6 +54,10 @@ public:
 		force_integration_userdata = p_userdata;
 	}
 
+	bool has_custom_integrator() const { return custom_integrator; }
+
+	void set_custom_integrator(bool p_enabled, bool p_lock = true);
+
 	bool is_sleeping(bool p_lock = true) const;
 
 	void set_is_sleeping(bool p_enabled, bool p_lock = true);
@@ -202,9 +206,9 @@ public:
 
 	void set_angular_damp(float p_damp, bool p_lock = true);
 
-	float get_total_linear_damp(bool p_lock = true) const;
+	float get_total_linear_damp() const { return total_linear_damp; }
 
-	float get_total_angular_damp(bool p_lock = true) const;
+	float get_total_angular_damp() const { return total_angular_damp; }
 
 	float get_collision_priority() const { return collision_priority; }
 
@@ -293,6 +297,10 @@ private:
 
 	float angular_damp = 0.0f;
 
+	float total_linear_damp = 0.0f;
+
+	float total_angular_damp = 0.0f;
+
 	float collision_priority = 1.0f;
 
 	int32_t contact_count = 0;
@@ -300,4 +308,6 @@ private:
 	uint32_t locked_axes = 0;
 
 	bool custom_center_of_mass = false;
+
+	bool custom_integrator = false;
 };

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -924,11 +924,11 @@ double JoltPhysicsServer3D::_body_get_contacts_reported_depth_threshold(
 	return 0.0;
 }
 
-void JoltPhysicsServer3D::_body_set_omit_force_integration(
-	[[maybe_unused]] const RID& p_body,
-	bool p_enable
-) {
-	ERR_FAIL_COND_MSG(p_enable, "Custom integrators are not supported by Godot Jolt.");
+void JoltPhysicsServer3D::_body_set_omit_force_integration(const RID& p_body, bool p_enable) {
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_custom_integrator(p_enable);
 }
 
 bool JoltPhysicsServer3D::_body_is_omitting_force_integration([[maybe_unused]] const RID& p_body


### PR DESCRIPTION
Fixes #332.

This adds support for the [`custom_integrator`](https://docs.godotengine.org/en/4.0/classes/class_rigidbody3d.html#class-rigidbody3d-property-custom-integrator) property on `RigidBody3D` as well as `PhysicalBone3D`, allowing you to omit the integration of gravity and damping, and instead integrate them yourself.