### PR TITLE
Added support for areas detecting static bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Breaking changes are denoted with ⚠️.
 ### Added
 
 - Added new project setting, "Use Shape Margins", to allow for globally setting shape margins to 0.
+- Added new project setting, "Areas Detect Static Bodies", to allow `Area3D` to detect overlaps with
+  `StaticBody3D`, as well as `RigidBody3D` frozen with the "Static" freeze mode, with a potentially
+  heavy performance/memory cost.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ should not be relied upon if determinism is a hard requirement.
 - Joints do not support springs or soft limits (yet)
 - `SoftBody3D` is not supported
 - `WorldBoundaryShape3D` is not supported
-- `Area3D` is not able to detect overlaps with static bodies, including the static freeze mode (yet)
 - The physics server is not thread-safe (yet)
 - Double-precision builds of Godot are not supported (yet)
 - Memory usage is not reflected in Godot's performance monitors (yet)
 
 ## What else is different?
 
+- `Area3D` detecting static bodies is opt-in, with a potentially [heavy performance/memory
+  cost][jst]
 - Ray-casts will hit the back-faces of all shape types, not just concave polygons and height maps
 - Shape-casts should be more accurate, but their cost also scale with the cast distance
 - Shape margins are used, but are treated as an upper bound and scale with the shape's extents
@@ -131,6 +132,7 @@ Godot Jolt is distributed under the MIT license. See [`LICENSE.txt`][lic] for mo
 [log]: docs/logo.svg
 [god]: https://godotengine.org/
 [jlt]: https://github.com/jrouwe/JoltPhysics
+[jst]: docs/settings.md#jolt-3d
 [jdc]: https://jrouwe.github.io/JoltPhysics/
 [rls]: https://github.com/godot-jolt/godot-jolt/releases/latest
 [prj]: https://github.com/orgs/godot-jolt/projects/1

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -202,6 +202,21 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       </td>
     </tr>
     <tr>
+      <td>Collisions</td>
+      <td>Areas Detect Static Bodies</td>
+      <td>
+        Whether or not <code>Area3D</code> is able to detect overlaps with <code>StaticBody3D</code>
+        and <code>RigidBody3D</code> frozen with <code>FREEZE_MODE_STATIC</code>.
+      </td>
+      <td>
+        ⚠️ This can come at a heavy performance and memory cost if you allow many/large areas to
+        overlap with complex static geometry, such as <code>ConcavePolygonShape3D</code> or
+        <code>HeightMapShape3D</code>.
+        <br><br>It is strongly recommended that you set up your collision layers and masks in such a
+        way that only a few small <code>Area3D</code> can detect static bodies.
+      </td>
+    </tr>
+    <tr>
       <td>Continuous CD</td>
       <td>Movement Threshold</td>
       <td>

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -1,6 +1,7 @@
 #include "jolt_area_impl_3d.hpp"
 
 #include "objects/jolt_body_impl_3d.hpp"
+#include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
@@ -270,6 +271,10 @@ void JoltAreaImpl3D::create_in_space() {
 
 	jolt_settings->mIsSensor = true;
 	jolt_settings->mUseManifoldReduction = false;
+
+	if (JoltProjectSettings::areas_detect_static_bodies()) {
+		jolt_settings->mSensorDetectsStatic = true;
+	}
 
 	create_end();
 }

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -7,6 +7,7 @@ constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_thre
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
 constexpr char USE_SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
+constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_3d/collisions/areas_detect_static_bodies";
 
 constexpr char CCD_MOVEMENT_THRESHOLD[] = "physics/jolt_3d/continuous_cd/movement_threshold";
 constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetration";
@@ -117,6 +118,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
 	register_setting_plain(USE_SHAPE_MARGINS, true, true);
