### PR TITLE
Refactored joints to allow different backing constraints

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -27,6 +27,15 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	static JPH::Constraint* build_swing_twist(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b,
+		float p_swing_limit,
+		float p_twist_limit
+	);
+
 	void limits_changed(bool p_lock = true);
 
 	double swing_span = 0.0;

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -405,36 +405,30 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count, p_lock);
 
-	JPH::SixDOFConstraintSettings constraint_settings;
+	auto* jolt_body_a = static_cast<JPH::Body*>(jolt_bodies[0]);
+	ERR_FAIL_COND(jolt_body_a == nullptr);
+
+	auto* jolt_body_b = static_cast<JPH::Body*>(jolt_bodies[1]);
+	ERR_FAIL_COND(jolt_body_b == nullptr && body_count == 2);
 
 	float ref_shift[AXIS_COUNT] = {};
+	float limits[AXIS_COUNT] = {FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX};
 
 	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
 		if (!use_limits[axis]) {
-			constraint_settings.MakeFreeAxis((JoltAxis)axis);
 			continue;
 		}
 
 		const double lower = limit_lower[axis];
 		const double upper = limit_upper[axis];
 
-		if (lower > upper) {
-			// HACK(mihe): This seems to emulate the behavior of Godot Physics, where if the limits
-			// result in a negative span then the axis becomes unbounded.
-			constraint_settings.MakeFreeAxis((JoltAxis)axis);
-		} else {
+		if (lower <= upper) {
 			const double midpoint = (lower + upper) / 2.0f;
 
-			ref_shift[axis] = (float)-midpoint;
-
-			if (Math::is_equal_approx(lower, upper)) {
-				constraint_settings.MakeFixedAxis((JoltAxis)axis);
-			} else {
-				const auto extent = float(upper - midpoint);
-				constraint_settings.SetLimitedAxis((JoltAxis)axis, -extent, extent);
-			}
+			ref_shift[axis] = float(-midpoint);
+			limits[axis] = float(upper - midpoint);
 		}
 	}
 
@@ -453,28 +447,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 
 	shift_reference_frames(linear_shift, angular_shift, shifted_ref_a, shifted_ref_b);
 
-	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPosition1 = to_jolt(shifted_ref_a.origin);
-	constraint_settings.mAxisX1 = to_jolt(shifted_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mAxisY1 = to_jolt(shifted_ref_a.basis.get_column(Vector3::AXIS_Y));
-	constraint_settings.mPosition2 = to_jolt(shifted_ref_b.origin);
-	constraint_settings.mAxisX2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mAxisY2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
-
-	if (body_b != nullptr) {
-		const JoltWritableBody3D jolt_body_a = bodies[0];
-		ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-		const JoltWritableBody3D jolt_body_b = bodies[1];
-		ERR_FAIL_COND(jolt_body_b.is_invalid());
-
-		jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
-	} else {
-		const JoltWritableBody3D jolt_body_a = bodies[0];
-		ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-		jolt_ref = constraint_settings.Create(*jolt_body_a, JPH::Body::sFixedToWorld);
-	}
+	jolt_ref = build_6dof(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b, limits);
 
 	space->add_joint(this);
 
@@ -482,6 +455,42 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 		update_motor_state(axis);
 		update_motor_velocity(axis);
 		update_motor_limit(axis);
+	}
+}
+
+JPH::Constraint* JoltGeneric6DOFJointImpl3D::build_6dof(
+	JPH::Body* p_jolt_body_a,
+	JPH::Body* p_jolt_body_b,
+	const Transform3D& p_shifted_ref_a,
+	const Transform3D& p_shifted_ref_b,
+	const float p_limits[AXIS_COUNT]
+) {
+	JPH::SixDOFConstraintSettings constraint_settings;
+
+	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
+		const float limit = p_limits[axis];
+
+		if (limit == 0.0f) {
+			constraint_settings.MakeFixedAxis((JoltAxis)axis);
+		} else if (limit == FLT_MAX) {
+			constraint_settings.MakeFreeAxis((JoltAxis)axis);
+		} else {
+			constraint_settings.SetLimitedAxis((JoltAxis)axis, -limit, limit);
+		}
+	}
+
+	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
+	constraint_settings.mPosition1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mAxisX1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mAxisY1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Y));
+	constraint_settings.mPosition2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mAxisX2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mAxisY2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
+
+	if (p_jolt_body_b != nullptr) {
+		return constraint_settings.Create(*p_jolt_body_a, *p_jolt_body_b);
+	} else {
+		return constraint_settings.Create(*p_jolt_body_a, JPH::Body::sFixedToWorld);
 	}
 }
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -51,6 +51,14 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	static JPH::Constraint* build_6dof(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b,
+		const float p_limits[AXIS_COUNT]
+	);
+
 	void update_motor_state(int32_t p_axis);
 
 	void update_motor_velocity(int32_t p_axis);

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -174,23 +174,22 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count, p_lock);
 
-	JPH::HingeConstraintSettings constraint_settings;
+	auto* jolt_body_a = static_cast<JPH::Body*>(jolt_bodies[0]);
+	ERR_FAIL_COND(jolt_body_a == nullptr);
+
+	auto* jolt_body_b = static_cast<JPH::Body*>(jolt_bodies[1]);
+	ERR_FAIL_COND(jolt_body_b == nullptr && body_count == 2);
 
 	float axis_shift = 0.0f;
+	float limit = JPH::JPH_PI;
 
