### PR TITLE
Changed Jolt assert function to use `CRASH_NOW_MSG`

### DIFF
--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -33,15 +33,13 @@ void jolt_trace(const char* p_format, ...) {
 #ifdef JPH_ENABLE_ASSERTS
 
 bool jolt_assert(const char* p_expr, const char* p_msg, const char* p_file, uint32_t p_line) {
-	ERR_PRINT(vformat(
+	CRASH_NOW_MSG(vformat(
 		"Assertion '%s' failed with message '%s' at '%s:%d'",
 		p_expr,
 		p_msg != nullptr ? p_msg : "",
 		p_file,
 		p_line
 	));
-
-	CRASH_NOW();
 
 	return false;
 }


### PR DESCRIPTION
The assert function passed to Jolt has until now used `ERR_PRINT` followed by `CRASH_NOW` because there were issues with the stream not flushing fast enough when just using `CRASH_NOW_MSG`, but that has since been resolved, so I changed this back to use `CRASH_NOW_MSG` instead.

Note that this assert function is not used at all in regular distribution builds of Godot Jolt.