### PR TITLE
Updated godot-cpp to 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Breaking changes are denoted with ⚠️.
 
 - ⚠️ Changed the `cast_motion` method in `PhysicsDirectSpaceState3D` to return `[1.0, 1.0]` when no
   collision was detected, to match Godot Physics.
+- ⚠️ Changed contact positions to be absolute global coordinates instead of relative global
+  coordinates, to match the new behavior in Godot Physics.
 
 ### Added
 
@@ -25,6 +27,11 @@ Breaking changes are denoted with ⚠️.
   center of mass.
 - Fixed issue where going from `CENTER_OF_MASS_MODE_CUSTOM` to `CENTER_OF_MASS_MODE_AUTO` wouldn't
   actually reset the body's center-of-mass.
+- Fixed issue where any usage of `PhysicsServer3D`, `PhysicsDirectBodyState3D` or
+  `PhysicsDirectSpaceState3D` in C# scripts would trigger an exception.
+- Fixed issue where the `recovery_as_collision` parameter in the `move_and_collide` and `test_move`
+  methods on bodies was always `true`.
+- Fixed issue where the `input_ray_pickable` property on bodies and areas was always `true`.
 
 ## [0.3.0] - 2023-06-28
 

--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 78f709c74450d5dcfe1a3510dede8d5b67e42502
+	GIT_COMMIT f5077b47711589c8fa6c3d4a907572c58fc6d9f6
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES

--- a/examples/project.godot
+++ b/examples/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="Godot Jolt Examples"
 config/description="Project for showcasing and testing the features of Godot Jolt."
 run/main_scene="res://scenes/shapes/shapes.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://project/icon.svg"
 
 [autoload]

--- a/godot-jolt.gdextension
+++ b/godot-jolt.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 
 entry_symbol = "godot_jolt_main"
