### PR TITLE
Changed shape margins to be interpreted as an upper bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Changed the direction of `Generic6DOFJoint` angular motors to match Godot Physics
+- Changed shape margins to be interpreted as an upper bound. They are now scaled according to the
+  shape's size, which removes the ability to have an incorrect margin, thereby removing any warnings
+  about that.
 
 ### Added
 

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -1,5 +1,11 @@
 #include "jolt_box_shape_impl_3d.hpp"
 
+namespace {
+
+constexpr float MARGIN_FACTOR = 0.08f;
+
+} // namespace
+
 Variant JoltBoxShapeImpl3D::get_data() const {
 	return half_extents;
 }
@@ -31,18 +37,10 @@ String JoltBoxShapeImpl3D::to_string() const {
 }
 
 JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
-	const float shortest_axis = half_extents[half_extents.min_axis_index()];
+	const float min_half_extent = half_extents[half_extents.min_axis_index()];
+	const float shrunk_margin = min(margin, min_half_extent * MARGIN_FACTOR);
 
-	ERR_FAIL_COND_D_MSG(
-		shortest_axis <= margin,
-		vformat(
-			"Failed to build box shape with %s. "
-			"Its half extents must be greater than its margin.",
-			to_string()
-		)
-	);
-
-	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), margin);
+	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), shrunk_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -1,5 +1,11 @@
 #include "jolt_cylinder_shape_impl_3d.hpp"
 
+namespace {
+
+constexpr float MARGIN_FACTOR = 0.08f;
+
+} // namespace
+
 Variant JoltCylinderShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["height"] = height;
@@ -43,27 +49,10 @@ String JoltCylinderShapeImpl3D::to_string() const {
 }
 
 JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
-	ERR_FAIL_COND_D_MSG(
-		height < margin * 2.0f,
-		vformat(
-			"Failed to build cylinder shape with %s. "
-			"Its height must be at least double that of its margin.",
-			to_string()
-		)
-	);
-
-	ERR_FAIL_COND_D_MSG(
-		radius < margin,
-		vformat(
-			"Failed to build cylinder shape with %s. "
-			"Its radius must be equal to or greater than its margin.",
-			to_string()
-		)
-	);
-
 	const float half_height = height / 2.0f;
+	const float shrunk_margin = min(margin, half_height * MARGIN_FACTOR, radius * MARGIN_FACTOR);
 
-	const JPH::CylinderShapeSettings shape_settings(half_height, radius, margin);
+	const JPH::CylinderShapeSettings shape_settings(half_height, radius, shrunk_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(


### PR DESCRIPTION
As discussed in #379.

This removes the warnings, for boxes and cylinders, that are emitted when the margin is greater than its minimum half extent.

The margin is now instead interpreted as an upper bound, and computed based on an arbitrary factor of the shape's minimum half extent.