### PR TITLE
Fixed broken LOD levels in debug renderer

### DIFF
--- a/src/spaces/jolt_debug_renderer_3d.cpp
+++ b/src/spaces/jolt_debug_renderer_3d.cpp
@@ -237,6 +237,7 @@ void JoltDebugRenderer3D::DrawGeometry(
 		const float lod_distance_sq = lod.mDistance * lod.mDistance;
 		if (camera_distance_sq <= lod_distance_sq * p_lod_scale_sq) {
 			model_lod = &lod;
+			break;
 		}
 	}
 


### PR DESCRIPTION
This fixes a long-standing issue where `JoltDebugGeometry3D` would always use the lowest-detailed LOD for the various triangle meshes that it makes use of, like spheres, cylinders, etc.