### PR TITLE
Refactored joints to apply changes in a more reactive way

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -53,11 +53,11 @@ void JoltConeTwistJointImpl3D::set_param(
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
 			swing_span = p_value;
-			rebuild(p_lock);
+			limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN: {
 			twist_span = p_value;
-			rebuild(p_lock);
+			limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
@@ -166,4 +166,8 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 	}
 
 	space->add_joint(this);
+}
+
+void JoltConeTwistJointImpl3D::limits_changed(bool p_lock) {
+	rebuild(p_lock);
 }

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -27,6 +27,8 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	void limits_changed(bool p_lock = true);
+
 	double swing_span = 0.0;
 
 	double twist_span = 0.0;

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -51,11 +51,25 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	void update_motor_state(int32_t p_axis);
+
+	void update_motor_velocity(int32_t p_axis);
+
+	void update_motor_limit(int32_t p_axis);
+
+	void limits_changed(bool p_lock = true);
+
+	void motor_state_changed(int32_t p_axis);
+
+	void motor_speed_changed(int32_t p_axis);
+
+	void motor_limit_changed(int32_t p_axis);
+
 	double limit_lower[AXIS_COUNT] = {};
 
 	double limit_upper[AXIS_COUNT] = {};
 
-	double motor_velocity[AXIS_COUNT] = {};
+	double motor_speed[AXIS_COUNT] = {};
 
 	double motor_limit[AXIS_COUNT] = {};
 

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -27,13 +27,25 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
-	double estimate_max_motor_torque() const;
+	void update_motor_state();
+
+	void update_motor_velocity();
+
+	void update_motor_limit();
+
+	void limits_changed(bool p_lock = true);
+
+	void motor_state_changed();
+
+	void motor_speed_changed();
+
+	void motor_limit_changed();
 
 	double limit_lower = 0.0;
 
 	double limit_upper = 0.0;
 
-	double motor_target_velocity = 0.0f;
+	double motor_target_speed = 0.0f;
 
 	double motor_max_impulse = 0.0;
 

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -24,12 +24,12 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 
 void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
 	local_ref_a = Transform3D({}, p_local_a);
-	rebuild(p_lock);
+	points_changed(p_lock);
 }
 
 void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
 	local_ref_b = Transform3D({}, p_local_b);
-	rebuild(p_lock);
+	points_changed(p_lock);
 }
 
 double JoltPinJointImpl3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
@@ -132,4 +132,8 @@ void JoltPinJointImpl3D::rebuild(bool p_lock) {
 	}
 
 	space->add_joint(this);
+}
+
+void JoltPinJointImpl3D::points_changed(bool p_lock) {
+	rebuild(p_lock);
 }

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -30,4 +30,7 @@ public:
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
 
 	void rebuild(bool p_lock = true) override;
+
+private:
+	void points_changed(bool p_lock = true);
 };

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -412,3 +412,7 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 
 	space->add_joint(this);
 }
+
+void JoltSliderJointImpl3D::limits_changed(bool p_lock) {
+	rebuild(p_lock);
+}

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -23,6 +23,8 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	void limits_changed(bool p_lock = true);
+
 	double limit_upper = 0.0;
 
 	double limit_lower = 0.0;


### PR DESCRIPTION
This was in part extracted from #430.

This is just bringing the joints in line with a convention I've already been applying to the object classes, where reactive changes typically involve a `*_changed` method being invoked after the relevant state changes, which in turn performs whatever subsequent state changes are needed, usually through one or more `update_*` methods.