### PR TITLE
Allowed for out-of-bounds access with body accessors

### DIFF
--- a/src/spaces/jolt_body_accessor_3d.cpp
+++ b/src/spaces/jolt_body_accessor_3d.cpp
@@ -119,13 +119,13 @@ JoltBodyReader3D::JoltBodyReader3D(const JoltSpace3D* p_space)
 	: JoltBodyAccessor3D(p_space) { }
 
 const JPH::Body* JoltBodyReader3D::try_get(const JPH::BodyID& p_id) const {
-	ERR_FAIL_COND_D(p_id.IsInvalid());
+	QUIET_FAIL_COND_D(p_id.IsInvalid());
 	ERR_FAIL_COND_D(not_acquired());
 	return lock_iface->TryGetBody(p_id);
 }
 
 const JPH::Body* JoltBodyReader3D::try_get(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, get_count());
+	QUIET_FAIL_INDEX_D(p_index, get_count());
 	return try_get(get_at(p_index));
 }
 
@@ -147,13 +147,13 @@ JoltBodyWriter3D::JoltBodyWriter3D(const JoltSpace3D* p_space)
 	: JoltBodyAccessor3D(p_space) { }
 
 JPH::Body* JoltBodyWriter3D::try_get(const JPH::BodyID& p_id) const {
-	ERR_FAIL_COND_D(p_id.IsInvalid());
+	QUIET_FAIL_COND_D(p_id.IsInvalid());
 	ERR_FAIL_COND_D(not_acquired());
 	return lock_iface->TryGetBody(p_id);
 }
 
 JPH::Body* JoltBodyWriter3D::try_get(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, get_count());
+	QUIET_FAIL_INDEX_D(p_index, get_count());
 	return try_get(get_at(p_index));
 }
 

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -119,6 +119,8 @@ public:
 
 	const JoltSpace3D& get_space() const { return inner.get_space(); }
 
+	int32_t get_count() const { return inner.get_count(); }
+
 	const JPH::BodyID& get_at(int32_t p_index) const { return inner.get_at(p_index); }
 
 	~JoltScopedBodyAccessor3D() { inner.release(); }
@@ -196,7 +198,11 @@ public:
 		: accessor(p_space, p_ids, p_id_count, p_lock) { }
 
 	JoltAccessibleBody3D<TAccessor, TBody> operator[](int32_t p_index) const {
-		return {accessor.get_space(), accessor.get_at(p_index), false};
+		const JPH::BodyID& body_id = p_index < accessor.get_count()
+			? accessor.get_at(p_index)
+			: JPH::BodyID();
+
+		return {accessor.get_space(), body_id, false};
 	}
 
 private:


### PR DESCRIPTION
Currently the multi-body accessors (`JoltAccessibleBodies3D`) behaves like `LocalVector`, where you'll crash if you try to access an index that's out-of-bounds. This makes certain scenarios needlessly complicated, since we usually end up testing the returned body pointers for null anyway.

This PR addresses this by allowing for out-of-bounds access in `JoltAccessibleBodies3D`, and in those cases have it return a body accessor containing an invalid `JPH::BodyID`, which in turn will produce a null `JPH::Body*`.