### PR TITLE
Fixed some regressions with kinematic bodies

### DIFF
--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -167,6 +167,8 @@ public:
 
 	void pre_step(float p_step, JPH::Body& p_jolt_body) override;
 
+	void move_kinematic(float p_step, JPH::Body& p_jolt_body);
+
 	JoltPhysicsDirectBodyState3D* get_direct_state();
 
 	PhysicsServer3D::BodyMode get_mode() const { return mode; }
@@ -253,6 +255,8 @@ private:
 	void update_mass_properties(bool p_lock = true);
 
 	void update_damp(bool p_lock = true);
+
+	void update_kinematic_transform(bool p_lock = true);
 
 	void update_group_filter(bool p_lock = true);
 


### PR DESCRIPTION
Complements #434 and #436.

The above mentioned changes introduced a couple of minor regressions.

The first regression being that #434 didn't update `kinematic_transform` when changing modes, so when a body would freeze into kinematic mode it would move back to wherever it was last in kinematic mode, which in the case of the first freeze would typically be `(0, 0, 0)`.

The second regression being that #436 didn't set `sync_state` to `true` in the correct place for kinematic bodies, leading to kinematic movements happening in `_process` to snap back to wherever they were previously.

The first regression is fixed in this PR by updating the `kinematic_transform` whenever a change to kinematic mode happens.

The second regression is fixed in this PR by instead comparing the previous and current kinematic transforms within `pre_step` to see whether a move is necessary, and then move and set `sync_state` accordingly there instead.