+compatibility_minimum = 4.1
 
 [libraries]
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -390,6 +390,7 @@ void JoltBodyImpl3D::add_contact(
 	const Vector3& p_normal,
 	const Vector3& p_position,
 	const Vector3& p_collider_position,
+	const Vector3& p_velocity,
 	const Vector3& p_collider_velocity,
 	const Vector3& p_impulse
 ) {
@@ -425,6 +426,7 @@ void JoltBodyImpl3D::add_contact(
 		contact->normal = p_normal;
 		contact->position = p_position;
 		contact->collider_position = p_collider_position;
+		contact->velocity = p_velocity;
 		contact->collider_velocity = p_collider_velocity;
 		contact->impulse = p_impulse;
 	}

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -29,6 +29,8 @@ public:
 
 		Vector3 collider_position;
 
+		Vector3 velocity;
+
 		Vector3 collider_velocity;
 
 		Vector3 impulse;
@@ -109,6 +111,7 @@ public:
 		const Vector3& p_normal,
 		const Vector3& p_position,
 		const Vector3& p_collider_position,
+		const Vector3& p_velocity,
 		const Vector3& p_collider_velocity,
 		const Vector3& p_impulse
 	);

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -20,7 +20,7 @@ JoltObjectImpl3D::~JoltObjectImpl3D() {
 }
 
 GodotObject* JoltObjectImpl3D::get_instance() const {
-	return internal::gde_interface->object_get_instance_from_id(instance_id);
+	return internal::gdextension_interface_object_get_instance_from_id(instance_id);
 }
 
 Object* JoltObjectImpl3D::get_instance_unsafe() const {

--- a/src/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.cpp
@@ -199,6 +199,13 @@ int32_t JoltPhysicsDirectBodyState3D::_get_contact_local_shape(int32_t p_contact
 	return body->get_contact(p_contact_idx).shape_index;
 }
 
+Vector3 JoltPhysicsDirectBodyState3D::_get_contact_local_velocity_at_position(int32_t p_contact_idx
+) const {
+	QUIET_FAIL_NULL_D_ED(body);
+	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());
+	return body->get_contact(p_contact_idx).velocity;
+}
+
 RID JoltPhysicsDirectBodyState3D::_get_contact_collider(int32_t p_contact_idx) const {
 	QUIET_FAIL_NULL_D_ED(body);
 	ERR_FAIL_INDEX_D(p_contact_idx, body->get_contact_count());

--- a/src/objects/jolt_physics_direct_body_state_3d.hpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.hpp
@@ -86,6 +86,8 @@ public:
 
 	int32_t _get_contact_local_shape(int32_t p_contact_idx) const override;
 
+	Vector3 _get_contact_local_velocity_at_position(int32_t p_contact_idx) const override;
+
 	RID _get_contact_collider(int32_t p_contact_idx) const override;
 
 	Vector3 _get_contact_collider_position(int32_t p_contact_idx) const override;

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -62,11 +62,11 @@ void on_terminate(ModuleInitializationLevel p_level) {
 extern "C" {
 
 GDExtensionBool GDE_EXPORT godot_jolt_main(
-	GDExtensionInterface* p_interface,
-	GDExtensionClassLibraryPtr p_class_library,
+	GDExtensionInterfaceGetProcAddress p_get_proc_address,
+	GDExtensionClassLibraryPtr p_library,
 	GDExtensionInitialization* p_initialization
 ) {
-	const GDExtensionBinding::InitObject init_obj(p_interface, p_class_library, p_initialization);
+	const GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, p_initialization);
 
 	init_obj.register_initializer(&on_initialize);
 	init_obj.register_terminator(&on_terminate);

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -971,6 +971,7 @@ bool JoltPhysicsServer3D::_body_test_motion(
 	double p_margin,
 	int32_t p_max_collisions,
 	bool p_collide_separation_ray,
+	bool p_recovery_as_collision,
 	PhysicsServer3DExtensionMotionResult* p_result
 ) const {
 	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
@@ -986,6 +987,7 @@ bool JoltPhysicsServer3D::_body_test_motion(
 		(float)p_margin,
 		p_max_collisions,
 		p_collide_separation_ray,
+		p_recovery_as_collision,
 		p_result
 	);
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -293,6 +293,7 @@ public:
 		double p_margin,
 		int32_t p_max_collisions,
 		bool p_collide_separation_ray,
+		bool p_recovery_as_collision,
 		PhysicsServer3DExtensionMotionResult* p_result
 	) const override;
 

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -203,9 +203,6 @@ bool JoltContactListener3D::try_add_contacts(
 	manifold.contacts2.reserve((int32_t)contact_count);
 	manifold.depth = p_manifold.mPenetrationDepth;
 
-	const JPH::Vec3 body_position1 = p_body1.GetPosition();
-	const JPH::Vec3 body_position2 = p_body2.GetPosition();
-
 	JPH::CollisionEstimationResult collision;
 
 	JPH::EstimateCollisionResponse(
@@ -229,6 +226,9 @@ bool JoltContactListener3D::try_add_contacts(
 		const JPH::Vec3 world_point1 = p_manifold.mBaseOffset + relative_point1;
 		const JPH::Vec3 world_point2 = p_manifold.mBaseOffset + relative_point2;
 
+		const JPH::Vec3 velocity1 = p_body1.GetPointVelocity(world_point1);
+		const JPH::Vec3 velocity2 = p_body2.GetPointVelocity(world_point2);
+
 		const JPH::CollisionEstimationResult::Impulse& impulse = collision.mImpulses[i];
 
 		const JPH::Vec3 contact_impulse = p_manifold.mWorldSpaceNormal * impulse.mContactImpulse;
@@ -237,15 +237,17 @@ bool JoltContactListener3D::try_add_contacts(
 		const JPH::Vec3 combined_impulse = contact_impulse + friction_impulse1 + friction_impulse2;
 
 		contact1.normal = -p_manifold.mWorldSpaceNormal;
-		contact1.point_self = world_point1 - body_position1;
-		contact1.point_other = world_point1 - body_position2;
-		contact1.velocity_other = p_body2.GetPointVelocity(world_point1);
+		contact1.point_self = world_point1;
+		contact1.point_other = world_point2;
+		contact1.velocity_self = velocity1;
+		contact1.velocity_other = velocity2;
 		contact1.impulse = -combined_impulse;
 
 		contact2.normal = p_manifold.mWorldSpaceNormal;
-		contact2.point_self = world_point2 - body_position2;
-		contact2.point_other = world_point2 - body_position1;
-		contact2.velocity_other = p_body1.GetPointVelocity(world_point2);
+		contact2.point_self = world_point2;
+		contact2.point_other = world_point1;
+		contact2.velocity_self = velocity2;
+		contact2.velocity_other = velocity1;
 		contact2.impulse = combined_impulse;
 	}
 
@@ -361,6 +363,7 @@ void JoltContactListener3D::flush_contacts() {
 				to_godot(contact.normal),
 				to_godot(contact.point_self),
 				to_godot(contact.point_other),
+				to_godot(contact.velocity_self),
 				to_godot(contact.velocity_other),
 				to_godot(contact.impulse)
 			);
@@ -375,6 +378,7 @@ void JoltContactListener3D::flush_contacts() {
 				to_godot(contact.normal),
 				to_godot(contact.point_self),
 				to_godot(contact.point_other),
+				to_godot(contact.velocity_self),
 				to_godot(contact.velocity_other),
 				to_godot(contact.impulse)
 			);

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -31,6 +31,8 @@ class JoltContactListener3D final : public JPH::ContactListener {
 
 		JPH::Vec3 point_other = {};
 
+		JPH::Vec3 velocity_self = {};
+
 		JPH::Vec3 velocity_other = {};
 
 		JPH::Vec3 impulse = {};

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -23,10 +23,16 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	bool p_collide_with_areas,
 	bool p_hit_from_inside,
 	bool p_hit_back_faces,
+	bool p_pick_ray,
 	PhysicsServer3DExtensionRayResult* p_result
 ) {
-	const JoltQueryFilter3D
-		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	const JoltQueryFilter3D query_filter(
+		*this,
+		p_collision_mask,
+		p_collide_with_bodies,
+		p_collide_with_areas,
+		p_pick_ray
+	);
 
 	const JPH::Vec3 from = to_jolt(p_from);
 	const JPH::Vec3 to = to_jolt(p_to);
@@ -491,6 +497,7 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	float p_margin,
 	int32_t p_max_collisions,
 	bool p_collide_separation_ray,
+	bool p_recovery_as_collision,
 	PhysicsServer3DExtensionMotionResult* p_result
 ) const {
 	p_margin = max(p_margin, 0.0001f);
@@ -521,7 +528,7 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 
 	bool collided = false;
 
-	if (hit || (recovered /* && p_recovery_as_collision */)) {
+	if (hit || (recovered && p_recovery_as_collision)) {
 		collided = body_motion_collide(
 			p_body,
 			transform.translated(p_motion * unsafe_fraction),

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -24,6 +24,7 @@ public:
 		bool p_collide_with_areas,
 		bool p_hit_from_inside,
 		bool p_hit_back_faces,
+		bool p_pick_ray,
 		PhysicsServer3DExtensionRayResult* p_result
 	) override;
 
@@ -95,6 +96,7 @@ public:
 		float p_margin,
 		int32_t p_max_collisions,
 		bool p_collide_separation_ray,
+		bool p_recovery_as_collision,
 		PhysicsServer3DExtensionMotionResult* p_result
 	) const;
 

--- a/src/spaces/jolt_query_filter_3d.cpp
+++ b/src/spaces/jolt_query_filter_3d.cpp
@@ -9,13 +9,15 @@ JoltQueryFilter3D::JoltQueryFilter3D(
 	const JoltPhysicsDirectSpaceState3D& p_space_state,
 	uint32_t p_collision_mask,
 	bool p_collide_with_bodies,
-	bool p_collide_with_areas
+	bool p_collide_with_areas,
+	bool p_picking
 )
 	: space_state(p_space_state)
 	, space(space_state.get_space())
 	, collision_mask(p_collision_mask)
 	, collide_with_bodies(p_collide_with_bodies)
-	, collide_with_areas(p_collide_with_areas) { }
+	, collide_with_areas(p_collide_with_areas)
+	, picking(p_picking) { }
 
 bool JoltQueryFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const {
 	const auto broad_phase_layer = (JPH::BroadPhaseLayer::Type)p_broad_phase_layer;
@@ -55,7 +57,8 @@ bool JoltQueryFilter3D::ShouldCollide([[maybe_unused]] const JPH::BodyID& p_body
 }
 
 bool JoltQueryFilter3D::ShouldCollideLocked(const JPH::Body& p_body) const {
-	return !space_state.is_body_excluded_from_query(
-		reinterpret_cast<JoltObjectImpl3D*>(p_body.GetUserData())->get_rid()
-	);
+	auto* object = reinterpret_cast<JoltObjectImpl3D*>(p_body.GetUserData());
+
+	return (!picking || object->is_pickable()) &&
+		!space_state.is_body_excluded_from_query(object->get_rid());
 }

--- a/src/spaces/jolt_query_filter_3d.hpp
+++ b/src/spaces/jolt_query_filter_3d.hpp
@@ -12,7 +12,8 @@ public:
 		const JoltPhysicsDirectSpaceState3D& p_space_state,
 		uint32_t p_collision_mask,
 		bool p_collide_with_bodies,
-		bool p_collide_with_areas
+		bool p_collide_with_areas,
+		bool p_picking = false
 	);
 
 	bool ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) const override;
@@ -33,4 +34,6 @@ private:
 	bool collide_with_bodies = false;
 
 	bool collide_with_areas = false;
+
+	bool picking = false;
 };


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@78f709c74450d5dcfe1a3510dede8d5b67e42502 aka 4.0.3-stable to godot-jolt/godot-cpp@f5077b47711589c8fa6c3d4a907572c58fc6d9f6 aka 4.1-stable (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/78f709c74450d5dcfe1a3510dede8d5b67e42502...f5077b47711589c8fa6c3d4a907572c58fc6d9f6)).

Fixes #270.
Fixes #336.
Fixes #337.