### PR TITLE
Refactored joints to accommodate for space changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added support for "Absorbent" physics material property
 - Added support for surface velocities, also known as "constant velocities", for both static and
   kinematic bodies
+- Added support for more flexible limits for `HingeJoint3D` and `SliderJoint3D`
 
 ### Fixed
 
@@ -31,6 +32,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue where setting velocities on kinematic bodies would actually move them instead of
   applying a surface velocity
 - Fixed issue where `RigidBody3D` would de-sync from its actual physics body after freezing
+- Fixed issues where disabling or removing a body connected to a joint would error or crash
 
 ## [0.1.0] - 2023-05-24
 

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -5,7 +5,6 @@
 class JoltConeTwistJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltConeTwistJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
@@ -14,7 +13,6 @@ public:
 	);
 
 	JoltConeTwistJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
@@ -29,9 +27,9 @@ public:
 
 	void set_param(PhysicsServer3D::ConeTwistJointParam p_param, double p_value);
 
-private:
-	void spans_changed();
+	void rebuild(bool p_lock = true) override;
 
+private:
 	double swing_span = 0.0;
 
 	double twist_span = 0.0;

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -19,7 +19,6 @@ class JoltGeneric6DOFJointImpl3D final : public JoltJointImpl3D {
 
 public:
 	JoltGeneric6DOFJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
@@ -28,7 +27,6 @@ public:
 	);
 
 	JoltGeneric6DOFJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
@@ -57,11 +55,9 @@ public:
 		bool p_lock = true
 	);
 
+	void rebuild(bool p_lock = true) override;
+
 private:
-	void rebuild(bool p_lock = true);
-
-	Transform3D world_ref;
-
 	double limit_lower[AXIS_COUNT] = {};
 
 	double limit_upper[AXIS_COUNT] = {};

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -5,7 +5,6 @@
 class JoltHingeJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltHingeJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
@@ -14,7 +13,6 @@ public:
 	);
 
 	JoltHingeJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
@@ -33,14 +31,20 @@ public:
 
 	void set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled);
 
+	void rebuild(bool p_lock = true) override;
+
 private:
-	void limits_changed();
+	double estimate_max_motor_torque() const;
 
 	double limit_lower = 0.0;
 
 	double limit_upper = 0.0;
 
+	double motor_target_velocity = 0.0f;
+
 	double motor_max_impulse = 0.0;
 
 	bool use_limits = false;
+
+	bool motor_enabled = false;
 };

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -10,18 +10,58 @@ constexpr int32_t DEFAULT_SOLVER_PRIORITY = 1;
 } // namespace
 
 JoltJointImpl3D::JoltJointImpl3D(
-	JoltSpace3D* p_space,
 	JoltBodyImpl3D* p_body_a,
-	JoltBodyImpl3D* p_body_b
+	JoltBodyImpl3D* p_body_b,
+	const Transform3D& p_local_ref_a,
+	[[maybe_unused]] const Transform3D& p_local_ref_b,
+	bool p_lock
 )
