### PR TITLE
Changed rotation lock to utilize infinite inertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Breaking changes are denoted with ⚠️.
   `Generic6DOFJoint` that used both linear and angular limits.
 - Fixed issue where setting the limits of a `SliderJoint3D` to the same value would make it free
   instead of fixed.
+- Fixed issue where you could still rotate a `RigidBody3D` slightly when using `lock_rotation`.
 
 ## [0.2.2] - 2023-06-09
 


### PR DESCRIPTION
Related to #443.

This PR changes the "Lock Rotation" property on `RigidBody3D` to utilize infinite inertia, like Godot Physics does, instead of using the same 6DOF constraint that's used for axis-locking. This seems to completely eliminate the ability to "budge" the lock.

This trick doesn't seem applicable to axis-locks though, since they need to lock you in world-space whereas this inertia trick locks you in local-space.