### PR TITLE
Added more context to error/warning messages

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -122,26 +122,32 @@ void JoltConeTwistJointImpl3D::set_param(
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Cone twist joint bias is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Cone twist joint softness is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. ",
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_RELAXATION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_RELAXATION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Cone twist joint relaxation is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		default: {

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -154,26 +154,32 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint linear limit softness is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint linear restitution is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint linear damping is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_TARGET_VELOCITY: {
@@ -192,26 +198,32 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 		} break;
 		case 7: /* G6DOF_JOINT_LINEAR_SPRING_STIFFNESS */ {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_SPRING_STIFFNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case 8: /* G6DOF_JOINT_LINEAR_SPRING_DAMPING */ {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_SPRING_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case 9: /* G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT */ {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_SPRING_EQUILIBRIUM_POINT)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT: {
@@ -224,42 +236,52 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint angular limit softness is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint angular damping is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint angular restitution is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_FORCE_LIMIT: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_FORCE_LIMIT)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF angular force limit is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_ERP: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ERP)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF angular ERP is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_TARGET_VELOCITY: {
@@ -281,26 +303,32 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 		} break;
 		case 19: /* G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS */ {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_SPRING_STIFFNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case 20: /* G6DOF_JOINT_ANGULAR_SPRING_DAMPING */ {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_SPRING_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case 21: /* G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT */ {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_SPRING_EQUILIBRIUM_POINT)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		default: {
@@ -364,18 +392,22 @@ void JoltGeneric6DOFJointImpl3D::set_flag(
 		} break;
 		case 2: /* G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING */ {
 			if (p_enabled) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case 3: /* G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING */ {
 			if (p_enabled) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Generic 6DOF joint springs are not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_MOTOR: {

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -127,10 +127,12 @@ void JoltHingeJointImpl3D::set_param(PhysicsServer3D::HingeJointParam p_param, d
 	switch (p_param) {
 		case PhysicsServer3D::HINGE_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Hinge joint bias is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER: {
@@ -143,26 +145,32 @@ void JoltHingeJointImpl3D::set_param(PhysicsServer3D::HingeJointParam p_param, d
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LIMIT_BIAS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Hinge joint bias limit is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Hinge joint softness is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_RELAXATION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_RELAXATION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Hinge joint relaxation is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_MOTOR_TARGET_VELOCITY: {
@@ -235,17 +243,21 @@ void JoltHingeJointImpl3D::limits_changed() {
 		constexpr double basically_neg_pi = -Math_PI - CMP_EPSILON;
 
 		if (limit_lower < basically_neg_pi || limit_lower > basically_pos_zero) {
-			WARN_PRINT(
+			WARN_PRINT(vformat(
 				"Hinge joint lower limits less than -180º or greater than 0º are not supported by "
-				"Godot Jolt. Values outside this range will be clamped."
-			);
+				"Godot Jolt. Values outside this range will be clamped. "
+				"This joint connects %s.",
+				owners_to_string()
+			));
 		}
 
 		if (limit_upper < basically_neg_zero || limit_upper > basically_pos_pi) {
-			WARN_PRINT(
+			WARN_PRINT(vformat(
 				"Hinge joint upper limits less than 0º or greater than 180º are not supported by "
-				"Godot Jolt. Values outside this range will be clamped."
-			);
+				"Godot Jolt. Values outside this range will be clamped. "
+				"This joint connects %s.",
+				owners_to_string()
+			));
 		}
 
 		const float limit_lower_clamped = clamp((float)limit_lower, -JPH::JPH_PI, 0.0f);

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -54,3 +54,11 @@ void JoltJointImpl3D::set_collision_disabled(bool p_disabled) {
 		physics_server->body_remove_collision_exception(body_b->get_rid(), body_a->get_rid());
 	}
 }
+
+String JoltJointImpl3D::owners_to_string() const {
+	return vformat(
+		"'%s' and '%s'",
+		body_a != nullptr ? body_a->to_string() : "<unknown>",
+		body_b != nullptr ? body_b->to_string() : "<World>"
+	);
+}

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -34,6 +34,8 @@ public:
 	void set_collision_disabled(bool p_disabled);
 
 protected:
+	String owners_to_string() const;
+
 	RID rid;
 
 	JoltSpace3D* space = nullptr;

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -143,26 +143,32 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 	switch (p_param) {
 		case PhysicsServer3D::PIN_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Pin joint bias is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::PIN_JOINT_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Pin joint damping is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::PIN_JOINT_IMPULSE_CLAMP: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_IMPULSE_CLAMP)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Pin joint impulse clamp is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		default: {

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -194,164 +194,204 @@ void JoltSliderJointImpl3D::set_param(PhysicsServer3D::SliderJointParam p_param,
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear limit softness is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear limit restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear limit damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_MOTION_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_MOTION_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear motion softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_MOTION_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_MOTION_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear motion restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_MOTION_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_MOTION_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear motion damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_ORTHOGONAL_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_ORTHO_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear ortho softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_ORTHOGONAL_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_ORTHO_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear ortho restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_ORTHOGONAL_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_ORTHO_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint linear ortho damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_UPPER: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_UPPER)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular limits are not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-					"Try using Generic6DOFJoint3D instead."
-				);
+					"Try using Generic6DOFJoint3D instead. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_LOWER: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_LOWER)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular limits are not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-					"Try using Generic6DOFJoint3D instead."
-				);
+					"Try using Generic6DOFJoint3D instead. "
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular limit softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular limit restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular limit damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_MOTION_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_MOTION_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular motion softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_MOTION_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_MOTION_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular motion restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_MOTION_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_MOTION_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular motion damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_ORTHOGONAL_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ORTHO_SOFTNESS)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular ortho softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_ORTHOGONAL_RESTITUTION: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ORTHO_RESTITUTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular ortho restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_ANGULAR_ORTHOGONAL_DAMPING: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_ORTHO_DAMPING)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
 					"Slider joint angular ortho damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
-				);
+					"This joint connects %s.",
+					owners_to_string()
+				));
 			}
 		} break;
 		default: {
@@ -368,17 +408,21 @@ void JoltSliderJointImpl3D::limits_changed() {
 	constexpr double basically_neg_zero = -CMP_EPSILON;
 
 	if (limit_lower > basically_pos_zero) {
-		WARN_PRINT(
+		WARN_PRINT(vformat(
 			"Slider joint lower distances greater than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped."
-		);
+			"Values outside this range will be clamped. "
+			"This joint connects %s.",
+			owners_to_string()
+		));
 	}
 
 	if (limit_upper < basically_neg_zero) {
-		WARN_PRINT(
+		WARN_PRINT(vformat(
 			"Slider joint upper distances less than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped."
-		);
+			"Values outside this range will be clamped. "
+			"This joint connects %s.",
+			owners_to_string()
+		));
 	}
 
 	const float limit_lower_clamped = min((float)limit_lower, 0.0f);

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -98,34 +98,42 @@ void JoltAreaImpl3D::set_param(PhysicsServer3D::AreaParameter p_param, const Var
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_FORCE_MAGNITUDE: {
 			if (!Math::is_equal_approx((double)p_value, DEFAULT_WIND_FORCE_MAGNITUDE)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
+					"Invalid wind force magnitude for '%s'. "
 					"Area wind force magnitude is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored.",
+					to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_SOURCE: {
 			if (!((Vector3)p_value).is_equal_approx(DEFAULT_WIND_SOURCE)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
+					"Invalid wind source for '%s'. "
 					"Area wind source is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored.",
+					to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_DIRECTION: {
 			if (!((Vector3)p_value).is_equal_approx(DEFAULT_WIND_DIRECTION)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
+					"Invalid wind direction for '%s'. "
 					"Area wind direction is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored.",
+					to_string()
+				));
 			}
 		} break;
 		case PhysicsServer3D::AREA_PARAM_WIND_ATTENUATION_FACTOR: {
 			if (!Math::is_equal_approx((double)p_value, DEFAULT_WIND_ATTENUATION_FACTOR)) {
-				WARN_PRINT(
+				WARN_PRINT(vformat(
+					"Invalid wind attenuation for '%s'. "
 					"Area wind attenuation is not supported by Godot Jolt. "
-					"Any such value will be ignored."
-				);
+					"Any such value will be ignored.",
+					to_string()
+				));
 			}
 		} break;
 		default: {

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -923,10 +923,12 @@ void JoltBodyImpl3D::set_gravity_scale(float p_scale, bool p_lock) {
 
 void JoltBodyImpl3D::set_linear_damp(float p_damp, bool p_lock) {
 	if (p_damp < 0.0f) {
-		WARN_PRINT(
+		WARN_PRINT(vformat(
+			"Invalid linear damp for '%s'. "
 			"Linear damp values less than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped."
-		);
+			"Values outside this range will be clamped.",
+			to_string()
+		));
 
 		p_damp = 0;
 	}
@@ -942,10 +944,12 @@ void JoltBodyImpl3D::set_linear_damp(float p_damp, bool p_lock) {
 
 void JoltBodyImpl3D::set_angular_damp(float p_damp, bool p_lock) {
 	if (p_damp < 0.0f) {
-		WARN_PRINT(
+		WARN_PRINT(vformat(
+			"Invalid angular damp for '%s'. "
 			"Angular damp values less than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped."
-		);
+			"Values outside this range will be clamped.",
+			to_string()
+		));
 
 		p_damp = 0;
 	}

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -436,6 +436,11 @@ void JoltObjectImpl3D::post_step([[maybe_unused]] float p_step) {
 	previous_jolt_shape = nullptr;
 }
 
+String JoltObjectImpl3D::to_string() const {
+	Object* instance = ObjectDB::get_instance(instance_id);
+	return instance != nullptr ? instance->to_string() : "<unknown>";
+}
+
 JPH::ObjectLayer JoltObjectImpl3D::get_object_layer() const {
 	if (space == nullptr) {
 		return jolt_settings->mObjectLayer;
@@ -466,9 +471,10 @@ JPH::Body* JoltObjectImpl3D::create_end() {
 	ERR_FAIL_NULL_D_MSG(
 		body,
 		vformat(
-			"Failed to create Jolt body. "
+			"Failed to create Jolt body for '%s'. "
 			"Consider increasing maximum number of bodies in project settings. "
 			"Maximum number of bodies is currently set to %d.",
+			to_string(),
 			JoltProjectSettings::get_max_bodies()
 		)
 	);

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -118,6 +118,8 @@ public:
 
 	virtual bool generates_contacts() const = 0;
 
+	String to_string() const;
+
 protected:
 	friend class JoltShapeImpl3D;
 

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1686,7 +1686,7 @@ void JoltPhysicsServer3D::_free_rid(const RID& p_rid) {
 	} else if (JoltSpace3D* space = space_owner.get_or_null(p_rid)) {
 		free_space(space);
 	} else {
-		ERR_FAIL_MSG("Invalid ID.");
+		ERR_FAIL_MSG("Failed to free RID: The specified RID has no owner.");
 	}
 }
 

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -47,9 +47,11 @@ JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build box shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_capsule_shape_impl_3d.cpp
+++ b/src/shapes/jolt_capsule_shape_impl_3d.cpp
@@ -37,8 +37,10 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 		radius <= 0.0f,
 		vformat(
 			"Failed to build capsule shape with %s. "
-			"Its radius must be greater than 0.",
-			to_string()
+			"Its radius must be greater than 0. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -46,8 +48,10 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 		height <= 0.0f,
 		vformat(
 			"Failed to build capsule shape with %s. "
-			"Its height must be greater than 0.",
-			to_string()
+			"Its height must be greater than 0. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -55,8 +59,10 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 		height < radius * 2.0f,
 		vformat(
 			"Failed to build capsule shape with %s. "
-			"Its height must be at least double that of its radius.",
-			to_string()
+			"Its height must be at least double that of its radius. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -70,9 +76,11 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build capsule shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -46,8 +46,10 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 		vertex_count < 3,
 		vformat(
 			"Failed to build concave polygon shape with %s. "
-			"It must have a vertex count of at least 3.",
-			to_string()
+			"It must have a vertex count of at least 3. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -55,8 +57,10 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 		excess_vertex_count != 0,
 		vformat(
 			"Failed to build concave polygon shape with %s. "
-			"It must have a vertex count that is divisible by 3.",
-			to_string()
+			"It must have a vertex count that is divisible by 3. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -93,9 +97,11 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build concave polygon shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -37,8 +37,10 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 		vertex_count < 3,
 		vformat(
 			"Failed to build convex polygon shape with %s. "
-			"It must have a vertex count of at least 3.",
-			to_string()
+			"It must have a vertex count of at least 3. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -59,9 +61,11 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build convex polygon shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -59,9 +59,11 @@ JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build cylinder shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -46,8 +46,10 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 		height_count < 16,
 		vformat(
 			"Failed to build height map shape with %s. "
-			"Height count must be at least 16.",
-			to_string()
+			"Height count must be at least 16. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -55,8 +57,10 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 		height_count != width * depth,
 		vformat(
 			"Failed to build height map shape with %s. "
-			"Height count must be the product of width and depth.",
-			to_string()
+			"Height count must be the product of width and depth. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -64,8 +68,10 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 		width != depth,
 		vformat(
 			"Failed to build height map shape with %s. "
-			"Width must be equal to depth.",
-			to_string()
+			"Width must be equal to depth. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -73,8 +79,10 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 		!is_power_of_2((uint32_t)width),
 		vformat(
 			"Failed to build height map shape with %s. "
-			"Width/depth must be a power-of-two.",
-			to_string()
+			"Width/depth must be a power-of-two. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -99,9 +107,11 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build height map shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
+++ b/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
@@ -39,8 +39,10 @@ JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 		length <= 0.0f,
 		vformat(
 			"Failed to build separation ray shape with %s. "
-			"Its length must be greater than 0.",
-			to_string()
+			"Its length must be greater than 0. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -51,9 +53,11 @@ JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build separation ray shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -37,10 +37,12 @@ float JoltShapeImpl3D::get_solver_bias() const {
 
 void JoltShapeImpl3D::set_solver_bias(float p_bias) {
 	if (!Math::is_equal_approx(p_bias, DEFAULT_SOLVER_BIAS)) {
-		WARN_PRINT(
+		WARN_PRINT(vformat(
 			"Custom solver bias for shapes is not supported by Godot Jolt. "
-			"Any such value will be ignored."
-		);
+			"Any such value will be ignored. "
+			"This shape belongs to %s.",
+			owners_to_string()
+		));
 	}
 }
 
@@ -180,4 +182,16 @@ void JoltShapeImpl3D::invalidated(bool p_lock) {
 	for (const auto& [owner, ref_count] : ref_counts_by_owner) {
 		owner->shapes_changed(p_lock);
 	}
+}
+
+String JoltShapeImpl3D::owners_to_string() const {
+	const int32_t owner_count = ref_counts_by_owner.size();
+
+	if (owner_count == 0) {
+		return "'<unknown>' and 0 other object(s)";
+	}
+
+	const JoltObjectImpl3D& random_owner = *ref_counts_by_owner.begin()->first;
+
+	return vformat("'%s' and %d other object(s)", random_owner.to_string(), owner_count - 1);
 }

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -74,6 +74,8 @@ protected:
 
 	virtual void invalidated(bool p_lock = true);
 
+	String owners_to_string() const;
+
 	HashMap<JoltObjectImpl3D*, int32_t> ref_counts_by_owner;
 
 	RID rid;

--- a/src/shapes/jolt_sphere_shape_impl_3d.cpp
+++ b/src/shapes/jolt_sphere_shape_impl_3d.cpp
@@ -25,8 +25,10 @@ JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
 		radius <= 0.0f,
 		vformat(
 			"Failed to build sphere shape with %s. "
-			"Its radius must be greater than 0.",
-			to_string()
+			"Its radius must be greater than 0. "
+			"This shape belongs to %s.",
+			to_string(),
+			owners_to_string()
 		)
 	);
 
@@ -37,9 +39,11 @@ JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
 		shape_result.HasError(),
 		vformat(
 			"Failed to build sphere shape with %s. "
-			"It returned the following error: '%s'.",
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
 			to_string(),
-			to_godot(shape_result.GetError())
+			to_godot(shape_result.GetError()),
+			owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
@@ -17,8 +17,10 @@ void JoltWorldBoundaryShapeImpl3D::set_data(const Variant& p_data) {
 }
 
 JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::build() const {
-	ERR_FAIL_D_MSG(
+	ERR_FAIL_D_MSG(vformat(
 		"WorldBoundaryShape3D is not supported by Godot Jolt. "
-		"Consider using one or more reasonably sized BoxShape3D instead."
-	);
+		"Consider using one or more reasonably sized BoxShape3D instead. "
+		"This shape belongs to %s.",
+		owners_to_string()
+	));
 }

--- a/src/spaces/jolt_layer_mapper.cpp
+++ b/src/spaces/jolt_layer_mapper.cpp
@@ -104,7 +104,14 @@ JPH::ObjectLayer JoltLayerMapper::to_object_layer(
 
 		ERR_FAIL_COND_D_MSG(
 			next_object_layer == object_layer_count,
-			vformat("Maximum number of object layers (%d) reached.", object_layer_count)
+			vformat(
+				"Maximum number of object layers (%d) reached. "
+				"This means there are %d combinations of collision layers and masks. "
+				"This should not happen under normal circumstances. "
+				"Consider reporting this issue.",
+				object_layer_count,
+				object_layer_count
+			)
 		);
 
 		object_layer = allocate_object_layer(collision);


### PR DESCRIPTION
Fixes #379.

This improves error/warning messages in the following ways:

- Messages regarding objects now include their name, or `<unknown>` if the instance ID is invalid
- Messages regarding shapes now include a random owner's name and owner count
- Messages regarding joints now include the names of the bodies they connect
- `JoltLayerMapper` now spells out more clearly what exceeding object layers actually means
- Failing to free an RID now explains why