### PR TITLE
Updated Jolt to b40883585c

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 8d3008e21baff6ce774b821adc73618bb3b891af
+	GIT_COMMIT b40883585c503a8eb7c9eb85fa923a964f8a314f
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
Fixes #443.

This bumps Jolt from godot-jolt/jolt@8d3008e21baff6ce774b821adc73618bb3b891af to godot-jolt/jolt@b40883585c503a8eb7c9eb85fa923a964f8a314f (see diff [here](https://github.com/godot-jolt/jolt/compare/8d3008e21baff6ce774b821adc73618bb3b891af...b40883585c503a8eb7c9eb85fa923a964f8a314f)).

This brings in the following relevant changes:

- Springs for 6DOF constraints
- Soft limits for hinge and 6DOF constraints
- Bugfix in friction approximation (needed for [#443](https://github.com/godot-jolt/godot-jolt/issues/443))