-	if (!use_limits || limit_lower > limit_upper) {
-		constraint_settings.mLimitsMin = -JPH::JPH_PI;
-		constraint_settings.mLimitsMax = JPH::JPH_PI;
-	} else {
+	if (use_limits && limit_lower <= limit_upper) {
 		const double limit_midpoint = (limit_lower + limit_upper) / 2.0f;
 
-		axis_shift = (float)-limit_midpoint;
-
-		const auto limit_extent = float(limit_upper - limit_midpoint);
-		constraint_settings.mLimitsMin = -limit_extent;
-		constraint_settings.mLimitsMax = limit_extent;
+		axis_shift = float(-limit_midpoint);
+		limit = float(limit_upper - limit_midpoint);
 	}
 
 	Transform3D shifted_ref_a;
@@ -203,27 +202,10 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 		shifted_ref_b
 	);
 
-	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = to_jolt(shifted_ref_a.origin);
-	constraint_settings.mHingeAxis1 = to_jolt(-shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mNormalAxis1 = to_jolt(shifted_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mPoint2 = to_jolt(shifted_ref_b.origin);
-	constraint_settings.mHingeAxis2 = to_jolt(-shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mNormalAxis2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_X));
-
-	if (body_b != nullptr) {
-		const JoltWritableBody3D jolt_body_a = bodies[0];
-		ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-		const JoltWritableBody3D jolt_body_b = bodies[1];
-		ERR_FAIL_COND(jolt_body_b.is_invalid());
-
-		jolt_ref = constraint_settings.Create(*jolt_body_a, *jolt_body_b);
+	if (limit_lower != limit_upper) {
+		jolt_ref = build_hinge(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b, limit);
 	} else {
-		const JoltWritableBody3D jolt_body_a = bodies[0];
-		ERR_FAIL_COND(jolt_body_a.is_invalid());
-
-		jolt_ref = constraint_settings.Create(*jolt_body_a, JPH::Body::sFixedToWorld);
+		jolt_ref = build_fixed(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
 	}
 
 	space->add_joint(this);
@@ -231,6 +213,56 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 	update_motor_state();
 	update_motor_velocity();
 	update_motor_limit();
+}
+
+JPH::Constraint* JoltHingeJointImpl3D::build_hinge(
+	JPH::Body* p_jolt_body_a,
+	JPH::Body* p_jolt_body_b,
+	const Transform3D& p_shifted_ref_a,
+	const Transform3D& p_shifted_ref_b,
+	float p_limit
+) {
+	JPH::HingeConstraintSettings constraint_settings;
+
+	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
+	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mHingeAxis1 = to_jolt(-p_shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mNormalAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mHingeAxis2 = to_jolt(-p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mNormalAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mLimitsMin = -p_limit;
+	constraint_settings.mLimitsMax = p_limit;
+
+	if (p_jolt_body_b != nullptr) {
+		return constraint_settings.Create(*p_jolt_body_a, *p_jolt_body_b);
+	} else {
+		return constraint_settings.Create(*p_jolt_body_a, JPH::Body::sFixedToWorld);
+	}
+}
+
+JPH::Constraint* JoltHingeJointImpl3D::build_fixed(
+	JPH::Body* p_jolt_body_a,
+	JPH::Body* p_jolt_body_b,
+	const Transform3D& p_shifted_ref_a,
+	const Transform3D& p_shifted_ref_b
+) {
+	JPH::FixedConstraintSettings constraint_settings;
+
+	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
+	constraint_settings.mAutoDetectPoint = false;
+	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mAxisX1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mAxisY1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Y));
+	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mAxisX2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mAxisY2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
+
+	if (p_jolt_body_b != nullptr) {
+		return constraint_settings.Create(*p_jolt_body_a, *p_jolt_body_b);
+	} else {
+		return constraint_settings.Create(*p_jolt_body_a, JPH::Body::sFixedToWorld);
+	}
 }
 
 void JoltHingeJointImpl3D::update_motor_state() {

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -27,6 +27,21 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	static JPH::Constraint* build_hinge(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b,
+		float p_limit
+	);
+
+	static JPH::Constraint* build_fixed(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b
+	);
+
 	void update_motor_state();
 
 	void update_motor_velocity();

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -32,5 +32,12 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	static JPH::Constraint* build_pin(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b
+	);
+
 	void points_changed(bool p_lock = true);
 };

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -23,6 +23,21 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
+	static JPH::Constraint* build_slider(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b,
+		float p_limit
+	);
+
+	static JPH::Constraint* build_fixed(
+		JPH::Body* p_jolt_body_a,
+		JPH::Body* p_jolt_body_b,
+		const Transform3D& p_shifted_ref_a,
+		const Transform3D& p_shifted_ref_b
+	);
+
 	void limits_changed(bool p_lock = true);
 
 	double limit_upper = 0.0;

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -80,6 +80,7 @@
 #include <Jolt/Physics/Collision/Shape/ScaledShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
 #include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
+#include <Jolt/Physics/Constraints/FixedConstraint.h>
 #include <Jolt/Physics/Constraints/HingeConstraint.h>
 #include <Jolt/Physics/Constraints/PointConstraint.h>
 #include <Jolt/Physics/Constraints/SixDOFConstraint.h>


### PR DESCRIPTION
Stems from #446.

This changes `SliderJoint3D` and `HingeJoint3D` to use `JPH::FixedConstraint` as the backing constraint when their lower and upper limits are the same. This helps silence some asserts from within Jolt, that can arise as the joints are being initialized, about how sliders/hinges with fixed limits are better suited as a `FixedConstraint`.

I also refactored the other joints to rebuild themselves in a similar manner, even if they only have one backing constraint, for the sake of consistency.