### PR TITLE
Added project setting "Bounce Velocity Threshold"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added support for custom integrators
+- Added new project setting "Bounce Velocity Threshold"
 
 ## [0.1.0] - 2023-05-24
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -243,6 +243,14 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Solver</td>
+      <td>Bounce Velocity Threshold</td>
+      <td>
+        The minimum velocity needed before a collision can be elastic.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Solver</td>
       <td>Contact Speculative Distance</td>
       <td>
         Radius around objects, inside which speculative contact points will be detected.

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -15,6 +15,7 @@ constexpr char RECOVERY_AMOUNT[] = "physics/jolt_3d/kinematics/recovery_amount";
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
 constexpr char VELOCITY_ITERATIONS[] = "physics/jolt_3d/solver/velocity_iterations";
 constexpr char POSITION_CORRECTION[] = "physics/jolt_3d/solver/position_correction";
+constexpr char BOUNCE_VELOCITY_THRESHOLD[] = "physics/jolt_3d/solver/bounce_velocity_threshold";
 constexpr char CONTACT_DISTANCE[] = "physics/jolt_3d/solver/contact_speculative_distance";
 constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_penetration";
 
@@ -122,6 +123,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
 	register_setting_ranged(POSITION_CORRECTION, 20.0f, U"0,100,0.1,suffix:%");
+	register_setting_hinted(BOUNCE_VELOCITY_THRESHOLD, 1.0f, U"suffix:m/s");
 	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 
@@ -180,6 +182,11 @@ int32_t JoltProjectSettings::get_position_iterations() {
 
 float JoltProjectSettings::get_position_correction() {
 	static const auto value = get_setting<float>(POSITION_CORRECTION) / 100.0f;
+	return value;
+}
+
+float JoltProjectSettings::get_bounce_velocity_threshold() {
+	static const auto value = get_setting<float>(BOUNCE_VELOCITY_THRESHOLD);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -24,6 +24,8 @@ public:
 
 	static float get_position_correction();
 
+	static float get_bounce_velocity_threshold();
+
 	static float get_contact_distance();
 
 	static float get_contact_penetration();

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -2,6 +2,7 @@
 
 #include "objects/jolt_area_impl_3d.hpp"
 #include "objects/jolt_body_impl_3d.hpp"
+#include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
 namespace {
@@ -126,7 +127,7 @@ void JoltContactListener3D::update_contacts(
 		collision,
 		p_settings.mCombinedFriction,
 		p_settings.mCombinedRestitution,
-		1.0f,
+		JoltProjectSettings::get_bounce_velocity_threshold(),
 		5
 	);
 

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -46,6 +46,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	settings.mLinearCastMaxPenetration = JoltProjectSettings::get_ccd_max_penetration();
 	settings.mNumVelocitySteps = JoltProjectSettings::get_velocity_iterations();
 	settings.mNumPositionSteps = JoltProjectSettings::get_position_iterations();
+	settings.mMinVelocityForRestitution = JoltProjectSettings::get_bounce_velocity_threshold();
 	settings.mTimeBeforeSleep = JoltProjectSettings::get_sleep_time_threshold();
 	settings.mPointVelocitySleepThreshold = JoltProjectSettings::get_sleep_velocity_threshold();
 	settings.mAllowSleeping = JoltProjectSettings::is_sleep_enabled();


### PR DESCRIPTION
Relates to #374.

This adds a new project setting called "Bounce Velocity Threshold" that controls the minimum velocity needed before a collision can be elastic.