### PR TITLE
Updated Jolt to c24af412ff

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 31a4fb3d5bd82cb11f3db9775ed828083d454782
+	GIT_COMMIT c24af412ff419c567b30ff96f6f77d85e88f5876
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@31a4fb3d5bd82cb11f3db9775ed828083d454782 to godot-jolt/jolt@c24af412ff419c567b30ff96f6f77d85e88f5876 (see diff [here](https://github.com/godot-jolt/jolt/compare/31a4fb3d5bd82cb11f3db9775ed828083d454782...c24af412ff419c567b30ff96f6f77d85e88f5876)).

This brings in the following relevant changes:

- Sensors can now detect static bodies through body flag `SensorDetectsStatic` (needed for [#391](https://github.com/godot-jolt/godot-jolt/issues/391) and [#397](https://github.com/godot-jolt/godot-jolt/issues/397))