### PR TITLE
Updated Jolt to 99bf29c110

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT c24af412ff419c567b30ff96f6f77d85e88f5876
+	GIT_COMMIT 99bf29c110b6bda786f3252b3dc74b5ef66c4588
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@c24af412ff419c567b30ff96f6f77d85e88f5876 to godot-jolt/jolt@99bf29c110b6bda786f3252b3dc74b5ef66c4588 (see diff [here](https://github.com/godot-jolt/jolt/compare/c24af412ff419c567b30ff96f6f77d85e88f5876...99bf29c110b6bda786f3252b3dc74b5ef66c4588)).

This brings in the following relevant changes:

- `JPH::HeightFieldShape` now registers collision functions for convex shapes (needed for [#391](https://github.com/godot-jolt/godot-jolt/issues/391) and [#397](https://github.com/godot-jolt/godot-jolt/issues/397))