### PR TITLE
Added support for surface velocities on static/kinematic bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added new project setting "Bounce Velocity Threshold"
 - Added support for "Rough" physics material property
 - Added support for "Absorbent" physics material property
+- Added support for surface velocities, also known as "constant velocities", for both static and
+  kinematic bodies
 
 ### Fixed
 
 - Fixed issue where friction values weren't combined in the same way as Godot Physics
 - Fixed issue where bounce values weren't combined in the same way as Godot Physics
 - Fixed issue where setting friction on an already entered body would instead set bounce
+- Fixed issue where setting velocities on kinematic bodies would actually move them instead of
+  applying a surface velocity
 
 ## [0.1.0] - 2023-05-24
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ should not be relied upon if determinism is a hard requirement.
 - Joints do not support springs or soft limits (yet)
 - `SoftBody3D` is not supported
 - `WorldBoundaryShape3D` is not supported
-- `StaticBody3D` does not support "constant velocities"
 - The physics server is not thread-safe (yet)
 - Memory usage is not reflected in Godot's performance monitors (yet)
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -307,6 +307,12 @@ Basis JoltBodyImpl3D::get_inverse_inertia_tensor(bool p_lock) const {
 }
 
 void JoltBodyImpl3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock) {
+	if (is_static() || is_kinematic()) {
+		linear_surface_velocity = p_velocity;
+		motion_changed(p_lock);
+		return;
+	}
+
 	if (space == nullptr) {
 		jolt_settings->mLinearVelocity = to_jolt(p_velocity);
 		motion_changed(p_lock);
@@ -322,6 +328,12 @@ void JoltBodyImpl3D::set_linear_velocity(const Vector3& p_velocity, bool p_lock)
 }
 
 void JoltBodyImpl3D::set_angular_velocity(const Vector3& p_velocity, bool p_lock) {
+	if (is_static() || is_kinematic()) {
+		angular_surface_velocity = p_velocity;
+		motion_changed(p_lock);
+		return;
+	}
+
 	if (space == nullptr) {
 		jolt_settings->mAngularVelocity = to_jolt(p_velocity);
 		motion_changed(p_lock);
@@ -788,6 +800,9 @@ void JoltBodyImpl3D::set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock) {
 		body->SetLinearVelocity(JPH::Vec3::sZero());
 		body->SetAngularVelocity(JPH::Vec3::sZero());
 	}
+
+	linear_surface_velocity = Vector3();
+	angular_surface_velocity = Vector3();
 
 	mode_changed(false);
 }

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -138,6 +138,10 @@ public:
 
 	void set_constant_torque(const Vector3& p_torque, bool p_lock = true);
 
+	Vector3 get_linear_surface_velocity() const { return linear_surface_velocity; }
+
+	Vector3 get_angular_surface_velocity() const { return angular_surface_velocity; }
+
 	void add_collision_exception(const RID& p_excepted_body, bool p_lock = true);
 
 	void remove_collision_exception(const RID& p_excepted_body, bool p_lock = true);
@@ -274,6 +278,10 @@ private:
 	Vector3 constant_force;
 
 	Vector3 constant_torque;
+
+	Vector3 linear_surface_velocity;
+
+	Vector3 angular_surface_velocity;
 
 	Vector3 gravity;
 

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -106,6 +106,13 @@ private:
 
 	void flush_area_exits();
 
+	void apply_surface_velocities(
+		const JPH::Body& p_body1,
+		const JPH::Body& p_body2,
+		const JPH::ContactManifold& p_manifold,
+		JPH::ContactSettings& p_settings
+	);
+
 #ifdef GDJ_CONFIG_EDITOR
 	void add_debug_contacts(const JPH::ContactManifold& p_manifold);
 #endif // GDJ_CONFIG_EDITOR


### PR DESCRIPTION
Fixes #331.

This adds support for the [`constant_linear_velocity`](https://docs.godotengine.org/en/4.0/classes/class_staticbody3d.html#class-staticbody3d-property-constant-linear-velocity) and [`constant_angular_velocity`](https://docs.godotengine.org/en/4.0/classes/class_staticbody3d.html#class-staticbody3d-property-constant-angular-velocity) properties on `StaticBody3D`, as well as changing the `linear_velocity` and `angular_velocity` properties on frozen bodies to instead be interpreted as surface/constant velocities.