### PR TITLE
Fixed kinematic bodies not being able to monitor contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Breaking changes are denoted with ⚠️.
 
 - Added new project setting, "Use Shape Margins", to allow for globally setting shape margins to 0.
 
+### Fixed
+
+- Fixed issue where a `RigidBody3D` frozen with the "Kinematic" freeze mode wouldn't have its
+  `_integrate_forces` method called when monitoring contacts.
+
 ## [0.2.3] - 2023-06-16
 
 ### Fixed

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -246,6 +246,12 @@ private:
 
 	void create_in_space() override;
 
+	void pre_step_static(float p_step, JPH::Body& p_jolt_body);
+
+	void pre_step_rigid(float p_step, JPH::Body& p_jolt_body);
+
+	void pre_step_kinematic(float p_step, JPH::Body& p_jolt_body);
+
 	void apply_transform(const Transform3D& p_transform, bool p_lock = true) override;
 
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;


### PR DESCRIPTION
Apparently Godot Physics allow kinematic bodies to have their `_integrate_forces` method invoked on every tick if it uses contact monitoring with a non-zero amount of contacts.

This PR brings Godot Jolt up-to-speed with that.