### PR TITLE
Refactored the way joints are copied

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -12,13 +12,14 @@ constexpr double DEFAULT_RELAXATION = 1.0;
 } // namespace
 
 JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
+	const JoltJointImpl3D& p_old_joint,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
+	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
 	rebuild(p_lock);
 }
 

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -5,6 +5,7 @@
 class JoltConeTwistJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltConeTwistJointImpl3D(
+		const JoltJointImpl3D& p_old_joint,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -18,13 +18,14 @@ constexpr double DEFAULT_ANGULAR_ERP = 0.5;
 } // namespace
 
 JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
+	const JoltJointImpl3D& p_old_joint,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
+	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
 	rebuild(p_lock);
 }
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -19,6 +19,7 @@ class JoltGeneric6DOFJointImpl3D final : public JoltJointImpl3D {
 
 public:
 	JoltGeneric6DOFJointImpl3D(
+		const JoltJointImpl3D& p_old_joint,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -13,13 +13,14 @@ constexpr double DEFAULT_RELAXATION = 1.0;
 } // namespace
 
 JoltHingeJointImpl3D::JoltHingeJointImpl3D(
+	const JoltJointImpl3D& p_old_joint,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
+	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
 	rebuild(p_lock);
 }
 

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -5,6 +5,7 @@
 class JoltHingeJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltHingeJointImpl3D(
+		const JoltJointImpl3D& p_old_joint,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -10,13 +10,16 @@ constexpr int32_t DEFAULT_SOLVER_PRIORITY = 1;
 } // namespace
 
 JoltJointImpl3D::JoltJointImpl3D(
+	const JoltJointImpl3D& p_old_joint,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b
 )
-	: body_a(p_body_a)
+	: collision_disabled(p_old_joint.collision_disabled)
+	, body_a(p_body_a)
 	, body_b(p_body_b)
+	, rid(p_old_joint.rid)
 	, local_ref_a(p_local_ref_a)
 	, local_ref_b(p_local_ref_b) {
 	body_a->add_joint(this);

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -8,6 +8,7 @@ public:
 	JoltJointImpl3D() = default;
 
 	JoltJointImpl3D(
+		const JoltJointImpl3D& p_old_joint,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -12,13 +12,20 @@ constexpr double DEFAULT_IMPULSE_CLAMP = 0.0;
 } // namespace
 
 JoltPinJointImpl3D::JoltPinJointImpl3D(
+	const JoltJointImpl3D& p_old_joint,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Vector3& p_local_a,
 	const Vector3& p_local_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_body_a, p_body_b, Transform3D({}, p_local_a), Transform3D({}, p_local_b)) {
+	: JoltJointImpl3D(
+		  p_old_joint,
+		  p_body_a,
+		  p_body_b,
+		  Transform3D({}, p_local_a),
+		  Transform3D({}, p_local_b)
+	  ) {
 	rebuild(p_lock);
 }
 

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -8,6 +8,7 @@ class JoltSpace3D;
 class JoltPinJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltPinJointImpl3D(
+		const JoltJointImpl3D& p_old_joint,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Vector3& p_local_a,

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -34,13 +34,14 @@ constexpr double DEFAULT_ANGULAR_ORTHO_DAMPING = 1.0;
 } // namespace
 
 JoltSliderJointImpl3D::JoltSliderJointImpl3D(
+	const JoltJointImpl3D& p_old_joint,
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b,
 	bool p_lock
 )
-	: JoltJointImpl3D(p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
+	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
 	rebuild(p_lock);
 }
 

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -5,6 +5,7 @@
 class JoltSliderJointImpl3D final : public JoltJointImpl3D {
 public:
 	JoltSliderJointImpl3D(
+		const JoltJointImpl3D& p_old_joint,
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1267,10 +1267,9 @@ void JoltPhysicsServer3D::_joint_make_pin(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = memnew(JoltPinJointImpl3D(body_a, body_b, p_local_a, p_local_b));
-
-	new_joint->set_rid(old_joint->get_rid());
-	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
+	JoltJointImpl3D* new_joint = memnew(
+		JoltPinJointImpl3D(*old_joint, body_a, body_b, p_local_a, p_local_b)
+	);
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1356,10 +1355,9 @@ void JoltPhysicsServer3D::_joint_make_hinge(
 	JoltBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
 	ERR_FAIL_COND(body_a == body_b);
 
-	JoltJointImpl3D* new_joint = memnew(JoltHingeJointImpl3D(body_a, body_b, p_hinge_a, p_hinge_b));
-
-	new_joint->set_rid(old_joint->get_rid());
-	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
+	JoltJointImpl3D* new_joint = memnew(
+		JoltHingeJointImpl3D(*old_joint, body_a, body_b, p_hinge_a, p_hinge_b)
+	);
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1445,11 +1443,8 @@ void JoltPhysicsServer3D::_joint_make_slider(
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltJointImpl3D* new_joint = memnew(
-		JoltSliderJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b)
+		JoltSliderJointImpl3D(*old_joint, body_a, body_b, p_local_ref_a, p_local_ref_b)
 	);
-
-	new_joint->set_rid(old_joint->get_rid());
-	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1497,11 +1492,8 @@ void JoltPhysicsServer3D::_joint_make_cone_twist(
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltJointImpl3D* new_joint = memnew(
-		JoltConeTwistJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b)
+		JoltConeTwistJointImpl3D(*old_joint, body_a, body_b, p_local_ref_a, p_local_ref_b)
 	);
-
-	new_joint->set_rid(old_joint->get_rid());
-	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);
@@ -1551,11 +1543,8 @@ void JoltPhysicsServer3D::_joint_make_generic_6dof(
 	ERR_FAIL_COND(body_a == body_b);
 
 	JoltJointImpl3D* new_joint = memnew(
-		JoltGeneric6DOFJointImpl3D(body_a, body_b, p_local_ref_a, p_local_ref_b)
+		JoltGeneric6DOFJointImpl3D(*old_joint, body_a, body_b, p_local_ref_a, p_local_ref_b)
 	);
-
-	new_joint->set_rid(old_joint->get_rid());
-	new_joint->set_collision_disabled(old_joint->is_collision_disabled());
 
 	memdelete_safely(old_joint);
 	joint_owner.replace(p_joint, new_joint);


### PR DESCRIPTION
This changes the way joints copy over some of the `JoltJointImpl3D` properties when changing type, like the `RID` and whether the bodies should have collisions with eachother disabled.

Previously this would be explicitly copied over in every `_joint_make_*` method, which was somewhat error-prone. Now instead the old joint reference gets passed into the respective joint constructor and the data gets copied in the `JoltJointImpl3D` constructor instead.