### PR TITLE
Refactored away some unnecessary body accessors

### DIFF
--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -260,7 +260,7 @@ bool JoltAreaImpl3D::shape_exited(
 		area_shape_exited(p_body_id, p_other_shape_id, p_self_shape_id);
 }
 
-void JoltAreaImpl3D::call_queries() {
+void JoltAreaImpl3D::call_queries([[maybe_unused]] JPH::Body& p_jolt_body) {
 	flush_events(bodies_by_id, body_monitor_callback);
 	flush_events(areas_by_id, area_monitor_callback);
 }

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -148,7 +148,7 @@ public:
 		const JPH::SubShapeID& p_self_shape_id
 	);
 
-	void call_queries();
+	void call_queries(JPH::Body& p_jolt_body);
 
 	bool has_custom_center_of_mass() const override { return false; }
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -161,11 +161,11 @@ public:
 
 	void remove_joint(JoltJointImpl3D* p_joint, bool p_lock = true);
 
-	void integrate_forces(float p_step, bool p_lock = true);
+	void integrate_forces(float p_step, JPH::Body& p_jolt_body);
 
-	void call_queries();
+	void call_queries(JPH::Body& p_jolt_body);
 
-	void pre_step(float p_step) override;
+	void pre_step(float p_step, JPH::Body& p_jolt_body) override;
 
 	JoltPhysicsDirectBodyState3D* get_direct_state();
 

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -434,9 +434,15 @@ void JoltObjectImpl3D::apply_transform(const Transform3D& p_transform, bool p_lo
 	);
 }
 
-void JoltObjectImpl3D::pre_step([[maybe_unused]] float p_step) { }
+void JoltObjectImpl3D::pre_step(
+	[[maybe_unused]] float p_step,
+	[[maybe_unused]] JPH::Body& p_jolt_body
+) { }
 
-void JoltObjectImpl3D::post_step([[maybe_unused]] float p_step) {
+void JoltObjectImpl3D::post_step(
+	[[maybe_unused]] float p_step,
+	[[maybe_unused]] JPH::Body& p_jolt_body
+) {
 	previous_jolt_shape = nullptr;
 }
 

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -112,9 +112,9 @@ public:
 
 	void set_ray_pickable(bool p_enabled) { ray_pickable = p_enabled; }
 
-	virtual void pre_step(float p_step);
+	virtual void pre_step(float p_step, JPH::Body& p_jolt_body);
 
-	virtual void post_step(float p_step);
+	virtual void post_step(float p_step, JPH::Body& p_jolt_body);
 
 	virtual bool generates_contacts() const = 0;
 

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -140,17 +140,21 @@ void JoltSpace3D::call_queries() {
 	const int32_t body_count = body_accessor.get_count();
 
 	for (int32_t i = 0; i < body_count; ++i) {
-		if (const JPH::Body* body = body_accessor.try_get(i)) {
-			if (!body->IsSensor()) {
-				reinterpret_cast<JoltBodyImpl3D*>(body->GetUserData())->call_queries();
+		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
+			if (!jolt_body->IsSensor()) {
+				auto* body = reinterpret_cast<JoltBodyImpl3D*>(jolt_body->GetUserData());
+
+				body->call_queries(*jolt_body);
 			}
 		}
 	}
 
 	for (int32_t i = 0; i < body_count; ++i) {
-		if (const JPH::Body* body = body_accessor.try_get(i)) {
-			if (body->IsSensor()) {
-				reinterpret_cast<JoltAreaImpl3D*>(body->GetUserData())->call_queries();
+		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
+			if (jolt_body->IsSensor()) {
+				auto* area = reinterpret_cast<JoltAreaImpl3D*>(jolt_body->GetUserData());
+
+				area->call_queries(*jolt_body);
 			}
 		}
 	}
@@ -400,10 +404,10 @@ void JoltSpace3D::pre_step(float p_step) {
 	const int32_t body_count = body_accessor.get_count();
 
 	for (int32_t i = 0; i < body_count; ++i) {
-		if (const JPH::Body* jolt_body = body_accessor.try_get(i)) {
+		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
 			auto* object = reinterpret_cast<JoltObjectImpl3D*>(jolt_body->GetUserData());
 
-			object->pre_step(p_step);
+			object->pre_step(p_step, *jolt_body);
 
 			if (object->generates_contacts()) {
 				contact_listener->listen_for(object);
@@ -422,10 +426,10 @@ void JoltSpace3D::post_step(float p_step) {
 	const int32_t body_count = body_accessor.get_count();
 
 	for (int32_t i = 0; i < body_count; ++i) {
-		if (const JPH::Body* jolt_body = body_accessor.try_get(i)) {
+		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
 			auto* object = reinterpret_cast<JoltObjectImpl3D*>(jolt_body->GetUserData());
 
-			object->post_step(p_step);
+			object->post_step(p_step, *jolt_body);
 		}
 	}
 


### PR DESCRIPTION
I figured since we've already gone through the trouble of getting the Jolt body in methods like `JoltSpace3D::call_queries`, `JoltSpace3D::pre_step` and `JoltSpace3D::post_step` we might as well pass them on to the functions they're calling as well, which might help with performance a tiny bit. If nothing else it looks a bit cleaner.