### PR TITLE
Removed setting of Jolt's `Trace` function for non-debug builds

### DIFF
--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -20,6 +20,8 @@ void jolt_aligned_free(void* p_mem) {
 	mi_free(p_mem);
 }
 
+#ifdef JPH_ENABLE_ASSERTS
+
 void jolt_trace(const char* p_format, ...) {
 	// NOLINTNEXTLINE(cppcoreguidelines-init-variables)
 	va_list args;
@@ -29,8 +31,6 @@ void jolt_trace(const char* p_format, ...) {
 	va_end(args);
 	UtilityFunctions::print_verbose(buffer);
 }
-
-#ifdef JPH_ENABLE_ASSERTS
 
 bool jolt_assert(const char* p_expr, const char* p_msg, const char* p_file, uint32_t p_line) {
 	CRASH_NOW_MSG(vformat(
@@ -52,9 +52,8 @@ void jolt_initialize() {
 	JPH::AlignedAllocate = &jolt_aligned_alloc;
 	JPH::AlignedFree = &jolt_aligned_free;
 
-	JPH::Trace = &jolt_trace;
-
 #ifdef JPH_ENABLE_ASSERTS
+	JPH::Trace = &jolt_trace;
 	JPH::AssertFailed = jolt_assert;
 #endif // JPH_ENABLE_ASSERTS
 


### PR DESCRIPTION
This removes the setting of `JPH::Trace`, which I believe is meant to serve as a way for Jolt to log stuff in the host application.

Since this doesn't seem to be used for anything important, I figured I might as well remove the setting of it for non-debug builds and rely on the no-op default implementation instead.