### PR TITLE
Refactored property bind macros

### DIFF
--- a/src/misc/bind_macros.hpp
+++ b/src/misc/bind_macros.hpp
@@ -2,18 +2,21 @@
 
 #define BIND_METHOD(m_class, m_name) ClassDB::bind_method(D_METHOD(#m_name), &m_class::m_name)
 
-#define BIND_PROPERTY(m_name, m_type)  \
-	ClassDB::add_property(             \
-		get_class_static(),            \
-		PropertyInfo(m_type, #m_name), \
-		"set_" #m_name,                \
-		"get_" #m_name                 \
+#define BIND_PROPERTY(m_name, m_type) \
+	ClassDB::add_property(            \
+		get_class_static(),           \
+		PropertyInfo(m_type, m_name), \
+		"set_" m_name,                \
+		"get_" m_name                 \
 	)
 
-#define BIND_PROPERTY_ENUM(m_name, m_hint_str)                               \
-	ClassDB::add_property(                                                   \
-		get_class_static(),                                                  \
-		PropertyInfo(Variant::INT, #m_name, PROPERTY_HINT_ENUM, m_hint_str), \
-		"set_" #m_name,                                                      \
-		"get_" #m_name                                                       \
+#define BIND_PROPERTY_HINTED(m_name, m_type, m_hint, m_hint_str) \
+	ClassDB::add_property(                                       \
+		get_class_static(),                                      \
+		PropertyInfo(m_type, m_name, m_hint, m_hint_str),        \
+		"set_" m_name,                                           \
+		"get_" m_name                                            \
 	)
+
+#define BIND_PROPERTY_ENUM(m_name, m_hint_str) \
+	BIND_PROPERTY_HINTED(m_name, Variant::INT, PROPERTY_HINT_ENUM, m_hint_str)

--- a/src/spaces/jolt_debug_geometry_3d.cpp
+++ b/src/spaces/jolt_debug_geometry_3d.cpp
@@ -43,34 +43,34 @@ void JoltDebugGeometry3D::_bind_methods() {
 
 	ADD_GROUP("Draw", "draw_");
 
-	BIND_PROPERTY(draw_bodies, Variant::BOOL);
+	BIND_PROPERTY("draw_bodies", Variant::BOOL);
 
-	BIND_PROPERTY(draw_shapes, Variant::BOOL);
+	BIND_PROPERTY("draw_shapes", Variant::BOOL);
 
-	BIND_PROPERTY(draw_constraints, Variant::BOOL);
+	BIND_PROPERTY("draw_constraints", Variant::BOOL);
 
-	BIND_PROPERTY(draw_bounding_boxes, Variant::BOOL);
+	BIND_PROPERTY("draw_bounding_boxes", Variant::BOOL);
 
-	BIND_PROPERTY(draw_centers_of_mass, Variant::BOOL);
+	BIND_PROPERTY("draw_centers_of_mass", Variant::BOOL);
 
-	BIND_PROPERTY(draw_transforms, Variant::BOOL);
+	BIND_PROPERTY("draw_transforms", Variant::BOOL);
 
-	BIND_PROPERTY(draw_velocities, Variant::BOOL);
+	BIND_PROPERTY("draw_velocities", Variant::BOOL);
 
-	BIND_PROPERTY(draw_constraint_reference_frames, Variant::BOOL);
+	BIND_PROPERTY("draw_constraint_reference_frames", Variant::BOOL);
 
-	BIND_PROPERTY(draw_constraint_limits, Variant::BOOL);
+	BIND_PROPERTY("draw_constraint_limits", Variant::BOOL);
 
-	BIND_PROPERTY(draw_as_wireframe, Variant::BOOL);
+	BIND_PROPERTY("draw_as_wireframe", Variant::BOOL);
 
 	BIND_PROPERTY_ENUM(
-		draw_with_color_scheme,
+		"draw_with_color_scheme",
 		"Instance,Shape Type,Motion Type,Sleep State,Island"
 	);
 
 	ADD_GROUP("Material", "material_");
 
-	BIND_PROPERTY(material_depth_test, Variant::BOOL);
+	BIND_PROPERTY("material_depth_test", Variant::BOOL);
 
 	BIND_ENUM_CONSTANT(COLOR_SCHEME_INSTANCE);
 	BIND_ENUM_CONSTANT(COLOR_SCHEME_SHAPE_TYPE);


### PR DESCRIPTION
This makes some minor changes to the `BIND_PROPERTY*` macros that are used within `_bind_methods`.

- Added a `BIND_PROPERTY_HINTED` macro
- Changed `BIND_PROPERTY_ENUM` to instead use the new `BIND_PROPERTY_HINTED`
- Changed all `BIND_PROPERTY` macros to take a string name instead of an identifier