### PR TITLE
Fixed joint misalignment when changing limits after moving

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -12,13 +12,6 @@ public:
 		bool p_lock = true
 	);
 
-	JoltConeTwistJointImpl3D(
-		JoltBodyImpl3D* p_body_a,
-		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
-	);
-
 	PhysicsServer3D::JointType get_type() const override {
 		return PhysicsServer3D::JOINT_TYPE_CONE_TWIST;
 	}

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -26,13 +26,6 @@ public:
 		bool p_lock = true
 	);
 
-	JoltGeneric6DOFJointImpl3D(
-		JoltBodyImpl3D* p_body_a,
-		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
-	);
-
 	PhysicsServer3D::JointType get_type() const override {
 		return PhysicsServer3D::JOINT_TYPE_6DOF;
 	}

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -12,13 +12,6 @@ public:
 		bool p_lock = true
 	);
 
-	JoltHingeJointImpl3D(
-		JoltBodyImpl3D* p_body_a,
-		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
-	);
-
 	PhysicsServer3D::JointType get_type() const override {
 		return PhysicsServer3D::JOINT_TYPE_HINGE;
 	}

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -11,11 +11,8 @@ public:
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
+		const Transform3D& p_local_ref_b
 	);
-
-	JoltJointImpl3D(JoltBodyImpl3D* p_body_a, const Transform3D& p_world_ref);
 
 	virtual ~JoltJointImpl3D();
 
@@ -42,6 +39,13 @@ public:
 	virtual void rebuild([[maybe_unused]] bool p_lock = true) { }
 
 protected:
+	void shift_reference_frames(
+		const Vector3& p_linear_shift,
+		const Vector3& p_angular_shift,
+		Transform3D& p_shifted_ref_a,
+		Transform3D& p_shifted_ref_b
+	);
+
 	String owners_to_string() const;
 
 	bool collision_disabled = false;
@@ -54,5 +58,7 @@ protected:
 
 	RID rid;
 
-	Transform3D world_ref;
+	Transform3D local_ref_a;
+
+	Transform3D local_ref_b;
 };

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -15,20 +15,13 @@ public:
 		bool p_lock = true
 	);
 
-	JoltPinJointImpl3D(
-		JoltBodyImpl3D* p_body_a,
-		const Vector3& p_local_a,
-		const Vector3& p_local_b,
-		bool p_lock = true
-	);
-
 	PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_PIN; }
 
-	Vector3 get_local_a() const { return local_a; }
+	Vector3 get_local_a() const { return local_ref_a.origin; }
 
 	void set_local_a(const Vector3& p_local_a, bool p_lock = true);
 
-	Vector3 get_local_b() const { return local_b; }
+	Vector3 get_local_b() const { return local_ref_b.origin; }
 
 	void set_local_b(const Vector3& p_local_b, bool p_lock = true);
 
@@ -37,9 +30,4 @@ public:
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
 
 	void rebuild(bool p_lock = true) override;
-
-private:
-	Vector3 local_a;
-
-	Vector3 local_b;
 };

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -12,13 +12,6 @@ public:
 		bool p_lock = true
 	);
 
-	JoltSliderJointImpl3D(
-		JoltBodyImpl3D* p_body_a,
-		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
-	);
-
 	PhysicsServer3D::JointType get_type() const override {
 		return PhysicsServer3D::JOINT_TYPE_SLIDER;
 	}

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1265,9 +1265,7 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltPinJointImpl3D(body_a, body_b, p_local_a, p_local_b))
-		: memnew(JoltPinJointImpl3D(body_a, p_local_a, p_local_b));
+	JoltJointImpl3D* new_joint = memnew(JoltPinJointImpl3D(body_a, body_b, p_local_a, p_local_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1356,9 +1354,7 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltHingeJointImpl3D(body_a, body_b, p_hinge_a, p_hinge_b))
-		: memnew(JoltHingeJointImpl3D(body_a, p_hinge_a, p_hinge_b));
+	JoltJointImpl3D* new_joint = memnew(JoltHingeJointImpl3D(body_a, body_b, p_hinge_a, p_hinge_b));
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1446,9 +1442,9 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltSliderJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltSliderJointImpl3D(body_a, p_local_ref_a, p_local_ref_b));
+	JoltJointImpl3D* new_joint = memnew(
+		JoltSliderJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b)
+	);
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1498,9 +1494,9 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltConeTwistJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltConeTwistJointImpl3D(body_a, p_local_ref_a, p_local_ref_b));
+	JoltJointImpl3D* new_joint = memnew(
+		JoltConeTwistJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b)
+	);
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
@@ -1552,9 +1548,9 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = body_b != nullptr
-		? memnew(JoltGeneric6DOFJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b))
-		: memnew(JoltGeneric6DOFJointImpl3D(body_a, p_local_ref_a, p_local_ref_b));
+	JoltJointImpl3D* new_joint = memnew(
+		JoltGeneric6DOFJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b)
+	);
 
 	new_joint->set_rid(old_joint->get_rid());
 	new_joint->set_collision_disabled(old_joint->is_collision_disabled());


### PR DESCRIPTION
Related to #418.

In order to allow for joint limits outside of what Jolt allows for I've been shifting the reference frames of the two bodies connected to the joint. I had however been doing this in world-space using a reference frame that's cached when the joint is first created. This for some reason seemed fine to me at the time, but this obviously creates problem when you decide to change the limits after the whole setup has actually started moving around.

This PR changes all that to instead do the reference frame shifting in local-space. It also unifies the shifting to now happen in one place, which is the new `JoltJointImpl3D::shift_reference_frames` method.