### PR TITLE
Fixed issue with kinematic bodies not moving as they should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   applying a surface velocity
 - Fixed issue where `RigidBody3D` would de-sync from its actual physics body after freezing
 - Fixed issues where disabling or removing a body connected to a joint would error or crash
+- Fixed issue with `CharacterBody3D` and other kinematic bodies where they wouldn't elicit a proper
+  collision response from dynamic bodies
 
 ## [0.1.0] - 2023-05-24
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -159,6 +159,8 @@ private:
 
 	void create_in_space() override;
 
+	bool moves_kinematically() const override { return false; }
+
 	void add_shape_pair(
 		Overlap& p_overlap,
 		const JPH::BodyID& p_body_id,

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -244,6 +244,8 @@ private:
 
 	void create_in_space() override;
 
+	bool moves_kinematically() const override { return is_kinematic(); }
+
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 
 	JPH::MassProperties calculate_mass_properties() const;

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -127,6 +127,8 @@ protected:
 
 	JPH::ObjectLayer get_object_layer() const;
 
+	virtual bool moves_kinematically() const = 0;
+
 	virtual bool has_custom_center_of_mass() const = 0;
 
 	virtual Vector3 get_center_of_mass_custom() const = 0;


### PR DESCRIPTION
Fixes #414.

As described in the linked issue, this changes the way kinematic bodies are moved. Previously they would be moved like any other body, using `JPH::BodyInterface::SetPositionAndRotation`, but this doesn't actually apply any linear/angular velocity to the kinematic body, resulting in there not being any real collision response between it and dynamic bodies.

This PR instead makes it so kinematic bodies are moved using `JPH::Body::MoveKinematic`, which will set the appropriate linear/angular velocity.