### PR TITLE
Added null checks to `acquire` methods on body accessor

### DIFF
--- a/src/spaces/jolt_body_accessor_3d.cpp
+++ b/src/spaces/jolt_body_accessor_3d.cpp
@@ -20,18 +20,24 @@ JoltBodyAccessor3D::JoltBodyAccessor3D(const JoltSpace3D* p_space)
 JoltBodyAccessor3D::~JoltBodyAccessor3D() = default;
 
 void JoltBodyAccessor3D::acquire(const JPH::BodyID* p_ids, int32_t p_id_count, bool p_lock) {
+	ERR_FAIL_NULL(space);
+
 	lock_iface = &space->get_lock_iface(p_lock);
 	ids = BodyIDSpan(p_ids, p_id_count);
 	acquire_internal(p_ids, p_id_count);
 }
 
 void JoltBodyAccessor3D::acquire(const JPH::BodyID& p_id, bool p_lock) {
+	ERR_FAIL_NULL(space);
+
 	lock_iface = &space->get_lock_iface(p_lock);
 	ids = p_id;
 	acquire_internal(&p_id, 1);
 }
 
 void JoltBodyAccessor3D::acquire_active(bool p_lock) {
+	ERR_FAIL_NULL(space);
+
 	lock_iface = &space->get_lock_iface(p_lock);
 
 	auto* vector = std::get_if<JPH::BodyIDVector>(&ids);
@@ -47,6 +53,8 @@ void JoltBodyAccessor3D::acquire_active(bool p_lock) {
 }
 
 void JoltBodyAccessor3D::acquire_all(bool p_lock) {
+	ERR_FAIL_NULL(space);
+
 	lock_iface = &space->get_lock_iface(p_lock);
 
 	auto* vector = std::get_if<JPH::BodyIDVector>(&ids);


### PR DESCRIPTION
When trying to acquire/lock a Jolt body without a valid space, you would end up crashing in one of these acquire methods.

I figured it's better to just early-out and have the user face whatever shower of subsequent errors there might be, so this PR adds exactly that.