### PR TITLE
Updated Jolt to 31a4fb3d5b

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT b40883585c503a8eb7c9eb85fa923a964f8a314f
+	GIT_COMMIT 31a4fb3d5bd82cb11f3db9775ed828083d454782
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@b40883585c503a8eb7c9eb85fa923a964f8a314f to godot-jolt/jolt@31a4fb3d5bd82cb11f3db9775ed828083d454782 (see diff [here](https://github.com/godot-jolt/jolt/compare/b40883585c503a8eb7c9eb85fa923a964f8a314f...31a4fb3d5bd82cb11f3db9775ed828083d454782)).

This brings in the following relevant changes:

- Ability to override mass and inertia from `JPH::ContactListener` (needed for [#400](https://github.com/godot-jolt/godot-jolt/issues/400))