### PR TITLE
Fixed kinematic bodies reporting zero velocity in collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where a `RigidBody3D` frozen with the "Kinematic" freeze mode wouldn't have its
   `_integrate_forces` method called when monitoring contacts.
 - Fixed issue where scaling bodies/shapes with negative values would break them in various ways.
+- Fixed issue where kinematic bodies would always report a zero velocity from collisions performed
+  in `_physics_process`.
 
 ## [0.2.3] - 2023-06-16
 


### PR DESCRIPTION
Complements #434.

This fixes an issue where things like `get_platform_velocity` on `CharacterBody3D` would always report a zero velocity.

`get_platform_velocity` relies on kinematic bodies having an up-to-date velocity when you call `move_and_slide`, which you'd normally do in `_physics_process`, since it fetches the kinematic body's velocity from the collision data. Until now I had been clearing the velocity right after the state synchronization (and `_integrate_forces`), which meant the velocities would be zeroed out during `_physics_process`. This changes the zeroing out to happen as part of `pre_step` instead.