### PR TITLE
Fixed issue with `AnimatableBody3D` not synchronizing its state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where `AnimatableBody3D` would de-sync from its underlying body when moved.
+
 ## [0.2.1] - 2023-06-06
 
 ### Fixed

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -708,8 +708,6 @@ void JoltBodyImpl3D::integrate_forces(float p_step, bool p_lock) {
 		jolt_body->AddForce(to_jolt(constant_force));
 		jolt_body->AddTorque(to_jolt(constant_torque));
 	}
-
-	sync_state = true;
 }
 
 void JoltBodyImpl3D::call_queries() {
@@ -749,6 +747,14 @@ void JoltBodyImpl3D::pre_step(float p_step) {
 	}
 
 	contact_count = 0;
+}
+
+void JoltBodyImpl3D::post_step(float p_step) {
+	if (!is_static()) {
+		sync_state = true;
+	}
+
+	JoltObjectImpl3D::post_step(p_step);
 }
 
 JoltPhysicsDirectBodyState3D* JoltBodyImpl3D::get_direct_state() {

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -167,6 +167,8 @@ public:
 
 	void pre_step(float p_step) override;
 
+	void post_step(float p_step) override;
+
 	JoltPhysicsDirectBodyState3D* get_direct_state();
 
 	PhysicsServer3D::BodyMode get_mode() const { return mode; }


### PR DESCRIPTION
Fixes #432.

This fixes an issue where `AnimatableBody3D` would de-sync from its underlying body when moved.

Apparently `AnimatableBody3D` pretends to be a `StaticBody3D` but is in fact kinematic. On top of this it does some strange stuff where it deliberately sets the transform on the underlying physics body but then [immediately reverts it](https://github.com/godotengine/godot/blob/72b59325cf7beba7e6e9170cf6023a079fd58672/scene/3d/physics_body_3d.cpp#L358-L362), just for the physics server to sync it back and have it be set again. Since I had assumed that only dynamic bodies were the ones able to move on their own, and therefore the only type that needs to be synced, I had not been syncing kinematic bodies.

This PR fixes all this by simply allowing kinematic bodies to sync their state.