### PR TITLE
Added collision response override for asymmetrical collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed collision layers/masks to behave like they do in Godot Physics, which allows for
+  asymmetrical collisions.
+
 ### Added
 
 - Added new project setting, "Use Shape Margins", to allow for globally setting shape margins to 0.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ should not be relied upon if determinism is a hard requirement.
 
 ## What else is different?
 
-- Collision layers/masks behave like they did in Godot 3, meaning no asymmetrical collisions
 - Ray-casts will hit the back-faces of all shape types, not just concave polygons and height maps
 - Shape-casts should be more accurate, but their cost also scale with the cast distance
 - Shape margins are used, but are treated as an upper bound and scale with the shape's extents

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -106,6 +106,12 @@ private:
 
 	void flush_area_exits();
 
+	void override_collision_response(
+		const JPH::Body& p_body1,
+		const JPH::Body& p_body2,
+		JPH::ContactSettings& p_settings
+	);
+
 	void apply_surface_velocities(
 		const JPH::Body& p_body1,
 		const JPH::Body& p_body2,


### PR DESCRIPTION
Fixes #400.

This changes collision layers/masks to behave less like they did in Godot 3 and more like they do in Godot 4, where having an asymmetric layer/mask setup will result in the body whose mask does not contain the layer of the other body effectively having infinite inertia/mass in the context of that collision.