+	register_setting_plain(AREAS_DETECT_STATIC, false);
 
 	register_setting_ranged(CCD_MOVEMENT_THRESHOLD, 75.0f, U"0,100,0.1,suffix:%");
 	register_setting_ranged(CCD_MAX_PENETRATION, 25.0f, U"0,100,0.1,suffix:%");
@@ -156,6 +158,11 @@ float JoltProjectSettings::get_sleep_time_threshold() {
 
 bool JoltProjectSettings::use_shape_margins() {
 	static const auto value = get_setting<bool>(USE_SHAPE_MARGINS);
+	return value;
+}
+
+bool JoltProjectSettings::areas_detect_static_bodies() {
+	static const auto value = get_setting<bool>(AREAS_DETECT_STATIC);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -12,6 +12,8 @@ public:
 
 	static bool use_shape_margins();
 
+	static bool areas_detect_static_bodies();
+
 	static float get_ccd_movement_threshold();
 
 	static float get_ccd_max_penetration();

--- a/src/spaces/jolt_layer_mapper.cpp
+++ b/src/spaces/jolt_layer_mapper.cpp
@@ -1,5 +1,6 @@
 #include "jolt_layer_mapper.hpp"
 
+#include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
 
 namespace {
@@ -10,7 +11,7 @@ class JoltBroadPhaseLayerTable {
 	using UnderlyingType = LayerType::Type;
 
 public:
-	constexpr JoltBroadPhaseLayerTable() {
+	JoltBroadPhaseLayerTable() {
 		using namespace JoltBroadPhaseLayer;
 
 		allow_collision(BODY_STATIC, BODY_DYNAMIC);
@@ -26,21 +27,28 @@ public:
 
 		allow_collision(AREA_UNDETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_UNDETECTABLE, AREA_DETECTABLE);
+
+		if (JoltProjectSettings::areas_detect_static_bodies()) {
+			allow_collision(BODY_STATIC, AREA_DETECTABLE);
+			allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
+			allow_collision(AREA_DETECTABLE, BODY_STATIC);
+			allow_collision(AREA_UNDETECTABLE, BODY_STATIC);
+		}
 	}
 
-	constexpr void allow_collision(UnderlyingType p_layer1, UnderlyingType p_layer2) {
+	void allow_collision(UnderlyingType p_layer1, UnderlyingType p_layer2) {
 		table[p_layer1][p_layer2] = true;
 	}
 
-	constexpr void allow_collision(LayerType p_layer1, LayerType p_layer2) {
+	void allow_collision(LayerType p_layer1, LayerType p_layer2) {
 		allow_collision((UnderlyingType)p_layer1, (UnderlyingType)p_layer2);
 	}
 
-	constexpr bool should_collide(UnderlyingType p_layer1, UnderlyingType p_layer2) const {
+	bool should_collide(UnderlyingType p_layer1, UnderlyingType p_layer2) const {
 		return table[p_layer1][p_layer2];
 	}
 
-	constexpr bool should_collide(LayerType p_layer1, LayerType p_layer2) const {
+	bool should_collide(LayerType p_layer1, LayerType p_layer2) const {
 		return should_collide((UnderlyingType)p_layer1, (UnderlyingType)p_layer2);
 	}
 
@@ -194,7 +202,7 @@ bool JoltLayerMapper::ShouldCollide(
 	JPH::ObjectLayer p_encoded_layer1,
 	JPH::BroadPhaseLayer p_broad_phase_layer2
 ) const {
-	static constexpr JoltBroadPhaseLayerTable table;
+	static const JoltBroadPhaseLayerTable table;
 
 	JPH::BroadPhaseLayer broad_phase_layer1 = {};
 	JPH::ObjectLayer object_layer1 = 0;


### PR DESCRIPTION
Fixes #391.
Fixes #397.

This adds the project setting `physics/jolt_3d/collisions/areas_detect_static_bodies` to allow `Area3D` to detect overlaps with `StaticBody3D`, as well as bodies frozen with `FREEZE_MODE_STATIC`, with a potentially heavy performance/memory cost.