-	: space(p_space)
-	, body_a(p_body_a)
-	, body_b(p_body_b) { }
+	: body_a(p_body_a)
+	, body_b(p_body_b)
+	, world_ref(body_a->get_transform_scaled(p_lock) * p_local_ref_a) {
+	body_a->add_joint(this);
+	body_b->add_joint(this);
+
+	world_ref.orthonormalize();
+}
+
+JoltJointImpl3D::JoltJointImpl3D(JoltBodyImpl3D* p_body_a, const Transform3D& p_world_ref)
+	: body_a(p_body_a)
+	, world_ref(p_world_ref) {
+	body_a->add_joint(this);
+}
 
 JoltJointImpl3D::~JoltJointImpl3D() {
-	if (jolt_ref != nullptr) {
-		space->remove_joint(this);
+	if (body_a != nullptr) {
+		body_a->remove_joint(this);
 	}
+
+	if (body_b != nullptr) {
+		body_b->remove_joint(this);
+	}
+
+	destroy();
+}
+
+JoltSpace3D* JoltJointImpl3D::get_space() const {
+	JoltSpace3D* space_a = body_a->get_space();
+
+	if (body_b != nullptr) {
+		JoltSpace3D* space_b = body_b->get_space();
+		QUIET_FAIL_NULL_D(space_b);
+
+		ERR_FAIL_COND_D_MSG(
+			space_a != space_b,
+			vformat(
+				"Joint was found to connect bodies in different physics spaces. "
+				"This joint will effectively be disabled. "
+				"This joint connects %s.",
+				owners_to_string()
+			)
+		);
+	}
+
+	return space_a;
 }
 
 int32_t JoltJointImpl3D::get_solver_priority() const {
@@ -30,10 +70,12 @@ int32_t JoltJointImpl3D::get_solver_priority() const {
 
 void JoltJointImpl3D::set_solver_priority(int32_t p_priority) {
 	if (p_priority != DEFAULT_SOLVER_PRIORITY) {
-		WARN_PRINT(
+		WARN_PRINT(vformat(
 			"Joint solver priority is not supported by Godot Jolt. "
 			"Any such value will be ignored."
-		);
+			"This joint connects %s.",
+			owners_to_string()
+		));
 	}
 }
 
@@ -53,6 +95,20 @@ void JoltJointImpl3D::set_collision_disabled(bool p_disabled) {
 		physics_server->body_remove_collision_exception(body_a->get_rid(), body_b->get_rid());
 		physics_server->body_remove_collision_exception(body_b->get_rid(), body_a->get_rid());
 	}
+}
+
+void JoltJointImpl3D::destroy() {
+	if (jolt_ref == nullptr) {
+		return;
+	}
+
+	JoltSpace3D* space = get_space();
+
+	if (space != nullptr) {
+		space->remove_joint(this);
+	}
+
+	jolt_ref = nullptr;
 }
 
 String JoltJointImpl3D::owners_to_string() const {

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -8,10 +8,14 @@ public:
 	JoltJointImpl3D() = default;
 
 	JoltJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
-		JoltBodyImpl3D* p_body_b = nullptr
+		JoltBodyImpl3D* p_body_b,
+		const Transform3D& p_local_ref_a,
+		const Transform3D& p_local_ref_b,
+		bool p_lock = true
 	);
+
+	JoltJointImpl3D(JoltBodyImpl3D* p_body_a, const Transform3D& p_world_ref);
 
 	virtual ~JoltJointImpl3D();
 
@@ -21,7 +25,7 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
-	JoltSpace3D* get_space() const { return space; }
+	JoltSpace3D* get_space() const;
 
 	JPH::Constraint* get_jolt_ref() const { return jolt_ref; }
 
@@ -33,18 +37,22 @@ public:
 
 	void set_collision_disabled(bool p_disabled);
 
+	void destroy();
+
+	virtual void rebuild([[maybe_unused]] bool p_lock = true) { }
+
 protected:
 	String owners_to_string() const;
 
-	RID rid;
+	bool collision_disabled = false;
 
-	JoltSpace3D* space = nullptr;
+	JPH::Ref<JPH::Constraint> jolt_ref;
 
 	JoltBodyImpl3D* body_a = nullptr;
 
 	JoltBodyImpl3D* body_b = nullptr;
 
-	JPH::Ref<JPH::Constraint> jolt_ref;
+	RID rid;
 
-	bool collision_disabled = false;
+	Transform3D world_ref;
 };

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -12,114 +12,48 @@ constexpr double DEFAULT_IMPULSE_CLAMP = 0.0;
 } // namespace
 
 JoltPinJointImpl3D::JoltPinJointImpl3D(
-	JoltSpace3D* p_space,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_space, p_body_a, p_body_b)
+	: JoltJointImpl3D(p_body_a, p_body_b, Transform3D({}, p_local_a), Transform3D({}, p_local_b))
 	, local_a(p_local_a)
 	, local_b(p_local_b) {
-	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
-	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
-
-	const JoltWritableBody3D jolt_body_a = bodies[0];
-	ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-	const JoltWritableBody3D jolt_body_b = bodies[1];
-	ERR_FAIL_COND(jolt_body_b.is_invalid());
-
-	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
-	const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
-
-	const JPH::Vec3 point_scaled_a = to_jolt(local_a * object_a.get_scale());
-	const JPH::Vec3 point_scaled_b = to_jolt(local_b * object_b.get_scale());
-
-	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
-	const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
-
-	JPH::PointConstraintSettings constraint_settings;
-	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
-	constraint_settings.mPoint2 = point_scaled_b - com_scaled_b;
-
-	jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
-
-	space->add_joint(this);
+	rebuild(p_lock);
 }
 
 JoltPinJointImpl3D::JoltPinJointImpl3D(
-	JoltSpace3D* p_space,
 	JoltBodyImpl3D* p_body_a,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_space, p_body_a)
