### PR TITLE
Changed so kinematic bodies only synchronize state when needed

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -744,17 +744,10 @@ void JoltBodyImpl3D::pre_step(float p_step) {
 
 	if (is_rigid() && !is_sleeping(false)) {
 		integrate_forces(p_step, false);
-	}
-
-	contact_count = 0;
-}
-
-void JoltBodyImpl3D::post_step(float p_step) {
-	if (!is_static()) {
 		sync_state = true;
 	}
 
-	JoltObjectImpl3D::post_step(p_step);
+	contact_count = 0;
 }
 
 JoltPhysicsDirectBodyState3D* JoltBodyImpl3D::get_direct_state() {
@@ -1233,6 +1226,10 @@ void JoltBodyImpl3D::joints_changed(bool p_lock) {
 
 void JoltBodyImpl3D::transform_changed(bool p_lock) {
 	wake_up(p_lock);
+
+	if (moves_kinematically()) {
+		sync_state = true;
+	}
 }
 
 void JoltBodyImpl3D::motion_changed(bool p_lock) {

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -167,8 +167,6 @@ public:
 
 	void pre_step(float p_step) override;
 
-	void post_step(float p_step) override;
-
 	JoltPhysicsDirectBodyState3D* get_direct_state();
 
 	PhysicsServer3D::BodyMode get_mode() const { return mode; }


### PR DESCRIPTION
Improves upon #433.

I noticed while debugging another issue that `_integrate_forces` was being called a lot more often for kinematic bodies in Godot Jolt compared to Godot Physics. This turned out to be because Godot Physics doesn't do any state synchronization for kinematic bodies unless they've actually moved.

This PR addresses that by only flagging the body as needing synchronization if it's either dynamic (and not sleeping) or if it's kinematic and a transform change has happened.