### PR TITLE
Fixed kinematic bodies not starting with correct transform

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1056,7 +1056,9 @@ void JoltBodyImpl3D::create_in_space() {
 void JoltBodyImpl3D::apply_transform(const Transform3D& p_transform, bool p_lock) {
 	if (is_kinematic()) {
 		kinematic_transform = p_transform;
-	} else {
+	}
+
+	if (!is_kinematic() || space == nullptr) {
 		JoltObjectImpl3D::apply_transform(p_transform, p_lock);
 	}
 }

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -113,13 +113,6 @@ void JoltObjectImpl3D::set_transform(Transform3D p_transform, bool p_lock) {
 		shapes_changed(p_lock);
 	}
 
-	if (space == nullptr) {
-		jolt_settings->mPosition = to_jolt(p_transform.origin);
-		jolt_settings->mRotation = to_jolt(p_transform.basis);
-		transform_changed(p_lock);
-		return;
-	}
-
 	apply_transform(p_transform);
 
 	transform_changed(p_lock);
@@ -426,6 +419,12 @@ void JoltObjectImpl3D::destroy_in_space(bool p_lock) {
 }
 
 void JoltObjectImpl3D::apply_transform(const Transform3D& p_transform, bool p_lock) {
+	if (space == nullptr) {
+		jolt_settings->mPosition = to_jolt(p_transform.origin);
+		jolt_settings->mRotation = to_jolt(p_transform.basis);
+		return;
+	}
+
 	space->get_body_iface(p_lock).SetPositionAndRotation(
 		jolt_id,
 		to_jolt(p_transform.origin),


### PR DESCRIPTION
This is another regression with kinematic bodies, caused by #434, where the initial transform for kinematic bodies wasn't correct, because `kinematic_transform` wasn't being updated by transform changes that happened before the body entered the space.