+	: JoltJointImpl3D(p_body_a, Transform3D({}, p_local_b))
 	, local_a(p_local_a)
 	, local_b(p_local_b) {
-	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
-	ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
-
-	const JPH::Vec3 point_scaled_a = to_jolt(local_a * object_a.get_scale());
-	const JPH::Vec3 point_scaled_b = to_jolt(local_b);
-
-	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
-
-	JPH::PointConstraintSettings constraint_settings;
-	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
-	constraint_settings.mPoint2 = point_scaled_b;
-
-	jolt_ref = constraint_settings.Create(*jolt_body_a, JPH::Body::sFixedToWorld);
-
-	space->add_joint(this);
+	rebuild(p_lock);
 }
 
 void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
 	local_a = p_local_a;
 
-	auto* jolt_constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());
-	ERR_FAIL_NULL(jolt_constraint);
+	world_ref = body_a->get_transform_scaled() * Transform3D({}, local_a);
 
-	const JoltReadableBody3D jolt_body_a = space->read_body(*body_a, p_lock);
-	ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
-	const JPH::Vec3 point_scaled_a = to_jolt(local_a * object_a.get_scale());
-	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
-
-	jolt_constraint->SetPoint1(
-		JPH::EConstraintSpace::LocalToBodyCOM,
-		point_scaled_a - com_scaled_a
-	);
+	rebuild(p_lock);
 }
 
 void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
 	local_b = p_local_b;
 
-	auto* jolt_constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());
-	ERR_FAIL_NULL(jolt_constraint);
-
 	if (body_b != nullptr) {
-		const JoltReadableBody3D jolt_body_b = space->read_body(*body_b, p_lock);
-		ERR_FAIL_COND(jolt_body_b.is_invalid());
-
-		const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
-		const JPH::Vec3 point_scaled_b = to_jolt(local_b * object_b.get_scale());
-		const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
-
-		jolt_constraint->SetPoint2(
-			JPH::EConstraintSpace::LocalToBodyCOM,
-			point_scaled_b - com_scaled_b
-		);
+		world_ref = body_b->get_transform_scaled() * Transform3D({}, local_b);
 	} else {
-		jolt_constraint->SetPoint2(JPH::EConstraintSpace::LocalToBodyCOM, to_jolt(local_b));
+		world_ref = Transform3D({}, local_b);
 	}
+
+	rebuild(p_lock);
 }
 
 double JoltPinJointImpl3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
@@ -175,4 +109,46 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 			ERR_FAIL_MSG(vformat("Unhandled pin joint parameter: '%d'", p_param));
 		} break;
 	}
+}
+
+void JoltPinJointImpl3D::rebuild(bool p_lock) {
+	destroy();
+
+	JoltSpace3D* space = get_space();
+
+	if (space == nullptr) {
+		return;
+	}
+
+	JPH::BodyID body_ids[2] = {body_a->get_jolt_id()};
+	int32_t body_count = 1;
+
+	if (body_b != nullptr) {
+		body_ids[1] = body_b->get_jolt_id();
+		body_count = 2;
+	}
+
+	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, body_count, p_lock);
+
+	JPH::PointConstraintSettings constraint_settings;
+	constraint_settings.mSpace = JPH::EConstraintSpace::WorldSpace;
+	constraint_settings.mPoint1 = to_jolt(world_ref.origin);
+	constraint_settings.mPoint2 = to_jolt(world_ref.origin);
+
+	if (body_b != nullptr) {
+		const JoltWritableBody3D jolt_body_a = bodies[0];
+		ERR_FAIL_COND(jolt_body_a.is_invalid());
+
+		const JoltWritableBody3D jolt_body_b = bodies[1];
+		ERR_FAIL_COND(jolt_body_b.is_invalid());
+
+		jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
+	} else {
+		const JoltWritableBody3D jolt_body_a = bodies[0];
+		ERR_FAIL_COND(jolt_body_a.is_invalid());
+
+		jolt_ref = constraint_settings.Create(*jolt_body_a, JPH::Body::sFixedToWorld);
+	}
+
+	space->add_joint(this);
 }

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -8,7 +8,6 @@ class JoltSpace3D;
 class JoltPinJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltPinJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Vector3& p_local_a,
@@ -17,7 +16,6 @@ public:
 	);
 
 	JoltPinJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		const Vector3& p_local_a,
 		const Vector3& p_local_b,
