### PR TITLE
Added project setting for disabling shape margins entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Added
+
+- Added new project setting, "Use Shape Margins", to allow for globally setting shape margins to 0.
+
 ## [0.2.3] - 2023-06-16
 
 ### Fixed

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -188,6 +188,20 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>-</td>
     </tr>
     <tr>
+      <td>Collisions</td>
+      <td>Use Shape Margins</td>
+      <td>
+        Whether or not the <code>margin</code> property on <code>Shape3D</code> should be respected
+        for the applicable convex shape types.
+      </td>
+      <td>
+        When disabled this will force a shape margin of 0, trading in performance for accuracy,
+        which can make things like collision normals more intuitive.
+        <br><br>This only applies to <code>BoxShape3D</code>, <code>CylinderShape3D</code> and
+        <code>ConvexPolygonShape3D</code>. Other shape types do not utilize margins.
+      </td>
+    </tr>
+    <tr>
       <td>Continuous CD</td>
       <td>Movement Threshold</td>
       <td>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -6,6 +6,8 @@ constexpr char SLEEP_ENABLED[] = "physics/jolt_3d/sleep/enabled";
 constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_threshold";
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
+constexpr char USE_SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
+
 constexpr char CCD_MOVEMENT_THRESHOLD[] = "physics/jolt_3d/continuous_cd/movement_threshold";
 constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetration";
 
@@ -114,6 +116,8 @@ void JoltProjectSettings::register_settings() {
 	register_setting_hinted(SLEEP_VELOCITY_THRESHOLD, 0.03f, U"suffix:m/s");
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
+	register_setting_plain(USE_SHAPE_MARGINS, true, true);
+
 	register_setting_ranged(CCD_MOVEMENT_THRESHOLD, 75.0f, U"0,100,0.1,suffix:%");
 	register_setting_ranged(CCD_MAX_PENETRATION, 25.0f, U"0,100,0.1,suffix:%");
 
@@ -147,6 +151,11 @@ float JoltProjectSettings::get_sleep_velocity_threshold() {
 
 float JoltProjectSettings::get_sleep_time_threshold() {
 	static const auto value = get_setting<float>(SLEEP_TIME_THRESHOLD);
+	return value;
+}
+
+bool JoltProjectSettings::use_shape_margins() {
+	static const auto value = get_setting<bool>(USE_SHAPE_MARGINS);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -10,6 +10,8 @@ public:
 
 	static float get_sleep_time_threshold();
 
+	static bool use_shape_margins();
+
 	static float get_ccd_movement_threshold();
 
 	static float get_ccd_max_penetration();

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -1,5 +1,7 @@
 #include "jolt_box_shape_impl_3d.hpp"
 
+#include "servers/jolt_project_settings.hpp"
+
 namespace {
 
 constexpr float MARGIN_FACTOR = 0.08f;
@@ -39,8 +41,9 @@ String JoltBoxShapeImpl3D::to_string() const {
 JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
 	const float min_half_extent = half_extents[half_extents.min_axis_index()];
 	const float shrunk_margin = min(margin, min_half_extent * MARGIN_FACTOR);
+	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
 
-	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), shrunk_margin);
+	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -1,5 +1,7 @@
 #include "jolt_convex_polygon_shape_impl_3d.hpp"
 
+#include "servers/jolt_project_settings.hpp"
+
 Variant JoltConvexPolygonShapeImpl3D::get_data() const {
 	return vertices;
 }
@@ -54,7 +56,9 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 		jolt_vertices.emplace_back(vertex->x, vertex->y, vertex->z);
 	}
 
-	const JPH::ConvexHullShapeSettings shape_settings(jolt_vertices, margin);
+	const float actual_margin = JoltProjectSettings::use_shape_margins() ? margin : 0.0f;
+
+	const JPH::ConvexHullShapeSettings shape_settings(jolt_vertices, actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -1,5 +1,7 @@
 #include "jolt_cylinder_shape_impl_3d.hpp"
 
+#include "servers/jolt_project_settings.hpp"
+
 namespace {
 
 constexpr float MARGIN_FACTOR = 0.08f;
@@ -51,8 +53,9 @@ String JoltCylinderShapeImpl3D::to_string() const {
 JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
 	const float half_height = height / 2.0f;
 	const float shrunk_margin = min(margin, half_height * MARGIN_FACTOR, radius * MARGIN_FACTOR);
+	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
 
-	const JPH::CylinderShapeSettings shape_settings(half_height, radius, shrunk_margin);
+	const JPH::CylinderShapeSettings shape_settings(half_height, radius, actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(


### PR DESCRIPTION
This introduces a new project setting, `physics/jolt_3d/collisions/use_shape_margins`, which allows you to disable shape margins entirely, trading in performance for accuracy, thereby making things like collision normals on `BoxShape3D`, `CylinderShape3D` and `ConvexPolygonShape3D` more intuitive.