### PR TITLE
Replaced 6DOF axis-locking with proper one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Removed
+
+- ⚠️ Removed the ability to lock all axes of a `RigidBody3D`. Consider freezing the body as static
+  instead.
+
+### Fixed
+
+- Fixed issue where linear axis locks could be budged a bit if enough force was applied.
+- Fixed issue where `CharacterBody3D` and other kinematic bodies wouldn't respect locked axes.
+
 ## [0.4.1] - 2023-07-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ should not be relied upon if determinism is a hard requirement.
 - Manipulating a body's shape(s) after it has entered a scene tree can be costly
 - Contact impulses are estimations and won't be accurate when colliding with multiple bodies
 - `HeightMapShape3D` only supports square height maps with dimensions that are power-of-two
-- Axis-locking is implemented using joints, which means a body can technically deviate a bit from
-  its locked axes
 
 Also consider this note from Jolt's [documentation][jdc]:
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -257,9 +257,13 @@ private:
 
 	void apply_transform(const Transform3D& p_transform, bool p_lock = true) override;
 
+	JPH::EAllowedDOFs calculate_allowed_dofs() const;
+
 	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
 
 	JPH::MassProperties calculate_mass_properties() const;
+
+	void stop_locked_axes(JPH::Body& p_jolt_body) const;
 
 	void update_mass_properties(bool p_lock = true);
 
@@ -272,10 +276,6 @@ private:
 	void update_joint_constraints(bool p_lock = true);
 
 	void destroy_joint_constraints();
-
-	void update_axes_constraint(bool p_lock = true);
-
-	void destroy_axes_constraint();
 
 	void mode_changed(bool p_lock = true);
 
@@ -328,8 +328,6 @@ private:
 	JoltPhysicsDirectBodyState3D* direct_state = nullptr;
 
 	JPH::Ref<JoltGroupFilterRID> group_filter;
-
-	JPH::Ref<JPH::Constraint> axes_constraint;
 
 	PhysicsServer3D::BodyMode mode = PhysicsServer3D::BODY_MODE_RIGID;
 

--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -202,6 +202,17 @@ JPH::AABox JoltCustomRayShape::GetLocalBounds() const {
 	return {JPH::Vec3::sZero(), JPH::Vec3(0.0f, 0.0f, length)};
 }
 
+JPH::MassProperties JoltCustomRayShape::GetMassProperties() const {
+	JPH::MassProperties mass_properties;
+
+	// HACK(mihe): Since this shape has no volume we can't really give it a correct set of mass
+	// properties, so instead we just give it some random/arbitrary ones.
+	mass_properties.mMass = 1.0f;
+	mass_properties.mInertia = JPH::Mat44::sScale(0.1f);
+
+	return mass_properties;
+}
+
 #ifdef JPH_DEBUG_RENDERER
 
 void JoltCustomRayShape::Draw(

--- a/src/shapes/jolt_custom_ray_shape.hpp
+++ b/src/shapes/jolt_custom_ray_shape.hpp
@@ -58,7 +58,7 @@ public:
 
 	float GetInnerRadius() const override { return 0.0f; }
 
-	JPH::MassProperties GetMassProperties() const override { return {}; }
+	JPH::MassProperties GetMassProperties() const override;
 
 	JPH::Vec3 GetSurfaceNormal(
 		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,


### PR DESCRIPTION
This replaces the current `JPH::SixDOFConstraint` implementation of the `axis_lock_*` and `lock_rotation` properties with the new `JPH::EAllowedDOFs`.

It also implements axis-locking for kinematic bodies.