@@ -37,6 +35,8 @@ public:
 	double get_param(PhysicsServer3D::PinJointParam p_param) const;
 
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
+
+	void rebuild(bool p_lock = true) override;
 
 private:
 	Vector3 local_a;

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -34,78 +34,24 @@ constexpr double DEFAULT_ANGULAR_ORTHO_DAMPING = 1.0;
 } // namespace
 
 JoltSliderJointImpl3D::JoltSliderJointImpl3D(
-	JoltSpace3D* p_space,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_space, p_body_a, p_body_b) {
-	const JPH::BodyID body_ids[] = {body_a->get_jolt_id(), body_b->get_jolt_id()};
-	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, count_of(body_ids), p_lock);
-
-	const JoltWritableBody3D jolt_body_a = bodies[0];
-	ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-	const JoltWritableBody3D jolt_body_b = bodies[1];
-	ERR_FAIL_COND(jolt_body_b.is_invalid());
-
-	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
-	const JoltObjectImpl3D& object_b = *jolt_body_b.as_object();
-
-	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
-	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin * object_b.get_scale());
-
-	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
-	const JPH::Vec3 com_scaled_b = jolt_body_b->GetShape()->GetCenterOfMass();
-
-	JPH::SliderConstraintSettings constraint_settings;
-	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
-	constraint_settings.mSliderAxis1 = to_jolt(p_local_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mNormalAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPoint2 = point_scaled_b - com_scaled_b;
-	constraint_settings.mSliderAxis2 = to_jolt(p_local_ref_b.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mNormalAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
-
-	jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
-
-	space->add_joint(this);
+	: JoltJointImpl3D(p_body_a, p_body_b, p_local_ref_a, p_local_ref_b, p_lock) {
+	rebuild(p_lock);
 }
 
 JoltSliderJointImpl3D::JoltSliderJointImpl3D(
-	JoltSpace3D* p_space,
 	JoltBodyImpl3D* p_body_a,
-	const Transform3D& p_local_ref_a,
+	[[maybe_unused]] const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_space, p_body_a) {
-	const JoltWritableBody3D jolt_body_a = space->write_body(*body_a, p_lock);
-	ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-	const JoltObjectImpl3D& object_a = *jolt_body_a.as_object();
-
-	const JPH::Vec3 point_scaled_a = to_jolt(p_local_ref_a.origin * object_a.get_scale());
-	const JPH::Vec3 point_scaled_b = to_jolt(p_local_ref_b.origin);
-
-	const JPH::Vec3 com_scaled_a = jolt_body_a->GetShape()->GetCenterOfMass();
-
-	JPH::SliderConstraintSettings constraint_settings;
-	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = point_scaled_a - com_scaled_a;
-	constraint_settings.mSliderAxis1 = to_jolt(p_local_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mNormalAxis1 = to_jolt(-p_local_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPoint2 = point_scaled_b;
-	constraint_settings.mSliderAxis2 = to_jolt(p_local_ref_b.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mNormalAxis2 = to_jolt(-p_local_ref_b.basis.get_column(Vector3::AXIS_Z));
-
-	jolt_ref = constraint_settings.Create(*jolt_body_a, JPH::Body::sFixedToWorld);
-
-	space->add_joint(this);
+	: JoltJointImpl3D(p_body_a, p_local_ref_b) {
+	rebuild(p_lock);
 }
 
 double JoltSliderJointImpl3D::get_param(PhysicsServer3D::SliderJointParam p_param) const {
@@ -186,11 +132,11 @@ void JoltSliderJointImpl3D::set_param(PhysicsServer3D::SliderJointParam p_param,
 	switch (p_param) {
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_UPPER: {
 			limit_upper = p_value;
-			limits_changed();
+			rebuild();
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_LOWER: {
 			limit_lower = p_value;
-			limits_changed();
+			rebuild();
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
@@ -400,33 +346,68 @@ void JoltSliderJointImpl3D::set_param(PhysicsServer3D::SliderJointParam p_param,
 	}
 }
 
-void JoltSliderJointImpl3D::limits_changed() {
-	auto* jolt_constraint = static_cast<JPH::SliderConstraint*>(jolt_ref.GetPtr());
-	ERR_FAIL_NULL(jolt_constraint);
+void JoltSliderJointImpl3D::rebuild(bool p_lock) {
+	destroy();
 
-	constexpr double basically_pos_zero = CMP_EPSILON;
-	constexpr double basically_neg_zero = -CMP_EPSILON;
+	JoltSpace3D* space = get_space();
 
-	if (limit_lower > basically_pos_zero) {
-		WARN_PRINT(vformat(
-			"Slider joint lower distances greater than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped. "
-			"This joint connects %s.",
-			owners_to_string()
-		));
+	if (space == nullptr) {
+		return;
 	}
 
-	if (limit_upper < basically_neg_zero) {
-		WARN_PRINT(vformat(
-			"Slider joint upper distances less than 0 are not supported by Godot Jolt. "
-			"Values outside this range will be clamped. "
-			"This joint connects %s.",
-			owners_to_string()
-		));
+	JPH::BodyID body_ids[2] = {body_a->get_jolt_id()};
+	int32_t body_count = 1;
+
+	if (body_b != nullptr) {
+		body_ids[1] = body_b->get_jolt_id();
+		body_count = 2;
 	}
 
-	const float limit_lower_clamped = min((float)limit_lower, 0.0f);
-	const float limit_upper_clamped = max((float)limit_upper, 0.0f);
+	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, body_count, p_lock);
 
-	jolt_constraint->SetLimits(limit_lower_clamped, limit_upper_clamped);
+	JPH::SliderConstraintSettings constraint_settings;
+
+	float axis_shift = 0.0f;
+
+	if (limit_lower >= limit_upper) {
+		constraint_settings.mLimitsMin = -FLT_MAX;
+		constraint_settings.mLimitsMax = FLT_MAX;
+	} else {
+		const double limit_middle = Math::lerp(limit_lower, limit_upper, 0.5);
+
+		axis_shift = (float)limit_middle;
+
+		const auto extent = (float)Math::abs(limit_middle - limit_lower);
+		constraint_settings.mLimitsMin = -extent;
+		constraint_settings.mLimitsMax = extent;
+	}
+
+	const Vector3 linear_shift = {axis_shift, 0.0f, 0.0f};
+	const Vector3 shifted_origin = world_ref.xform(linear_shift);
+
+	constraint_settings.mSpace = JPH::EConstraintSpace::WorldSpace;
+	constraint_settings.mAutoDetectPoint = false;
+	constraint_settings.mPoint1 = to_jolt(shifted_origin);
+	constraint_settings.mSliderAxis1 = to_jolt(world_ref.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mNormalAxis1 = to_jolt(-world_ref.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mPoint2 = to_jolt(world_ref.origin);
+	constraint_settings.mSliderAxis2 = to_jolt(world_ref.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mNormalAxis2 = to_jolt(-world_ref.basis.get_column(Vector3::AXIS_Z));
+
+	if (body_b != nullptr) {
+		const JoltWritableBody3D jolt_body_a = bodies[0];
+		ERR_FAIL_COND(jolt_body_a.is_invalid());
+
+		const JoltWritableBody3D jolt_body_b = bodies[1];
+		ERR_FAIL_COND(jolt_body_b.is_invalid());
+
+		jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
+	} else {
+		const JoltWritableBody3D jolt_body_a = bodies[0];
+		ERR_FAIL_COND(jolt_body_a.is_invalid());
+
+		jolt_ref = constraint_settings.Create(*jolt_body_a, JPH::Body::sFixedToWorld);
+	}
+
+	space->add_joint(this);
 }

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -5,7 +5,6 @@
 class JoltSliderJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltSliderJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
@@ -14,7 +13,6 @@ public:
 	);
 
 	JoltSliderJointImpl3D(
-		JoltSpace3D* p_space,
 		JoltBodyImpl3D* p_body_a,
 		const Transform3D& p_local_ref_a,
 		const Transform3D& p_local_ref_b,
@@ -29,9 +27,9 @@ public:
 
 	void set_param(PhysicsServer3D::SliderJointParam p_param, double p_value);
 
-private:
-	void limits_changed();
+	void rebuild(bool p_lock = true) override;
 
+private:
 	double limit_upper = 0.0;
 
 	double limit_lower = 0.0;

--- a/src/misc/utility_functions.hpp
+++ b/src/misc/utility_functions.hpp
@@ -51,3 +51,12 @@ _FORCE_INLINE_ void memdelete_safely(TType*& p_ptr) {
 		p_ptr = nullptr;
 	}
 }
+
+_FORCE_INLINE_ double estimate_physics_step() {
+	Engine* engine = Engine::get_singleton();
+
+	const double step = 1.0 / engine->get_physics_ticks_per_second();
+	const double step_scaled = step * engine->get_time_scale();
+
+	return step_scaled;
+}

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -6,6 +6,7 @@
 
 class JoltAreaImpl3D;
 class JoltGroupFilterRID;
+class JoltJointImpl3D;
 
 class JoltBodyImpl3D final : public JoltObjectImpl3D {
 public:
@@ -156,6 +157,10 @@ public:
 
 	void remove_area(JoltAreaImpl3D* p_area, bool p_lock = true);
 
+	void add_joint(JoltJointImpl3D* p_joint, bool p_lock = true);
+
+	void remove_joint(JoltJointImpl3D* p_joint, bool p_lock = true);
+
 	void integrate_forces(float p_step, bool p_lock = true);
 
 	void call_queries();
@@ -249,6 +254,10 @@ private:
 
 	void update_group_filter(bool p_lock = true);
 
+	void update_joint_constraints(bool p_lock = true);
+
+	void destroy_joint_constraints();
+
 	void update_axes_constraint(bool p_lock = true);
 
 	void destroy_axes_constraint();
@@ -263,6 +272,8 @@ private:
 
 	void areas_changed(bool p_lock = true);
 
+	void joints_changed(bool p_lock = true);
+
 	void transform_changed(bool p_lock = true) override;
 
 	void motion_changed(bool p_lock = true);
@@ -274,6 +285,8 @@ private:
 	LocalVector<Contact> contacts;
 
 	LocalVector<JoltAreaImpl3D*> areas;
+
+	LocalVector<JoltJointImpl3D*> joints;
 
 	Variant force_integration_userdata;
 

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -13,6 +13,7 @@
 #include <gdextension_interface.h>
 
 #include <godot_cpp/classes/camera3d.hpp>
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/geometry_instance3d.hpp>
 #include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/object.hpp>

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1265,12 +1265,9 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltSpace3D* space = body_a->get_space();
-	ERR_FAIL_NULL(space);
-
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltPinJointImpl3D(space, body_a, body_b, p_local_a, p_local_b))
-		: memnew(JoltPinJointImpl3D(space, body_a, p_local_a, p_local_b));
+		? memnew(JoltPinJointImpl3D(body_a, body_b, p_local_a, p_local_b))
+		: memnew(JoltPinJointImpl3D(body_a, p_local_a, p_local_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1359,12 +1356,9 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltSpace3D* space = body_a->get_space();
-	ERR_FAIL_NULL(space);
-
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltHingeJointImpl3D(space, body_a, body_b, p_hinge_a, p_hinge_b))
-		: memnew(JoltHingeJointImpl3D(space, body_a, p_hinge_a, p_hinge_b));
+		? memnew(JoltHingeJointImpl3D(body_a, body_b, p_hinge_a, p_hinge_b))
+		: memnew(JoltHingeJointImpl3D(body_a, p_hinge_a, p_hinge_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1452,12 +1446,9 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltSpace3D* space = body_a->get_space();
-	ERR_FAIL_NULL(space);
-
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltSliderJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltSliderJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltSliderJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltSliderJointImpl3D(body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1507,12 +1498,9 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltSpace3D* space = body_a->get_space();
-	ERR_FAIL_NULL(space);
-
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltConeTwistJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltConeTwistJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltConeTwistJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltConeTwistJointImpl3D(body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1564,12 +1552,9 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltSpace3D* space = body_a->get_space();
-	ERR_FAIL_NULL(space);
-
 	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltGeneric6DOFJointImpl3D(space, body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltGeneric6DOFJointImpl3D(space, body_a, p_local_ref_a, p_local_ref_b));
+		? memnew(JoltGeneric6DOFJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b))
+		: memnew(JoltGeneric6DOFJointImpl3D(body_a, p_local_ref_a, p_local_ref_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());


### PR DESCRIPTION
Fixes #333.
Fixes #343.
Fixes #344.
Fixes #393.

This is a major refactoring of how joints are built at runtime.

This changes all the joints to be rebuilt in the same manner as what `Generic6DOFJoint` has been doing until now. On top of this `JoltBodyImpl3D` will now also keep track of any joints connected to it, so that it can destroy/rebuild the joints whenever it goes through a space change, meaning when the underlying Jolt body is destroyed/created.

This helps resolve some crashes and other weird errors whenever you would do things like disable/remove a body that's currently connected to a joint.

I also snuck in changes to how limits are dealt with for hinges and sliders, so that they are now as flexible in their limits as what `Generic6DOFJoint` has been until now, where it shifts the reference frame to accommodate for things like a negative upper limit or a positive lower limit.