### PR TITLE
Updated Jolt to ea83565e61

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT a3d5318748fa234fff2340fbed110d0603a27ba9
+	GIT_COMMIT ea83565e6121a9d268932e403c0bf8ae5b688b90
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1128,7 +1128,7 @@ void JoltBodyImpl3D::update_mass_properties(bool p_lock) {
 
 	JPH::MotionProperties& motion_properties = *body->GetMotionPropertiesUnchecked();
 
-	motion_properties.SetMassProperties(calculate_mass_properties());
+	motion_properties.SetMassProperties(JPH::EAllowedDOFs::All, calculate_mass_properties());
 
 	if (is_rigid_linear()) {
 		motion_properties.SetInverseInertia(JPH::Vec3::sZero(), JPH::Quat::sIdentity());


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@a3d5318748fa234fff2340fbed110d0603a27ba9 to godot-jolt/jolt@ea83565e6121a9d268932e403c0bf8ae5b688b90 (see diff [here](https://github.com/godot-jolt/jolt/compare/a3d5318748fa234fff2340fbed110d0603a27ba9...ea83565e6121a9d268932e403c0bf8ae5b688b90)).

This brings in the following relevant changes:

- Ability to specify which DOFs a body has (needed for [#483](https://github.com/godot-jolt/godot-jolt/pull/483))
- Discarding slivers when building a mesh shape (needed for [#485](https://github.com/godot-jolt/godot-jolt/issues/485))

Fixes #485.