### PR TITLE
Fixed `center_of_mass_mode` not always applying properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where angular surface velocities (like `constant_angular_velocity` on `StaticBody3D`)
   wouldn't be applied as expected if the imparted upon body was placed across the imparting body's
   center of mass.
+- Fixed issue where going from `CENTER_OF_MASS_MODE_CUSTOM` to `CENTER_OF_MASS_MODE_AUTO` wouldn't
+  actually reset the body's center-of-mass.
 
 ## [0.3.0] - 2023-06-28
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -379,7 +379,7 @@ void JoltBodyImpl3D::set_center_of_mass_custom(const Vector3& p_center_of_mass, 
 	custom_center_of_mass = true;
 	center_of_mass_custom = p_center_of_mass;
 
-	build_shape(p_lock);
+	shapes_changed(p_lock);
 }
 
 void JoltBodyImpl3D::add_contact(
@@ -431,9 +431,15 @@ void JoltBodyImpl3D::add_contact(
 }
 
 void JoltBodyImpl3D::reset_mass_properties(bool p_lock) {
+	if (custom_center_of_mass) {
+		custom_center_of_mass = false;
+		center_of_mass_custom.zero();
+
+		shapes_changed(p_lock);
+	}
+
 	inertia.zero();
-	custom_center_of_mass = false;
-	center_of_mass_custom.zero();
+
 	update_mass_properties(p_lock);
 }
 


### PR DESCRIPTION
This fixes a bug where if you had a body using `CENTER_OF_MASS_MODE_CUSTOM` and then switched over to `CENTER_OF_MASS_MODE_AUTO` (while it was connected to a scene tree) you wouldn't see any actual difference. This was because the shapes didn't get rebuilt, and since the center-of-mass override in Jolt is a decorator shape that meant the new center-of-mass never got applied until something else would trigger a shape rebuild.