### PR TITLE
Fixed de-sync between node and body when freezing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue where setting friction on an already entered body would instead set bounce
 - Fixed issue where setting velocities on kinematic bodies would actually move them instead of
   applying a surface velocity
+- Fixed issue where `RigidBody3D` would de-sync from its actual physics body after freezing
 
 ## [0.1.0] - 2023-05-24
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -722,10 +722,12 @@ void JoltBodyImpl3D::integrate_forces(float p_step, bool p_lock) {
 		jolt_body->AddForce(to_jolt(constant_force));
 		jolt_body->AddTorque(to_jolt(constant_torque));
 	}
+
+	sync_state = true;
 }
 
 void JoltBodyImpl3D::call_queries() {
-	if (force_integration_callback.is_valid()) {
+	if (is_rigid() && force_integration_callback.is_valid()) {
 		static thread_local Array arguments = []() {
 			Array array;
 			array.resize(2);
@@ -738,7 +740,7 @@ void JoltBodyImpl3D::call_queries() {
 		force_integration_callback.callv(arguments);
 	}
 
-	if (body_state_callback.is_valid()) {
+	if (sync_state && body_state_callback.is_valid()) {
 		static thread_local Array arguments = []() {
 			Array array;
 			array.resize(1);
@@ -748,6 +750,8 @@ void JoltBodyImpl3D::call_queries() {
 		arguments[0] = get_direct_state();
 
 		body_state_callback.callv(arguments);
+
+		sync_state = false;
 	}
 }
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -315,6 +315,8 @@ private:
 
 	uint32_t locked_axes = 0;
 
+	bool sync_state = false;
+
 	bool custom_center_of_mass = false;
 
 	bool custom_integrator = false;

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -135,13 +135,13 @@ void JoltSpace3D::call_queries() {
 		return;
 	}
 
-	body_accessor.acquire_active();
+	body_accessor.acquire_all();
 
 	const int32_t body_count = body_accessor.get_count();
 
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (const JPH::Body* body = body_accessor.try_get(i)) {
-			if (!body->IsSensor() && !body->IsStatic()) {
+			if (!body->IsSensor()) {
 				reinterpret_cast<JoltBodyImpl3D*>(body->GetUserData())->call_queries();
 			}
 		}


### PR DESCRIPTION
This is something I happened to stumble upon.

Right after freezing a moving `RigidBody3D`, using the "Static" freeze mode, you would end up with the actual underlying physics body having moved further ahead than the node itself.

This turned out to be because static bodies instantly go to sleep, which means they would get skipped over by `acquire_active` in `call_queries`, and therefore not have their `body_state_callback` invoked.

Now instead we mark bodies with a dirty flag if they've had `integrate_forces` called (i.e. they've been rigid/dynamic) in the past tick and we instead do `acquire_all` in `call_queries`, but only invoke `body_state_callback` if the dirty flag is set.