### PR TITLE
Fixed kinematic bodies not resetting velocities between steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Breaking changes are denoted with ⚠️.
 ### Fixed
 
 - Fixed issue where `AnimatableBody3D` would de-sync from its underlying body when moved.
+- Fixed issue where `CharacterBody3D` and other kinematic bodies would sometimes maintain a velocity
+  after having moved.
 
 ## [0.2.1] - 2023-06-06
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -159,8 +159,6 @@ private:
 
 	void create_in_space() override;
 
-	bool moves_kinematically() const override { return false; }
-
 	void add_shape_pair(
 		Overlap& p_overlap,
 		const JPH::BodyID& p_body_id,

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -244,7 +244,7 @@ private:
 
 	void create_in_space() override;
 
-	bool moves_kinematically() const override { return is_kinematic(); }
+	void apply_transform(const Transform3D& p_transform, bool p_lock = true) override;
 
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 
@@ -291,6 +291,8 @@ private:
 	LocalVector<JoltJointImpl3D*> joints;
 
 	Variant force_integration_userdata;
+
+	Transform3D kinematic_transform;
 
 	Vector3 inertia;
 

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -120,25 +120,7 @@ void JoltObjectImpl3D::set_transform(Transform3D p_transform, bool p_lock) {
 		return;
 	}
 
-	if (moves_kinematically()) {
-		const JoltWritableBody3D body = space->write_body(jolt_id, p_lock);
-		ERR_FAIL_COND(body.is_invalid());
-
-		float step = space->get_last_step();
-
-		if (unlikely(step == 0.0f)) {
-			step = (float)estimate_physics_step();
-		}
-
-		body->MoveKinematic(to_jolt(p_transform.origin), to_jolt(p_transform.basis), step);
-	} else {
-		space->get_body_iface(p_lock).SetPositionAndRotation(
-			jolt_id,
-			to_jolt(p_transform.origin),
-			to_jolt(p_transform.basis),
-			JPH::EActivation::DontActivate
-		);
-	}
+	apply_transform(p_transform);
 
 	transform_changed(p_lock);
 }
@@ -441,6 +423,15 @@ void JoltObjectImpl3D::destroy_in_space(bool p_lock) {
 	space->get_body_iface(p_lock).DestroyBody(jolt_id);
 
 	jolt_id = {};
+}
+
+void JoltObjectImpl3D::apply_transform(const Transform3D& p_transform, bool p_lock) {
+	space->get_body_iface(p_lock).SetPositionAndRotation(
+		jolt_id,
+		to_jolt(p_transform.origin),
+		to_jolt(p_transform.basis),
+		JPH::EActivation::DontActivate
+	);
 }
 
 void JoltObjectImpl3D::pre_step([[maybe_unused]] float p_step) { }

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -127,8 +127,6 @@ protected:
 
 	JPH::ObjectLayer get_object_layer() const;
 
-	virtual bool moves_kinematically() const = 0;
-
 	virtual bool has_custom_center_of_mass() const = 0;
 
 	virtual Vector3 get_center_of_mass_custom() const = 0;
@@ -142,6 +140,8 @@ protected:
 	virtual void remove_from_space(bool p_lock = true);
 
 	virtual void destroy_in_space(bool p_lock = true);
+
+	virtual void apply_transform(const Transform3D& p_transform, bool p_lock = true);
 
 	void create_begin();
 


### PR DESCRIPTION
Related to #433.

This fixes an issue where if you moved a kinematic body in one step and then stopped moving it in the next step, the underlying Jolt body would maintain the previous velocity and just keep moving, causing de-sync.

This PR fixes this in part by refactoring when/how kinematic bodies are moved. This turned out to be slightly complicated though...

Until now we've been calling Jolt's `MoveKinematic` on every transform change, which is what sets the velocities for the body. However, this creates a problem since we need to reset these velocities at some point, but still be able use them when stepping the simulation, as well as be able to report them back to the engine when synchronizing state.

Let's say we decide to reset the velocities after each state synchronization. This unfortunately creates a problem when we move a kinematic body through `_process`, as shown in the flow below:

- For every physics iteration
    - Synchronize state
        - Call `_integrate_forces()`
    - Reset velocities
    - Call `_physics_process()`
    - Step Jolt simulation
- Call `_process()`
    - Set transform and thereby velocities
- Repeat

In this scenario we end up resetting the velocities before stepping the simulation, resulting in the kinematic body not moving at all, and likely de-syncing from its scene representation.

So to counter this maybe we can try resetting the velocities after stepping the simulation instead. This however creates another problem when we move a kinematic body through `_physics_process`:

- For every physics iteration
    - Synchronize state
        - Call `_integrate_forces()`
    - Call `_physics_process()`
        - Set transform and thereby velocities
    - Step Jolt simulation
    - Reset velocities
- Call `_process()`
- Repeat

In this scenario you instead end up resetting the velocities before synchronizing state, meaning the engine (and `_integrate_forces`) will always perceive them to be zero.

The only solution to this (that I can think of) is to do what this PR does and implement kinematic movement in the same way as Godot Physics, where any transform change performed on a kinematic body is cached in a separate transform and only applied using `MoveKinematic` right before the simulation gets stepped. This means any change in velocities always happens as part of the physics iteration and we can safely reset the velocities after each state synchronization.