### PR TITLE
Changed `cast_motion` to return results even when no hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed the `cast_motion` method in `PhysicsDirectSpaceState3D` to return `[1.0, 1.0]` when no
+  collision was detected, to match Godot Physics.
+
 ## [0.3.0] - 2023-06-28
 
 ### Changed

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -227,7 +227,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	return cast_motion(
+	cast_motion(
 		*jolt_shape,
 		transform_com,
 		scale,
@@ -241,6 +241,8 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 		*p_closest_safe,
 		*p_closest_unsafe
 	);
+
+	return true;
 }
 
 bool JoltPhysicsDirectSpaceState3D::_collide_shape(


### PR DESCRIPTION
This changes the `cast_motion` method in `PhysicsDirectSpaceState3D` to return `[1.0, 1.0]` when no collision was detected, to match Godot Physics.