### PR TITLE
Added custom combiners for friction and restitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added support for custom integrators
 - Added new project setting "Bounce Velocity Threshold"
+- Added support for "Rough" physics material property
+- Added support for "Absorbent" physics material property
+
+### Fixed
+
+- Fixed issue where friction values weren't combined in the same way as Godot Physics
+- Fixed issue where bounce values weren't combined in the same way as Godot Physics
+- Fixed issue where setting friction on an already entered body would instead set bounce
 
 ## [0.1.0] - 2023-05-24
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -843,15 +843,6 @@ float JoltBodyImpl3D::get_bounce(bool p_lock) const {
 }
 
 void JoltBodyImpl3D::set_bounce(float p_bounce, bool p_lock) {
-	if (p_bounce < 0.0f || p_bounce > 1.0f) {
-		WARN_PRINT(
-			"Bounce values less than 0 or greater than 1 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped."
-		);
-
-		p_bounce = clamp(p_bounce, 0.0f, 1.0f);
-	}
-
 	if (space == nullptr) {
 		jolt_settings->mRestitution = p_bounce;
 		return;
@@ -875,15 +866,6 @@ float JoltBodyImpl3D::get_friction(bool p_lock) const {
 }
 
 void JoltBodyImpl3D::set_friction(float p_friction, bool p_lock) {
-	if (p_friction < 0.0f) {
-		WARN_PRINT(
-			"Friction values less than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped."
-		);
-
-		p_friction = 0;
-	}
-
 	if (space == nullptr) {
 		jolt_settings->mFriction = p_friction;
 		return;
@@ -892,7 +874,7 @@ void JoltBodyImpl3D::set_friction(float p_friction, bool p_lock) {
 	const JoltWritableBody3D body = space->write_body(jolt_id, p_lock);
 	ERR_FAIL_COND(body.is_invalid());
 
-	body->SetRestitution(p_friction);
+	body->SetFriction(p_friction);
 }
 
 float JoltBodyImpl3D::get_gravity_scale(bool p_lock) const {

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -54,6 +54,24 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	physics_system->SetPhysicsSettings(settings);
 	physics_system->SetGravity(JPH::Vec3::sZero());
 	physics_system->SetContactListener(contact_listener);
+
+	physics_system->SetCombineFriction(
+		[](const JPH::Body& p_body1,
+		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id1,
+		   const JPH::Body& p_body2,
+		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2) {
+			return abs(min(p_body1.GetFriction(), p_body2.GetFriction()));
+		}
+	);
+
+	physics_system->SetCombineRestitution(
+		[](const JPH::Body& p_body1,
+		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id1,
+		   const JPH::Body& p_body2,
+		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2) {
+			return clamp(p_body1.GetRestitution() + p_body2.GetRestitution(), 0.0f, 1.0f);
+		}
+	);
 }
 
 JoltSpace3D::~JoltSpace3D() {


### PR DESCRIPTION
Fixes #396.

This makes use of Jolt's custom friction/restitution combiners in order to better align with how Godot Physics behaves. This also has the side effect of enabling support for the "Rough" and "Absorbent" physics material properties.

I also found a bug where friction set on an already created/active/entered body would instead set restitution, so I included that fix here.