### PR TITLE
Added proper support for angular surface velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Breaking changes are denoted with ⚠️.
 - ⚠️ Changed the `cast_motion` method in `PhysicsDirectSpaceState3D` to return `[1.0, 1.0]` when no
   collision was detected, to match Godot Physics.
 
+### Fixed
+
+- Fixed issue where angular surface velocities (like `constant_angular_velocity` on `StaticBody3D`)
+  wouldn't be applied as expected if the imparted upon body was placed across the imparting body's
+  center of mass.
+
 ## [0.3.0] - 2023-06-28
 
 ### Changed

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -113,9 +113,8 @@ private:
 	);
 
 	void apply_surface_velocities(
-		const JPH::Body& p_body1,
-		const JPH::Body& p_body2,
-		const JPH::ContactManifold& p_manifold,
+		const JPH::Body& p_jolt_body1,
+		const JPH::Body& p_jolt_body2,
 		JPH::ContactSettings& p_settings
 	);
 


### PR DESCRIPTION
Improves upon #331.

This replaces the current not-so-accurate implementation of angular surface velocities (such as `constant_angular_velocity`), which worked by applying the angular velocity through Jolt's `mRelativeSurfaceVelocity` mechanism, to now instead use Jolt's new `mRelativeAngularSurfaceVelocity` mechanism.

This allows for having bodies that span across the center-of-mass of the "rotating" body and still have them be affected as you'd expect.