### PR TITLE
Fixed issues related to reference frame shifting for joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where bodies would transform in unintuitive ways when attached to a joint that was
+  itself rotated.
+- Fixed issue where bodies would sometimes transform in unintuitive ways when attached to a
+  `Generic6DOFJoint` that used both linear and angular limits.
+
 ## [0.2.2] - 2023-06-09
 
 ### Fixed

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -425,14 +425,14 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 			// result in a negative span then the axis becomes unbounded.
 			constraint_settings.MakeFreeAxis((JoltAxis)axis);
 		} else {
-			const double middle = Math::lerp(lower, upper, 0.5);
+			const double midpoint = (lower + upper) / 2.0f;
 
-			ref_shift[axis] = (float)-middle;
+			ref_shift[axis] = (float)-midpoint;
 
 			if (Math::is_equal_approx(lower, upper)) {
 				constraint_settings.MakeFixedAxis((JoltAxis)axis);
 			} else {
-				const auto extent = (float)Math::abs(middle - lower);
+				const auto extent = float(upper - midpoint);
 				constraint_settings.SetLimitedAxis((JoltAxis)axis, -extent, extent);
 			}
 		}

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -184,13 +184,13 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 		constraint_settings.mLimitsMin = -JPH::JPH_PI;
 		constraint_settings.mLimitsMax = JPH::JPH_PI;
 	} else {
-		const double limit_middle = Math::lerp(limit_lower, limit_upper, 0.5);
+		const double limit_midpoint = (limit_lower + limit_upper) / 2.0f;
 
-		axis_shift = (float)-limit_middle;
+		axis_shift = (float)-limit_midpoint;
 
-		const auto extent = (float)Math::abs(limit_middle - limit_lower);
-		constraint_settings.mLimitsMin = -extent;
-		constraint_settings.mLimitsMax = extent;
+		const auto limit_extent = float(limit_upper - limit_midpoint);
+		constraint_settings.mLimitsMin = -limit_extent;
+		constraint_settings.mLimitsMax = limit_extent;
 	}
 
 	Transform3D shifted_ref_a;
@@ -198,7 +198,7 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 
 	shift_reference_frames(
 		Vector3(),
-		Vector3(0.0f, axis_shift, 0.0f),
+		Vector3(0.0f, 0.0f, axis_shift),
 		shifted_ref_a,
 		shifted_ref_b
 	);

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -123,8 +123,14 @@ void JoltJointImpl3D::shift_reference_frames(
 		origin_b -= to_godot(body_b->get_jolt_shape()->GetCenterOfMass());
 	}
 
-	p_shifted_ref_a = Transform3D(local_ref_a.basis.rotated(p_angular_shift), origin_a);
-	p_shifted_ref_b = Transform3D(local_ref_b.basis, origin_b + p_linear_shift);
+	const Basis& basis_a = local_ref_a.basis;
+	const Basis& basis_b = local_ref_b.basis;
+
+	const Basis shifted_basis_a = basis_a * Basis::from_euler(p_angular_shift);
+	const Vector3 shifted_origin_a = origin_a - basis_a.xform(p_linear_shift);
+
+	p_shifted_ref_a = Transform3D(shifted_basis_a, shifted_origin_a);
+	p_shifted_ref_b = Transform3D(basis_b, origin_b);
 }
 
 String JoltJointImpl3D::owners_to_string() const {

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -367,13 +367,13 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 		constraint_settings.mLimitsMin = -FLT_MAX;
 		constraint_settings.mLimitsMax = FLT_MAX;
 	} else {
-		const double limit_middle = Math::lerp(limit_lower, limit_upper, 0.5);
+		const double limit_midpoint = (limit_lower + limit_upper) / 2.0f;
 
-		axis_shift = (float)-limit_middle;
+		axis_shift = (float)-limit_midpoint;
 
-		const auto extent = (float)Math::abs(limit_middle - limit_lower);
-		constraint_settings.mLimitsMin = -extent;
-		constraint_settings.mLimitsMax = extent;
+		const auto limit_extent = float(limit_upper - limit_midpoint);
+		constraint_settings.mLimitsMin = -limit_extent;
+		constraint_settings.mLimitsMax = limit_extent;
 	}
 
 	Transform3D shifted_ref_a;


### PR DESCRIPTION
Related to #418, #424 and #425.

This PR fixes a multitude of issues related to the shifting of reference frames for joints, which is done to accommodate for Godot's much more flexible joint limits.