### PR TITLE
Fixed mistakes in the reference frame shifting for joints

### DIFF
--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -462,7 +462,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 		} else {
 			const double middle = Math::lerp(lower, upper, 0.5);
 
-			ref_shift[axis] = (float)middle;
+			ref_shift[axis] = (float)-middle;
 
 			if (Math::is_equal_approx(lower, upper)) {
 				constraint_settings.MakeFixedAxis((JoltAxis)axis);

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -201,7 +201,7 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 	} else {
 		const double limit_middle = Math::lerp(limit_lower, limit_upper, 0.5);
 
-		axis_shift = (float)limit_middle;
+		axis_shift = (float)-limit_middle;
 
 		const auto extent = (float)Math::abs(limit_middle - limit_lower);
 		constraint_settings.mLimitsMin = -extent;
@@ -213,7 +213,7 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 
 	shift_reference_frames(
 		Vector3(),
-		Vector3(axis_shift, 0.0f, 0.0f),
+		Vector3(0.0f, axis_shift, 0.0f),
 		shifted_ref_a,
 		shifted_ref_b
 	);

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -121,8 +121,8 @@ void JoltJointImpl3D::shift_reference_frames(
 		origin_b -= to_godot(body_b->get_jolt_shape()->GetCenterOfMass());
 	}
 
-	p_shifted_ref_a = Transform3D(local_ref_a.basis, origin_a + p_linear_shift);
-	p_shifted_ref_b = Transform3D(local_ref_b.basis.rotated(p_angular_shift), origin_b);
+	p_shifted_ref_a = Transform3D(local_ref_a.basis.rotated(p_angular_shift), origin_a);
+	p_shifted_ref_b = Transform3D(local_ref_b.basis, origin_b + p_linear_shift);
 }
 
 String JoltJointImpl3D::owners_to_string() const {

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -369,7 +369,7 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 	} else {
 		const double limit_middle = Math::lerp(limit_lower, limit_upper, 0.5);
 
-		axis_shift = (float)limit_middle;
+		axis_shift = (float)-limit_middle;
 
 		const auto extent = (float)Math::abs(limit_middle - limit_lower);
 		constraint_settings.mLimitsMin = -extent;


### PR DESCRIPTION
Complements #424.

It looks like I not only got the "order of operations" wrong for the shifting of the joint reference frames, but also the hinge joint didn't shift the correct axis.

This fixes all that.