### PR TITLE
Added underscore prefix to private/protected methods

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -282,16 +282,20 @@ CheckOptions:
   modernize-deprecated-headers.CheckHeaderFile: true
   modernize-use-auto.MinTypeNameLength: 0
   modernize-use-default-member-init.UseAssignment: true
+  readability-identifier-naming.AggressiveDependentMemberLookup: true
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.EnumCase: CamelCase
   readability-identifier-naming.EnumConstantCase: UPPER_CASE
   readability-identifier-naming.FunctionCase: lower_case
+  readability-identifier-naming.GetConfigPerFile: false
   readability-identifier-naming.GlobalConstantCase: UPPER_CASE
   readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
   readability-identifier-naming.MemberCase: lower_case
   readability-identifier-naming.NamespaceCase: lower_case
   readability-identifier-naming.ParameterCase: lower_case
   readability-identifier-naming.ParameterPrefix: p_
+  readability-identifier-naming.PrivateMethodPrefix: _
+  readability-identifier-naming.ProtectedMethodPrefix: _
   readability-identifier-naming.ScopedEnumConstantCase: UPPER_CASE
   readability-identifier-naming.TemplateParameterCase: CamelCase
   readability-identifier-naming.TemplateParameterPrefix: T

--- a/examples/scenes/common/scripts/free_look_camera.gd
+++ b/examples/scenes/common/scripts/free_look_camera.gd
@@ -28,13 +28,13 @@ func _input(event: InputEvent):
 				Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
 		elif event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			if event.pressed:
-				step_speed_up(event.factor)
+				_step_speed_up(event.factor)
 		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
 			if event.pressed:
-				step_speed_down(event.factor)
+				_step_speed_down(event.factor)
 	elif event is InputEventMouseMotion:
 		if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
-			rotate_from_mouse(event.relative)
+			_rotate_from_mouse(event.relative)
 
 func _process(delta: float):
 	if not current:
@@ -58,13 +58,13 @@ func _process(delta: float):
 
 	position = position.lerp(target_position, interpolation_speed * delta)
 
-func step_speed_up(factor: float = 1.0):
-	scale_speed(1.0 + (speed_step_factor - 1.0) * factor)
+func _step_speed_up(factor: float = 1.0):
+	_scale_speed(1.0 + (speed_step_factor - 1.0) * factor)
 
-func step_speed_down(factor: float = 1.0):
-	scale_speed(1.0 / (1.0 + (speed_step_factor - 1.0) * factor))
+func _step_speed_down(factor: float = 1.0):
+	_scale_speed(1.0 / (1.0 + (speed_step_factor - 1.0) * factor))
 
-func scale_speed(factor: float):
+func _scale_speed(factor: float):
 	var min_speed := near * 4
 	var max_speed := far / 4
 
@@ -73,7 +73,7 @@ func scale_speed(factor: float):
 	else:
 		speed = (min_speed + max_speed) / 2.0;
 
-func rotate_from_mouse(relative: Vector2):
+func _rotate_from_mouse(relative: Vector2):
 	var delta := -relative * 0.0015 * mouse_sensitivity
 
 	rotation = Vector3(

--- a/examples/scenes/shapes/entities/height_map/height_map.gd
+++ b/examples/scenes/shapes/entities/height_map/height_map.gd
@@ -6,43 +6,43 @@ class_name HeightMap3D extends StaticBody3D
 var collision_shape := NodePath():
 	set(value):
 		collision_shape = value
-		properties_changed()
+		_properties_changed()
 
 @export_node_path("MeshInstance3D")
 var mesh_instance := NodePath():
 	set(value):
 		mesh_instance = value
-		properties_changed()
+		_properties_changed()
 
 @export_range(4, 64, 1, "or_greater")
 var resolution: int = 16:
 	set(value):
 		resolution = value
-		properties_changed()
+		_properties_changed()
 
 @export_range(0.1, 10.0, 0.1, "or_greater")
 var amplitude: float = 1.0:
 	set(value):
 		amplitude = value
-		properties_changed()
+		_properties_changed()
 
 @export
 var noise_seed: int = 0:
 	set(value):
 		noise_seed = value
-		properties_changed()
+		_properties_changed()
 
 @export
 var noise_frequency: float = 0.2:
 	set(value):
 		noise_frequency = value
-		properties_changed()
+		_properties_changed()
 
-func properties_changed():
+func _properties_changed():
 	if Engine.is_editor_hint():
-		generate()
+		_generate()
 
-func generate():
+func _generate():
 	var _collision_shape := get_node_or_null(collision_shape)
 	if not _collision_shape:
 		return

--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -54,11 +54,11 @@ void JoltConeTwistJointImpl3D::set_param(
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
 			swing_span = p_value;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN: {
 			twist_span = p_value;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
@@ -66,7 +66,7 @@ void JoltConeTwistJointImpl3D::set_param(
 					"Cone twist joint bias is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -76,7 +76,7 @@ void JoltConeTwistJointImpl3D::set_param(
 					"Cone twist joint softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. ",
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -86,7 +86,7 @@ void JoltConeTwistJointImpl3D::set_param(
 					"Cone twist joint relaxation is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -124,9 +124,9 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 	Transform3D shifted_ref_a;
 	Transform3D shifted_ref_b;
 
-	shift_reference_frames(Vector3(), Vector3(), shifted_ref_a, shifted_ref_b);
+	_shift_reference_frames(Vector3(), Vector3(), shifted_ref_a, shifted_ref_b);
 
-	jolt_ref = build_swing_twist(
+	jolt_ref = _build_swing_twist(
 		jolt_body_a,
 		jolt_body_b,
 		shifted_ref_a,
@@ -138,7 +138,7 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 }
 
-JPH::Constraint* JoltConeTwistJointImpl3D::build_swing_twist(
+JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(
 	JPH::Body* p_jolt_body_a,
 	JPH::Body* p_jolt_body_b,
 	const Transform3D& p_shifted_ref_a,
@@ -184,6 +184,6 @@ JPH::Constraint* JoltConeTwistJointImpl3D::build_swing_twist(
 	}
 }
 
-void JoltConeTwistJointImpl3D::limits_changed(bool p_lock) {
+void JoltConeTwistJointImpl3D::_limits_changed(bool p_lock) {
 	rebuild(p_lock);
 }

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -28,7 +28,7 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* build_swing_twist(
+	static JPH::Constraint* _build_swing_twist(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
@@ -37,7 +37,7 @@ private:
 		float p_twist_limit
 	);
 
-	void limits_changed(bool p_lock = true);
+	void _limits_changed(bool p_lock = true);
 
 	double swing_span = 0.0;
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -121,11 +121,11 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 	switch ((int32_t)p_param) {
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT: {
 			limit_lower[axis_lin] = p_value;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_UPPER_LIMIT: {
 			limit_upper[axis_lin] = p_value;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
@@ -133,7 +133,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF joint linear limit softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -143,7 +143,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF joint linear restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -153,37 +153,37 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF joint linear damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_TARGET_VELOCITY: {
 			motor_speed[axis_lin] = p_value;
-			motor_speed_changed(axis_lin);
+			_motor_speed_changed(axis_lin);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_FORCE_LIMIT: {
 			motor_limit[axis_lin] = p_value;
-			motor_limit_changed(axis_lin);
+			_motor_limit_changed(axis_lin);
 		} break;
 		case 7: /* G6DOF_JOINT_LINEAR_SPRING_STIFFNESS */ {
 			spring_stiffness[axis_lin] = p_value;
-			spring_stiffness_changed(axis_lin);
+			_spring_stiffness_changed(axis_lin);
 		} break;
 		case 8: /* G6DOF_JOINT_LINEAR_SPRING_DAMPING */ {
 			spring_damping[axis_lin] = p_value;
-			spring_damping_changed(axis_lin);
+			_spring_damping_changed(axis_lin);
 		} break;
 		case 9: /* G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT */ {
 			spring_equilibrium[axis_lin] = p_value;
-			spring_equilibrium_changed(axis_lin);
+			_spring_equilibrium_changed(axis_lin);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT: {
 			limit_lower[axis_ang] = p_value;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_UPPER_LIMIT: {
 			limit_upper[axis_ang] = p_value;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_SOFTNESS)) {
@@ -191,7 +191,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF joint angular limit softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -201,7 +201,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF joint angular damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -211,7 +211,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF joint angular restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -221,7 +221,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF angular force limit is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -231,29 +231,29 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 					"Generic 6DOF angular ERP is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_TARGET_VELOCITY: {
 			motor_speed[axis_ang] = p_value;
-			motor_speed_changed(axis_ang);
+			_motor_speed_changed(axis_ang);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_FORCE_LIMIT: {
 			motor_limit[axis_ang] = p_value;
-			motor_limit_changed(axis_ang);
+			_motor_limit_changed(axis_ang);
 		} break;
 		case 19: /* G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS */ {
 			spring_stiffness[axis_ang] = p_value;
-			spring_stiffness_changed(axis_ang);
+			_spring_stiffness_changed(axis_ang);
 		} break;
 		case 20: /* G6DOF_JOINT_ANGULAR_SPRING_DAMPING */ {
 			spring_damping[axis_ang] = p_value;
-			spring_damping_changed(axis_ang);
+			_spring_damping_changed(axis_ang);
 		} break;
 		case 21: /* G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT */ {
 			spring_equilibrium[axis_ang] = p_value;
-			spring_equilibrium_changed(axis_ang);
+			_spring_equilibrium_changed(axis_ang);
 		} break;
 		default: {
 			ERR_FAIL_MSG(vformat("Unhandled 6DOF joint parameter: '%d'", p_param));
@@ -305,27 +305,27 @@ void JoltGeneric6DOFJointImpl3D::set_flag(
 	switch ((int32_t)p_flag) {
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT: {
 			use_limits[axis_lin] = p_enabled;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT: {
 			use_limits[axis_ang] = p_enabled;
-			limits_changed(p_lock);
+			_limits_changed(p_lock);
 		} break;
 		case 2: /* G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING */ {
 			spring_enabled[axis_ang] = p_enabled;
-			spring_state_changed(axis_ang);
+			_spring_state_changed(axis_ang);
 		} break;
 		case 3: /* G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING */ {
 			spring_enabled[axis_lin] = p_enabled;
-			spring_state_changed(axis_lin);
+			_spring_state_changed(axis_lin);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_MOTOR: {
 			motor_enabled[axis_ang] = p_enabled;
-			motor_state_changed(axis_ang);
+			_motor_state_changed(axis_ang);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_MOTOR: {
 			motor_enabled[axis_lin] = p_enabled;
-			motor_state_changed(axis_lin);
+			_motor_state_changed(axis_lin);
 		} break;
 		default: {
 			ERR_FAIL_MSG(vformat("Unhandled 6DOF joint flag: '%d'", p_flag));
@@ -396,7 +396,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	Transform3D shifted_ref_a;
 	Transform3D shifted_ref_b;
 
-	shift_reference_frames(linear_shift, angular_shift, shifted_ref_a, shifted_ref_b);
+	_shift_reference_frames(linear_shift, angular_shift, shifted_ref_a, shifted_ref_b);
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mPosition1 = to_jolt(shifted_ref_a.origin);
@@ -428,16 +428,16 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 
 	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
-		update_motor_state(axis);
-		update_motor_velocity(axis);
-		update_motor_limit(axis);
-		update_spring_stiffness(axis);
-		update_spring_damping(axis);
-		update_spring_equilibrium(axis);
+		_update_motor_state(axis);
+		_update_motor_velocity(axis);
+		_update_motor_limit(axis);
+		_update_spring_stiffness(axis);
+		_update_spring_damping(axis);
+		_update_spring_equilibrium(axis);
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::update_motor_state(int32_t p_axis) {
+void JoltGeneric6DOFJointImpl3D::_update_motor_state(int32_t p_axis) {
 	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
 		if (motor_enabled[p_axis]) {
 			constraint->SetMotorState((JoltAxis)p_axis, JPH::EMotorState::Velocity);
@@ -449,7 +449,7 @@ void JoltGeneric6DOFJointImpl3D::update_motor_state(int32_t p_axis) {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::update_motor_velocity(int32_t p_axis) {
+void JoltGeneric6DOFJointImpl3D::_update_motor_velocity(int32_t p_axis) {
 	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
 		if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
 			constraint->SetTargetVelocityCS(
@@ -470,7 +470,7 @@ void JoltGeneric6DOFJointImpl3D::update_motor_velocity(int32_t p_axis) {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::update_motor_limit(int32_t p_axis) {
+void JoltGeneric6DOFJointImpl3D::_update_motor_limit(int32_t p_axis) {
 	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
 		JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
 
@@ -487,21 +487,21 @@ void JoltGeneric6DOFJointImpl3D::update_motor_limit(int32_t p_axis) {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::update_spring_stiffness(int32_t p_axis) {
+void JoltGeneric6DOFJointImpl3D::_update_spring_stiffness(int32_t p_axis) {
 	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
 		JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
 		motor_settings.mSpringSettings.mStiffness = (float)spring_stiffness[p_axis];
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::update_spring_damping(int32_t p_axis) {
+void JoltGeneric6DOFJointImpl3D::_update_spring_damping(int32_t p_axis) {
 	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
 		JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
 		motor_settings.mSpringSettings.mDamping = (float)spring_damping[p_axis];
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::update_spring_equilibrium(int32_t p_axis) {
+void JoltGeneric6DOFJointImpl3D::_update_spring_equilibrium(int32_t p_axis) {
 	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
 		if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
 			const Vector3 target_position = Vector3(
@@ -526,35 +526,35 @@ void JoltGeneric6DOFJointImpl3D::update_spring_equilibrium(int32_t p_axis) {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::limits_changed(bool p_lock) {
+void JoltGeneric6DOFJointImpl3D::_limits_changed(bool p_lock) {
 	rebuild(p_lock);
 }
 
-void JoltGeneric6DOFJointImpl3D::motor_state_changed(int32_t p_axis) {
-	update_motor_state(p_axis);
-	update_motor_limit(p_axis);
+void JoltGeneric6DOFJointImpl3D::_motor_state_changed(int32_t p_axis) {
+	_update_motor_state(p_axis);
+	_update_motor_limit(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::motor_speed_changed(int32_t p_axis) {
-	update_motor_velocity(p_axis);
+void JoltGeneric6DOFJointImpl3D::_motor_speed_changed(int32_t p_axis) {
+	_update_motor_velocity(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::motor_limit_changed(int32_t p_axis) {
-	update_motor_limit(p_axis);
+void JoltGeneric6DOFJointImpl3D::_motor_limit_changed(int32_t p_axis) {
+	_update_motor_limit(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::spring_state_changed(int32_t p_axis) {
-	update_motor_state(p_axis);
+void JoltGeneric6DOFJointImpl3D::_spring_state_changed(int32_t p_axis) {
+	_update_motor_state(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::spring_stiffness_changed(int32_t p_axis) {
-	update_spring_stiffness(p_axis);
+void JoltGeneric6DOFJointImpl3D::_spring_stiffness_changed(int32_t p_axis) {
+	_update_spring_stiffness(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::spring_damping_changed(int32_t p_axis) {
-	update_spring_damping(p_axis);
+void JoltGeneric6DOFJointImpl3D::_spring_damping_changed(int32_t p_axis) {
+	_update_spring_damping(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::spring_equilibrium_changed(int32_t p_axis) {
-	update_spring_equilibrium(p_axis);
+void JoltGeneric6DOFJointImpl3D::_spring_equilibrium_changed(int32_t p_axis) {
+	_update_spring_equilibrium(p_axis);
 }

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -52,33 +52,33 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
-	void update_motor_state(int32_t p_axis);
+	void _update_motor_state(int32_t p_axis);
 
-	void update_motor_velocity(int32_t p_axis);
+	void _update_motor_velocity(int32_t p_axis);
 
-	void update_motor_limit(int32_t p_axis);
+	void _update_motor_limit(int32_t p_axis);
 
-	void update_spring_stiffness(int32_t p_axis);
+	void _update_spring_stiffness(int32_t p_axis);
 
-	void update_spring_damping(int32_t p_axis);
+	void _update_spring_damping(int32_t p_axis);
 
-	void update_spring_equilibrium(int32_t p_axis);
+	void _update_spring_equilibrium(int32_t p_axis);
 
-	void limits_changed(bool p_lock = true);
+	void _limits_changed(bool p_lock = true);
 
-	void motor_state_changed(int32_t p_axis);
+	void _motor_state_changed(int32_t p_axis);
 
-	void motor_speed_changed(int32_t p_axis);
+	void _motor_speed_changed(int32_t p_axis);
 
-	void motor_limit_changed(int32_t p_axis);
+	void _motor_limit_changed(int32_t p_axis);
 
-	void spring_state_changed(int32_t p_axis);
+	void _spring_state_changed(int32_t p_axis);
 
-	void spring_stiffness_changed(int32_t p_axis);
+	void _spring_stiffness_changed(int32_t p_axis);
 
-	void spring_damping_changed(int32_t p_axis);
+	void _spring_damping_changed(int32_t p_axis);
 
-	void spring_equilibrium_changed(int32_t p_axis);
+	void _spring_equilibrium_changed(int32_t p_axis);
 
 	double limit_lower[AXIS_COUNT] = {};
 

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -28,7 +28,7 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* build_hinge(
+	static JPH::Constraint* _build_hinge(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
@@ -36,28 +36,28 @@ private:
 		float p_limit
 	);
 
-	static JPH::Constraint* build_fixed(
+	static JPH::Constraint* _build_fixed(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b
 	);
 
-	bool is_fixed() const { return limit_lower == limit_upper; }
+	bool _is_fixed() const { return limit_lower == limit_upper; }
 
-	void update_motor_state();
+	void _update_motor_state();
 
-	void update_motor_velocity();
+	void _update_motor_velocity();
 
-	void update_motor_limit();
+	void _update_motor_limit();
 
-	void limits_changed(bool p_lock = true);
+	void _limits_changed(bool p_lock = true);
 
-	void motor_state_changed();
+	void _motor_state_changed();
 
-	void motor_speed_changed();
+	void _motor_speed_changed();
 
-	void motor_limit_changed();
+	void _motor_limit_changed();
 
 	double limit_lower = 0.0;
 

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -54,7 +54,7 @@ JoltSpace3D* JoltJointImpl3D::get_space() const {
 				"Joint was found to connect bodies in different physics spaces. "
 				"This joint will effectively be disabled. "
 				"This joint connects %s.",
-				bodies_to_string()
+				_bodies_to_string()
 			)
 		);
 	}
@@ -72,7 +72,7 @@ void JoltJointImpl3D::set_solver_priority(int32_t p_priority) {
 			"Joint solver priority is not supported by Godot Jolt. "
 			"Any such value will be ignored."
 			"This joint connects %s.",
-			bodies_to_string()
+			_bodies_to_string()
 		));
 	}
 }
@@ -109,7 +109,7 @@ void JoltJointImpl3D::destroy() {
 	jolt_ref = nullptr;
 }
 
-void JoltJointImpl3D::shift_reference_frames(
+void JoltJointImpl3D::_shift_reference_frames(
 	const Vector3& p_linear_shift,
 	const Vector3& p_angular_shift,
 	Transform3D& p_shifted_ref_a,
@@ -136,7 +136,7 @@ void JoltJointImpl3D::shift_reference_frames(
 	p_shifted_ref_b = Transform3D(basis_b, origin_b);
 }
 
-String JoltJointImpl3D::bodies_to_string() const {
+String JoltJointImpl3D::_bodies_to_string() const {
 	return vformat(
 		"'%s' and '%s'",
 		body_a != nullptr ? body_a->to_string() : "<unknown>",

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -40,14 +40,14 @@ public:
 	virtual void rebuild([[maybe_unused]] bool p_lock = true) { }
 
 protected:
-	void shift_reference_frames(
+	void _shift_reference_frames(
 		const Vector3& p_linear_shift,
 		const Vector3& p_angular_shift,
 		Transform3D& p_shifted_ref_a,
 		Transform3D& p_shifted_ref_b
 	);
 
-	String bodies_to_string() const;
+	String _bodies_to_string() const;
 
 	bool collision_disabled = false;
 

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -31,12 +31,12 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 
 void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
 	local_ref_a = Transform3D({}, p_local_a);
-	points_changed(p_lock);
+	_points_changed(p_lock);
 }
 
 void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
 	local_ref_b = Transform3D({}, p_local_b);
-	points_changed(p_lock);
+	_points_changed(p_lock);
 }
 
 double JoltPinJointImpl3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
@@ -64,7 +64,7 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 					"Pin joint bias is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -74,7 +74,7 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 					"Pin joint damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -84,7 +84,7 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 					"Pin joint impulse clamp is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -122,14 +122,14 @@ void JoltPinJointImpl3D::rebuild(bool p_lock) {
 	Transform3D shifted_ref_a;
 	Transform3D shifted_ref_b;
 
-	shift_reference_frames(Vector3(), Vector3(), shifted_ref_a, shifted_ref_b);
+	_shift_reference_frames(Vector3(), Vector3(), shifted_ref_a, shifted_ref_b);
 
-	jolt_ref = build_pin(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
+	jolt_ref = _build_pin(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
 
 	space->add_joint(this);
 }
 
-JPH::Constraint* JoltPinJointImpl3D::build_pin(
+JPH::Constraint* JoltPinJointImpl3D::_build_pin(
 	JPH::Body* p_jolt_body_a,
 	JPH::Body* p_jolt_body_b,
 	const Transform3D& p_shifted_ref_a,
@@ -147,6 +147,6 @@ JPH::Constraint* JoltPinJointImpl3D::build_pin(
 	}
 }
 
-void JoltPinJointImpl3D::points_changed(bool p_lock) {
+void JoltPinJointImpl3D::_points_changed(bool p_lock) {
 	rebuild(p_lock);
 }

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -33,12 +33,12 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* build_pin(
+	static JPH::Constraint* _build_pin(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b
 	);
 
-	void points_changed(bool p_lock = true);
+	void _points_changed(bool p_lock = true);
 };

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -139,7 +139,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear limit softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -149,7 +149,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear limit restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -159,7 +159,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear limit damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -169,7 +169,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear motion softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -179,7 +179,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear motion restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -189,7 +189,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear motion damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -199,7 +199,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear ortho softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -209,7 +209,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear ortho restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -219,7 +219,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint linear ortho damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -230,7 +230,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Any such value will be ignored. "
 					"Try using Generic6DOFJoint3D instead. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -241,7 +241,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Any such value will be ignored. "
 					"Try using Generic6DOFJoint3D instead. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -251,7 +251,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular limit softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -261,7 +261,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular limit restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -271,7 +271,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular limit damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -281,7 +281,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular motion softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -291,7 +291,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular motion restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -301,7 +301,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular motion damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -311,7 +311,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular ortho softness is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -321,7 +321,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular ortho restitution is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -331,7 +331,7 @@ void JoltSliderJointImpl3D::set_param(
 					"Slider joint angular ortho damping is not supported by Godot Jolt. "
 					"Any such value will be ignored. "
 					"This joint connects %s.",
-					bodies_to_string()
+					_bodies_to_string()
 				));
 			}
 		} break;
@@ -379,18 +379,23 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 	Transform3D shifted_ref_a;
 	Transform3D shifted_ref_b;
 
-	shift_reference_frames(Vector3(ref_shift, 0.0f, 0.0f), Vector3(), shifted_ref_a, shifted_ref_b);
+	_shift_reference_frames(
+		Vector3(ref_shift, 0.0f, 0.0f),
+		Vector3(),
+		shifted_ref_a,
+		shifted_ref_b
+	);
 
-	if (is_fixed()) {
-		jolt_ref = build_fixed(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
+	if (_is_fixed()) {
+		jolt_ref = _build_fixed(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
 	} else {
-		jolt_ref = build_slider(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b, limit);
+		jolt_ref = _build_slider(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b, limit);
 	}
 
 	space->add_joint(this);
 }
 
-JPH::Constraint* JoltSliderJointImpl3D::build_slider(
+JPH::Constraint* JoltSliderJointImpl3D::_build_slider(
 	JPH::Body* p_jolt_body_a,
 	JPH::Body* p_jolt_body_b,
 	const Transform3D& p_shifted_ref_a,
@@ -417,7 +422,7 @@ JPH::Constraint* JoltSliderJointImpl3D::build_slider(
 	}
 }
 
-JPH::Constraint* JoltSliderJointImpl3D::build_fixed(
+JPH::Constraint* JoltSliderJointImpl3D::_build_fixed(
 	JPH::Body* p_jolt_body_a,
 	JPH::Body* p_jolt_body_b,
 	const Transform3D& p_shifted_ref_a,
@@ -441,6 +446,6 @@ JPH::Constraint* JoltSliderJointImpl3D::build_fixed(
 	}
 }
 
-void JoltSliderJointImpl3D::limits_changed(bool p_lock) {
+void JoltSliderJointImpl3D::_limits_changed(bool p_lock) {
 	rebuild(p_lock);
 }

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -24,7 +24,7 @@ public:
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* build_slider(
+	static JPH::Constraint* _build_slider(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
@@ -32,16 +32,16 @@ private:
 		float p_limit
 	);
 
-	static JPH::Constraint* build_fixed(
+	static JPH::Constraint* _build_fixed(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b
 	);
 
-	bool is_fixed() const { return limit_lower == limit_upper; }
+	bool _is_fixed() const { return limit_lower == limit_upper; }
 
-	void limits_changed(bool p_lock = true);
+	void _limits_changed(bool p_lock = true);
 
 	double limit_upper = 0.0;
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -56,8 +56,6 @@ public:
 
 	void set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value);
 
-	JPH::BroadPhaseLayer get_broad_phase_layer() const override;
-
 	bool has_body_monitor_callback() const { return body_monitor_callback.is_valid(); }
 
 	void set_body_monitor_callback(const Callable& p_callback);
@@ -155,26 +153,28 @@ public:
 	Vector3 get_center_of_mass_custom() const override { return {0, 0, 0}; }
 
 private:
-	JPH::EMotionType get_motion_type() const override { return JPH::EMotionType::Kinematic; }
+	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 
-	void create_in_space() override;
+	JPH::EMotionType _get_motion_type() const override { return JPH::EMotionType::Kinematic; }
 
-	void add_shape_pair(
+	void _create_in_space() override;
+
+	void _add_shape_pair(
 		Overlap& p_overlap,
 		const JPH::BodyID& p_body_id,
 		const JPH::SubShapeID& p_other_shape_id,
 		const JPH::SubShapeID& p_self_shape_id
 	);
 
-	bool remove_shape_pair(
+	bool _remove_shape_pair(
 		Overlap& p_overlap,
 		const JPH::SubShapeID& p_other_shape_id,
 		const JPH::SubShapeID& p_self_shape_id
 	);
 
-	void flush_events(OverlapsById& p_objects, const Callable& p_callback);
+	void _flush_events(OverlapsById& p_objects, const Callable& p_callback);
 
-	void report_event(
+	void _report_event(
 		const Callable& p_callback,
 		PhysicsServer3D::AreaBodyStatus p_status,
 		const RID& p_other_rid,
@@ -183,25 +183,25 @@ private:
 		int32_t p_self_shape_index
 	) const;
 
-	void notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock = true);
+	void _notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock = true);
 
-	void notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock = true);
+	void _notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock = true);
 
-	void force_bodies_entered();
+	void _force_bodies_entered();
 
-	void force_bodies_exited(bool p_remove, bool p_lock = true);
+	void _force_bodies_exited(bool p_remove, bool p_lock = true);
 
-	void force_areas_entered();
+	void _force_areas_entered();
 
-	void force_areas_exited(bool p_remove, bool p_lock = true);
+	void _force_areas_exited(bool p_remove, bool p_lock = true);
 
-	void space_changing(bool p_lock = true) override;
+	void _space_changing(bool p_lock = true) override;
 
-	void body_monitoring_changed();
+	void _body_monitoring_changed();
 
-	void area_monitoring_changed();
+	void _area_monitoring_changed();
 
-	void monitorable_changed(bool p_lock = true);
+	void _monitorable_changed(bool p_lock = true);
 
 	OverlapsById bodies_by_id;
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -46,8 +46,6 @@ public:
 
 	void set_param(PhysicsServer3D::BodyParameter p_param, const Variant& p_value);
 
-	JPH::BroadPhaseLayer get_broad_phase_layer() const override;
-
 	bool has_state_sync_callback() const { return body_state_callback.is_valid(); }
 
 	void set_state_sync_callback(const Callable& p_callback) { body_state_callback = p_callback; }
@@ -243,59 +241,61 @@ public:
 	bool are_axes_locked() const { return locked_axes != 0; }
 
 private:
-	JPH::EMotionType get_motion_type() const override;
+	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 
-	void create_in_space() override;
+	JPH::EMotionType _get_motion_type() const override;
 
-	void integrate_forces(float p_step, JPH::Body& p_jolt_body);
+	void _create_in_space() override;
 
-	void pre_step_static(float p_step, JPH::Body& p_jolt_body);
+	void _integrate_forces(float p_step, JPH::Body& p_jolt_body);
 
-	void pre_step_rigid(float p_step, JPH::Body& p_jolt_body);
+	void _pre_step_static(float p_step, JPH::Body& p_jolt_body);
 
-	void pre_step_kinematic(float p_step, JPH::Body& p_jolt_body);
+	void _pre_step_rigid(float p_step, JPH::Body& p_jolt_body);
 
-	void apply_transform(const Transform3D& p_transform, bool p_lock = true) override;
+	void _pre_step_kinematic(float p_step, JPH::Body& p_jolt_body);
 
-	JPH::EAllowedDOFs calculate_allowed_dofs() const;
+	void _apply_transform(const Transform3D& p_transform, bool p_lock = true) override;
 
-	JPH::MassProperties calculate_mass_properties(const JPH::Shape& p_shape) const;
+	JPH::EAllowedDOFs _calculate_allowed_dofs() const;
 
-	JPH::MassProperties calculate_mass_properties() const;
+	JPH::MassProperties _calculate_mass_properties(const JPH::Shape& p_shape) const;
 
-	void stop_locked_axes(JPH::Body& p_jolt_body) const;
+	JPH::MassProperties _calculate_mass_properties() const;
 
-	void update_mass_properties(bool p_lock = true);
+	void _stop_locked_axes(JPH::Body& p_jolt_body) const;
 
-	void update_damp(bool p_lock = true);
+	void _update_mass_properties(bool p_lock = true);
 
-	void update_kinematic_transform(bool p_lock = true);
+	void _update_damp(bool p_lock = true);
 
-	void update_group_filter(bool p_lock = true);
+	void _update_kinematic_transform(bool p_lock = true);
 
-	void update_joint_constraints(bool p_lock = true);
+	void _update_group_filter(bool p_lock = true);
 
-	void destroy_joint_constraints();
+	void _update_joint_constraints(bool p_lock = true);
 
-	void mode_changed(bool p_lock = true);
+	void _destroy_joint_constraints();
 
-	void shapes_built(bool p_lock) override;
+	void _mode_changed(bool p_lock = true);
 
-	void space_changing(bool p_lock = true) override;
+	void _shapes_built(bool p_lock) override;
 
-	void space_changed(bool p_lock = true) override;
+	void _space_changing(bool p_lock = true) override;
 
-	void areas_changed(bool p_lock = true);
+	void _space_changed(bool p_lock = true) override;
 
-	void joints_changed(bool p_lock = true);
+	void _areas_changed(bool p_lock = true);
 
-	void transform_changed(bool p_lock = true) override;
+	void _joints_changed(bool p_lock = true);
 
-	void motion_changed(bool p_lock = true);
+	void _transform_changed(bool p_lock = true) override;
 
-	void exceptions_changed(bool p_lock = true);
+	void _motion_changed(bool p_lock = true);
 
-	void axis_lock_changed(bool p_lock = true);
+	void _exceptions_changed(bool p_lock = true);
+
+	void _axis_lock_changed(bool p_lock = true);
 
 	LocalVector<Contact> contacts;
 

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -127,41 +127,41 @@ public:
 protected:
 	friend class JoltShapeImpl3D;
 
-	virtual JPH::BroadPhaseLayer get_broad_phase_layer() const = 0;
+	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const = 0;
 
-	JPH::ObjectLayer get_object_layer() const;
+	JPH::ObjectLayer _get_object_layer() const;
 
-	virtual JPH::EMotionType get_motion_type() const = 0;
+	virtual JPH::EMotionType _get_motion_type() const = 0;
 
-	virtual void create_in_space() = 0;
+	virtual void _create_in_space() = 0;
 
-	virtual void add_to_space(bool p_lock = true);
+	virtual void _add_to_space(bool p_lock = true);
 
-	virtual void remove_from_space(bool p_lock = true);
+	virtual void _remove_from_space(bool p_lock = true);
 
-	virtual void destroy_in_space(bool p_lock = true);
+	virtual void _destroy_in_space(bool p_lock = true);
 
-	virtual void apply_transform(const Transform3D& p_transform, bool p_lock = true);
+	virtual void _apply_transform(const Transform3D& p_transform, bool p_lock = true);
 
-	void create_begin();
+	void _create_begin();
 
-	JPH::Body* create_end();
+	JPH::Body* _create_end();
 
-	void update_object_layer(bool p_lock = true);
+	void _update_object_layer(bool p_lock = true);
 
-	virtual void collision_layer_changed(bool p_lock = true);
+	virtual void _collision_layer_changed(bool p_lock = true);
 
-	virtual void collision_mask_changed(bool p_lock = true);
+	virtual void _collision_mask_changed(bool p_lock = true);
 
-	virtual void shapes_changed(bool p_lock = true);
+	virtual void _shapes_changed(bool p_lock = true);
 
-	virtual void shapes_built([[maybe_unused]] bool p_lock = true) { }
+	virtual void _shapes_built([[maybe_unused]] bool p_lock = true) { }
 
-	virtual void space_changing([[maybe_unused]] bool p_lock = true) { }
+	virtual void _space_changing([[maybe_unused]] bool p_lock = true) { }
 
-	virtual void space_changed([[maybe_unused]] bool p_lock = true) { }
+	virtual void _space_changed([[maybe_unused]] bool p_lock = true) { }
 
-	virtual void transform_changed([[maybe_unused]] bool p_lock = true) { }
+	virtual void _transform_changed([[maybe_unused]] bool p_lock = true) { }
 
 	LocalVector<JoltShapeInstance3D> shapes;
 

--- a/src/objects/jolt_physics_direct_body_state_3d.hpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.hpp
@@ -6,7 +6,6 @@ class JoltPhysicsDirectBodyState3D final : public PhysicsDirectBodyState3DExtens
 	GDCLASS_NO_WARN(JoltPhysicsDirectBodyState3D, PhysicsDirectBodyState3DExtension)
 
 private:
-	// NOLINTNEXTLINE(readability-identifier-naming)
 	static void _bind_methods() { }
 
 public:

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -11,7 +11,6 @@ class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
 	GDCLASS_NO_WARN(JoltPhysicsServer3D, PhysicsServer3DExtension)
 
 private:
-	// NOLINTNEXTLINE(readability-identifier-naming)
 	static void _bind_methods() { }
 
 public:

--- a/src/servers/jolt_physics_server_factory_3d.hpp
+++ b/src/servers/jolt_physics_server_factory_3d.hpp
@@ -6,7 +6,6 @@ class JoltPhysicsServerFactory3D final : public Object {
 	GDCLASS_NO_WARN(JoltPhysicsServerFactory3D, Object)
 
 private:
-	// NOLINTNEXTLINE(readability-identifier-naming)
 	static void _bind_methods() {
 		ClassDB::bind_method(D_METHOD("create_server"), &JoltPhysicsServerFactory3D::create_server);
 	}

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -14,7 +14,7 @@ Variant JoltBoxShapeImpl3D::get_data() const {
 
 void JoltBoxShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -26,7 +26,7 @@ void JoltBoxShapeImpl3D::set_data(const Variant& p_data) {
 
 void JoltBoxShapeImpl3D::set_margin(float p_margin) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -38,7 +38,7 @@ String JoltBoxShapeImpl3D::to_string() const {
 	return vformat("{half_extents=%v margin=%f}", half_extents, margin);
 }
 
-JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
+JPH::ShapeRefC JoltBoxShapeImpl3D::_build() const {
 	const float min_half_extent = half_extents[half_extents.min_axis_index()];
 	const float shrunk_margin = min(margin, min_half_extent * MARGIN_FACTOR);
 	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
@@ -54,7 +54,7 @@ JPH::ShapeRefC JoltBoxShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_box_shape_impl_3d.hpp
+++ b/src/shapes/jolt_box_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	Vector3 half_extents;
 

--- a/src/shapes/jolt_capsule_shape_impl_3d.cpp
+++ b/src/shapes/jolt_capsule_shape_impl_3d.cpp
@@ -9,7 +9,7 @@ Variant JoltCapsuleShapeImpl3D::get_data() const {
 
 void JoltCapsuleShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -32,7 +32,7 @@ String JoltCapsuleShapeImpl3D::to_string() const {
 	return vformat("{height=%f radius=%f}", height, radius);
 }
 
-JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
+JPH::ShapeRefC JoltCapsuleShapeImpl3D::_build() const {
 	ERR_FAIL_COND_D_MSG(
 		radius <= 0.0f,
 		vformat(
@@ -40,7 +40,7 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 			"Its radius must be greater than 0. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -51,7 +51,7 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 			"Its height must be greater than 0. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -62,7 +62,7 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 			"Its height must be at least double that of its radius. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -80,7 +80,7 @@ JPH::ShapeRefC JoltCapsuleShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_capsule_shape_impl_3d.hpp
+++ b/src/shapes/jolt_capsule_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	float height = 0.0f;
 

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -9,7 +9,7 @@ Variant JoltConcavePolygonShapeImpl3D::get_data() const {
 
 void JoltConcavePolygonShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -32,7 +32,7 @@ String JoltConcavePolygonShapeImpl3D::to_string() const {
 	return vformat("{vertex_count=%d}", faces.size());
 }
 
-JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
+JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 	const auto vertex_count = (int32_t)faces.size();
 	const int32_t face_count = vertex_count / 3;
 	const int32_t excess_vertex_count = vertex_count % 3;
@@ -49,7 +49,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 			"It must have a vertex count of at least 3. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -60,7 +60,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 			"It must have a vertex count that is divisible by 3. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -101,7 +101,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	PackedVector3Array faces;
 

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -8,7 +8,7 @@ Variant JoltConvexPolygonShapeImpl3D::get_data() const {
 
 void JoltConvexPolygonShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -20,7 +20,7 @@ void JoltConvexPolygonShapeImpl3D::set_data(const Variant& p_data) {
 
 void JoltConvexPolygonShapeImpl3D::set_margin(float p_margin) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -32,7 +32,7 @@ String JoltConvexPolygonShapeImpl3D::to_string() const {
 	return vformat("{vertex_count=%d margin=%f}", vertices.size(), margin);
 }
 
-JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
+JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::_build() const {
 	const auto vertex_count = (int32_t)vertices.size();
 
 	ERR_FAIL_COND_D_MSG(
@@ -42,7 +42,7 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 			"It must have a vertex count of at least 3. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -69,7 +69,7 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.hpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	PackedVector3Array vertices;
 

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -17,7 +17,7 @@ Variant JoltCylinderShapeImpl3D::get_data() const {
 
 void JoltCylinderShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -38,7 +38,7 @@ void JoltCylinderShapeImpl3D::set_data(const Variant& p_data) {
 
 void JoltCylinderShapeImpl3D::set_margin(float p_margin) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -50,7 +50,7 @@ String JoltCylinderShapeImpl3D::to_string() const {
 	return vformat("{height=%f radius=%f margin=%f}", height, radius, margin);
 }
 
-JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
+JPH::ShapeRefC JoltCylinderShapeImpl3D::_build() const {
 	const float half_height = height / 2.0f;
 	const float shrunk_margin = min(margin, half_height * MARGIN_FACTOR, radius * MARGIN_FACTOR);
 	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
@@ -66,7 +66,7 @@ JPH::ShapeRefC JoltCylinderShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_cylinder_shape_impl_3d.hpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	float height = 0.0f;
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -10,7 +10,7 @@ Variant JoltHeightMapShapeImpl3D::get_data() const {
 
 void JoltHeightMapShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -37,7 +37,7 @@ String JoltHeightMapShapeImpl3D::to_string() const {
 	return vformat("{height_count=%d width=%d depth=%d}", heights.size(), width, depth);
 }
 
-JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
+JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build() const {
 	const auto height_count = (int32_t)heights.size();
 
 	// NOTE(mihe): This somewhat arbitrary limit depends on what the block size is set to, which by
@@ -49,7 +49,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 			"Height count must be at least 16. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -60,7 +60,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 			"Height count must be the product of width and depth. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -71,7 +71,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 			"Width must be equal to depth. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -82,7 +82,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 			"Width/depth must be a power-of-two. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -111,7 +111,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.hpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	PackedFloat32Array heights;
 

--- a/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
+++ b/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
@@ -11,7 +11,7 @@ Variant JoltSeparationRayShapeImpl3D::get_data() const {
 
 void JoltSeparationRayShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -34,7 +34,7 @@ String JoltSeparationRayShapeImpl3D::to_string() const {
 	return vformat("{length=%f slide_on_slope=%s}", length, slide_on_slope);
 }
 
-JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
+JPH::ShapeRefC JoltSeparationRayShapeImpl3D::_build() const {
 	ERR_FAIL_COND_D_MSG(
 		length <= 0.0f,
 		vformat(
@@ -42,7 +42,7 @@ JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 			"Its length must be greater than 0. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -57,7 +57,7 @@ JPH::ShapeRefC JoltSeparationRayShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_separation_ray_shape_impl_3d.hpp
+++ b/src/shapes/jolt_separation_ray_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	float length = 0.0f;
 

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -41,14 +41,14 @@ void JoltShapeImpl3D::set_solver_bias(float p_bias) {
 			"Custom solver bias for shapes is not supported by Godot Jolt. "
 			"Any such value will be ignored. "
 			"This shape belongs to %s.",
-			owners_to_string()
+			_owners_to_string()
 		));
 	}
 }
 
 JPH::ShapeRefC JoltShapeImpl3D::try_build() {
 	if (jolt_ref == nullptr) {
-		jolt_ref = build();
+		jolt_ref = _build();
 	}
 
 	return jolt_ref;
@@ -178,13 +178,13 @@ JPH::ShapeRefC JoltShapeImpl3D::with_user_data(const JPH::Shape* p_shape, uint64
 	return shape_result.Get();
 }
 
-void JoltShapeImpl3D::invalidated(bool p_lock) {
+void JoltShapeImpl3D::_invalidated(bool p_lock) {
 	for (const auto& [owner, ref_count] : ref_counts_by_owner) {
-		owner->shapes_changed(p_lock);
+		owner->_shapes_changed(p_lock);
 	}
 }
 
-String JoltShapeImpl3D::owners_to_string() const {
+String JoltShapeImpl3D::_owners_to_string() const {
 	const int32_t owner_count = ref_counts_by_owner.size();
 
 	if (owner_count == 0) {

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -70,11 +70,11 @@ public:
 	static JPH::ShapeRefC as_compound(TCallable&& p_callable);
 
 protected:
-	virtual JPH::ShapeRefC build() const = 0;
+	virtual JPH::ShapeRefC _build() const = 0;
 
-	virtual void invalidated(bool p_lock = true);
+	virtual void _invalidated(bool p_lock = true);
 
-	String owners_to_string() const;
+	String _owners_to_string() const;
 
 	HashMap<JoltObjectImpl3D*, int32_t> ref_counts_by_owner;
 

--- a/src/shapes/jolt_sphere_shape_impl_3d.cpp
+++ b/src/shapes/jolt_sphere_shape_impl_3d.cpp
@@ -6,7 +6,7 @@ Variant JoltSphereShapeImpl3D::get_data() const {
 
 void JoltSphereShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -20,7 +20,7 @@ String JoltSphereShapeImpl3D::to_string() const {
 	return vformat("{radius=%f}", radius);
 }
 
-JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
+JPH::ShapeRefC JoltSphereShapeImpl3D::_build() const {
 	ERR_FAIL_COND_D_MSG(
 		radius <= 0.0f,
 		vformat(
@@ -28,7 +28,7 @@ JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
 			"Its radius must be greater than 0. "
 			"This shape belongs to %s.",
 			to_string(),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 
@@ -43,7 +43,7 @@ JPH::ShapeRefC JoltSphereShapeImpl3D::build() const {
 			"This shape belongs to %s.",
 			to_string(),
 			to_godot(shape_result.GetError()),
-			owners_to_string()
+			_owners_to_string()
 		)
 	);
 

--- a/src/shapes/jolt_sphere_shape_impl_3d.hpp
+++ b/src/shapes/jolt_sphere_shape_impl_3d.hpp
@@ -19,7 +19,7 @@ public:
 	String to_string() const;
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	float radius = 0.0f;
 };

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
@@ -6,7 +6,7 @@ Variant JoltWorldBoundaryShapeImpl3D::get_data() const {
 
 void JoltWorldBoundaryShapeImpl3D::set_data(const Variant& p_data) {
 	ON_SCOPE_EXIT {
-		invalidated();
+		_invalidated();
 	};
 
 	destroy();
@@ -16,11 +16,11 @@ void JoltWorldBoundaryShapeImpl3D::set_data(const Variant& p_data) {
 	plane = p_data;
 }
 
-JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::build() const {
+JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::_build() const {
 	ERR_FAIL_D_MSG(vformat(
 		"WorldBoundaryShape3D is not supported by Godot Jolt. "
 		"Consider using one or more reasonably sized BoxShape3D instead. "
 		"This shape belongs to %s.",
-		owners_to_string()
+		_owners_to_string()
 	));
 }

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.hpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.hpp
@@ -17,7 +17,7 @@ public:
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
 private:
-	JPH::ShapeRefC build() const override;
+	JPH::ShapeRefC _build() const override;
 
 	Plane plane;
 };

--- a/src/spaces/jolt_body_accessor_3d.cpp
+++ b/src/spaces/jolt_body_accessor_3d.cpp
@@ -24,7 +24,7 @@ void JoltBodyAccessor3D::acquire(const JPH::BodyID* p_ids, int32_t p_id_count, b
 
 	lock_iface = &space->get_lock_iface(p_lock);
 	ids = BodyIDSpan(p_ids, p_id_count);
-	acquire_internal(p_ids, p_id_count);
+	_acquire_internal(p_ids, p_id_count);
 }
 
 void JoltBodyAccessor3D::acquire(const JPH::BodyID& p_id, bool p_lock) {
@@ -32,7 +32,7 @@ void JoltBodyAccessor3D::acquire(const JPH::BodyID& p_id, bool p_lock) {
 
 	lock_iface = &space->get_lock_iface(p_lock);
 	ids = p_id;
-	acquire_internal(&p_id, 1);
+	_acquire_internal(&p_id, 1);
 }
 
 void JoltBodyAccessor3D::acquire_active(bool p_lock) {
@@ -49,7 +49,7 @@ void JoltBodyAccessor3D::acquire_active(bool p_lock) {
 
 	space->get_physics_system().GetActiveBodies(*vector);
 
-	acquire_internal(vector->data(), (int32_t)vector->size());
+	_acquire_internal(vector->data(), (int32_t)vector->size());
 }
 
 void JoltBodyAccessor3D::acquire_all(bool p_lock) {
@@ -66,11 +66,11 @@ void JoltBodyAccessor3D::acquire_all(bool p_lock) {
 
 	space->get_physics_system().GetBodies(*vector);
 
-	acquire_internal(vector->data(), (int32_t)vector->size());
+	_acquire_internal(vector->data(), (int32_t)vector->size());
 }
 
 void JoltBodyAccessor3D::release() {
-	release_internal();
+	_release_internal();
 	lock_iface = nullptr;
 }
 
@@ -133,12 +133,12 @@ const JPH::Body* JoltBodyReader3D::try_get() const {
 	return try_get(0);
 }
 
-void JoltBodyReader3D::acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) {
+void JoltBodyReader3D::_acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) {
 	mutex_mask = lock_iface->GetMutexMask(p_ids, p_id_count);
 	lock_iface->LockRead(mutex_mask);
 }
 
-void JoltBodyReader3D::release_internal() {
+void JoltBodyReader3D::_release_internal() {
 	ERR_FAIL_COND(not_acquired());
 	lock_iface->UnlockRead(mutex_mask);
 }
@@ -161,12 +161,12 @@ JPH::Body* JoltBodyWriter3D::try_get() const {
 	return try_get(0);
 }
 
-void JoltBodyWriter3D::acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) {
+void JoltBodyWriter3D::_acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) {
 	mutex_mask = lock_iface->GetMutexMask(p_ids, p_id_count);
 	lock_iface->LockWrite(mutex_mask);
 }
 
-void JoltBodyWriter3D::release_internal() {
+void JoltBodyWriter3D::_release_internal() {
 	ERR_FAIL_COND(not_acquired());
 	lock_iface->UnlockWrite(mutex_mask);
 }

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -44,9 +44,9 @@ public:
 	const JPH::BodyID& get_at(int32_t p_index) const;
 
 protected:
-	virtual void acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) = 0;
+	virtual void _acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) = 0;
 
-	virtual void release_internal() = 0;
+	virtual void _release_internal() = 0;
 
 	const JoltSpace3D* space = nullptr;
 
@@ -66,9 +66,9 @@ public:
 	const JPH::Body* try_get() const;
 
 private:
-	void acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) override;
+	void _acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) override;
 
-	void release_internal() override;
+	void _release_internal() override;
 
 	JPH::BodyLockInterface::MutexMask mutex_mask = 0;
 };
@@ -84,9 +84,9 @@ public:
 	JPH::Body* try_get() const;
 
 private:
-	void acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) override;
+	void _acquire_internal(const JPH::BodyID* p_ids, int32_t p_id_count) override;
 
-	void release_internal() override;
+	void _release_internal() override;
 
 	JPH::BodyLockInterface::MutexMask mutex_mask = 0;
 };

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -30,10 +30,10 @@ void JoltContactListener3D::pre_step() {
 }
 
 void JoltContactListener3D::post_step() {
-	flush_contacts();
-	flush_area_shifts();
-	flush_area_exits();
-	flush_area_enters();
+	_flush_contacts();
+	_flush_area_shifts();
+	_flush_area_exits();
+	_flush_area_enters();
 }
 
 void JoltContactListener3D::OnContactAdded(
@@ -42,13 +42,13 @@ void JoltContactListener3D::OnContactAdded(
 	const JPH::ContactManifold& p_manifold,
 	JPH::ContactSettings& p_settings
 ) {
-	try_override_collision_response(p_body1, p_body2, p_settings);
-	try_apply_surface_velocities(p_body1, p_body2, p_settings);
-	try_add_contacts(p_body1, p_body2, p_manifold, p_settings);
-	try_add_area_overlap(p_body1, p_body2, p_manifold);
+	_try_override_collision_response(p_body1, p_body2, p_settings);
+	_try_apply_surface_velocities(p_body1, p_body2, p_settings);
+	_try_add_contacts(p_body1, p_body2, p_manifold, p_settings);
+	_try_add_area_overlap(p_body1, p_body2, p_manifold);
 
 #ifdef GDJ_CONFIG_EDITOR
-	try_add_debug_contacts(p_manifold);
+	_try_add_debug_contacts(p_manifold);
 #endif // GDJ_CONFIG_EDITOR
 }
 
@@ -58,26 +58,26 @@ void JoltContactListener3D::OnContactPersisted(
 	const JPH::ContactManifold& p_manifold,
 	JPH::ContactSettings& p_settings
 ) {
-	try_override_collision_response(p_body1, p_body2, p_settings);
-	try_apply_surface_velocities(p_body1, p_body2, p_settings);
-	try_add_contacts(p_body1, p_body2, p_manifold, p_settings);
+	_try_override_collision_response(p_body1, p_body2, p_settings);
+	_try_apply_surface_velocities(p_body1, p_body2, p_settings);
+	_try_add_contacts(p_body1, p_body2, p_manifold, p_settings);
 
 #ifdef GDJ_CONFIG_EDITOR
-	try_add_debug_contacts(p_manifold);
+	_try_add_debug_contacts(p_manifold);
 #endif // GDJ_CONFIG_EDITOR
 }
 
 void JoltContactListener3D::OnContactRemoved(const JPH::SubShapeIDPair& p_shape_pair) {
-	if (!try_remove_contacts(p_shape_pair)) {
-		try_remove_area_overlap(p_shape_pair);
+	if (!_try_remove_contacts(p_shape_pair)) {
+		_try_remove_area_overlap(p_shape_pair);
 	}
 }
 
-bool JoltContactListener3D::is_listening_for(const JPH::Body& p_body) const {
+bool JoltContactListener3D::_is_listening_for(const JPH::Body& p_body) const {
 	return listening_for.has(p_body.GetID());
 }
 
-bool JoltContactListener3D::try_override_collision_response(
+bool JoltContactListener3D::_try_override_collision_response(
 	const JPH::Body& p_body1,
 	const JPH::Body& p_body2,
 	JPH::ContactSettings& p_settings
@@ -126,7 +126,7 @@ bool JoltContactListener3D::try_override_collision_response(
 	return true;
 }
 
-bool JoltContactListener3D::try_apply_surface_velocities(
+bool JoltContactListener3D::_try_apply_surface_velocities(
 	const JPH::Body& p_jolt_body1,
 	const JPH::Body& p_jolt_body2,
 	JPH::ContactSettings& p_settings
@@ -176,7 +176,7 @@ bool JoltContactListener3D::try_apply_surface_velocities(
 	return true;
 }
 
-bool JoltContactListener3D::try_add_contacts(
+bool JoltContactListener3D::_try_add_contacts(
 	const JPH::Body& p_body1,
 	const JPH::Body& p_body2,
 	const JPH::ContactManifold& p_manifold,
@@ -186,7 +186,7 @@ bool JoltContactListener3D::try_add_contacts(
 		return false;
 	}
 
-	if (!is_listening_for(p_body1) && !is_listening_for(p_body2)) {
+	if (!_is_listening_for(p_body1) && !_is_listening_for(p_body2)) {
 		return false;
 	}
 
@@ -254,7 +254,7 @@ bool JoltContactListener3D::try_add_contacts(
 	return true;
 }
 
-bool JoltContactListener3D::try_add_area_overlap(
+bool JoltContactListener3D::_try_add_area_overlap(
 	const JPH::Body& p_body1,
 	const JPH::Body& p_body2,
 	const JPH::ContactManifold& p_manifold
@@ -263,7 +263,7 @@ bool JoltContactListener3D::try_add_area_overlap(
 		return false;
 	}
 
-	if (!is_listening_for(p_body1) && !is_listening_for(p_body2)) {
+	if (!_is_listening_for(p_body1) && !_is_listening_for(p_body2)) {
 		return false;
 	}
 
@@ -277,13 +277,13 @@ bool JoltContactListener3D::try_add_area_overlap(
 	return true;
 }
 
-bool JoltContactListener3D::try_remove_contacts(const JPH::SubShapeIDPair& p_shape_pair) {
+bool JoltContactListener3D::_try_remove_contacts(const JPH::SubShapeIDPair& p_shape_pair) {
 	const MutexLock write_lock(write_mutex);
 
 	return manifolds_by_shape_pair.erase(p_shape_pair);
 }
 
-bool JoltContactListener3D::try_remove_area_overlap(const JPH::SubShapeIDPair& p_shape_pair) {
+bool JoltContactListener3D::_try_remove_area_overlap(const JPH::SubShapeIDPair& p_shape_pair) {
 	const MutexLock write_lock(write_mutex);
 
 	if (!area_overlaps.erase(p_shape_pair)) {
@@ -297,7 +297,7 @@ bool JoltContactListener3D::try_remove_area_overlap(const JPH::SubShapeIDPair& p
 
 #ifdef GDJ_CONFIG_EDITOR
 
-bool JoltContactListener3D::try_add_debug_contacts(const JPH::ContactManifold& p_manifold) {
+bool JoltContactListener3D::_try_add_debug_contacts(const JPH::ContactManifold& p_manifold) {
 	const int64_t max_count = debug_contacts.size();
 
 	if (max_count == 0) {
@@ -335,7 +335,7 @@ bool JoltContactListener3D::try_add_debug_contacts(const JPH::ContactManifold& p
 
 #endif // GDJ_CONFIG_EDITOR
 
-void JoltContactListener3D::flush_contacts() {
+void JoltContactListener3D::_flush_contacts() {
 	for (auto&& [shape_pair, manifold] : manifolds_by_shape_pair) {
 		const JPH::BodyID body_ids[] = {shape_pair.GetBody1ID(), shape_pair.GetBody2ID()};
 
@@ -389,7 +389,7 @@ void JoltContactListener3D::flush_contacts() {
 	}
 }
 
-void JoltContactListener3D::flush_area_enters() {
+void JoltContactListener3D::_flush_area_enters() {
 	for (const JPH::SubShapeIDPair& shape_pair : area_enters) {
 		const JPH::BodyID& body_id1 = shape_pair.GetBody1ID();
 		const JPH::BodyID& body_id2 = shape_pair.GetBody2ID();
@@ -433,7 +433,7 @@ void JoltContactListener3D::flush_area_enters() {
 	area_enters.clear();
 }
 
-void JoltContactListener3D::flush_area_shifts() {
+void JoltContactListener3D::_flush_area_shifts() {
 	for (const JPH::SubShapeIDPair& shape_pair : area_overlaps) {
 		auto is_shifted = [&](const JPH::BodyID& p_body_id, const JPH::SubShapeID& p_sub_shape_id) {
 			const JoltReadableBody3D jolt_body = space->read_body(p_body_id, false);
@@ -462,7 +462,7 @@ void JoltContactListener3D::flush_area_shifts() {
 	}
 }
 
-void JoltContactListener3D::flush_area_exits() {
+void JoltContactListener3D::_flush_area_exits() {
 	for (const JPH::SubShapeIDPair& shape_pair : area_exits) {
 		const JPH::BodyID& body_id1 = shape_pair.GetBody1ID();
 		const JPH::BodyID& body_id2 = shape_pair.GetBody2ID();

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -91,48 +91,48 @@ private:
 
 	void OnContactRemoved(const JPH::SubShapeIDPair& p_shape_pair) override;
 
-	bool is_listening_for(const JPH::Body& p_body) const;
+	bool _is_listening_for(const JPH::Body& p_body) const;
 
-	bool try_override_collision_response(
+	bool _try_override_collision_response(
 		const JPH::Body& p_body1,
 		const JPH::Body& p_body2,
 		JPH::ContactSettings& p_settings
 	);
 
-	bool try_apply_surface_velocities(
+	bool _try_apply_surface_velocities(
 		const JPH::Body& p_jolt_body1,
 		const JPH::Body& p_jolt_body2,
 		JPH::ContactSettings& p_settings
 	);
 
-	bool try_add_contacts(
+	bool _try_add_contacts(
 		const JPH::Body& p_body1,
 		const JPH::Body& p_body2,
 		const JPH::ContactManifold& p_manifold,
 		JPH::ContactSettings& p_settings
 	);
 
-	bool try_add_area_overlap(
+	bool _try_add_area_overlap(
 		const JPH::Body& p_body1,
 		const JPH::Body& p_body2,
 		const JPH::ContactManifold& p_manifold
 	);
 
-	bool try_remove_contacts(const JPH::SubShapeIDPair& p_shape_pair);
+	bool _try_remove_contacts(const JPH::SubShapeIDPair& p_shape_pair);
 
-	bool try_remove_area_overlap(const JPH::SubShapeIDPair& p_shape_pair);
+	bool _try_remove_area_overlap(const JPH::SubShapeIDPair& p_shape_pair);
 
 #ifdef GDJ_CONFIG_EDITOR
-	bool try_add_debug_contacts(const JPH::ContactManifold& p_manifold);
+	bool _try_add_debug_contacts(const JPH::ContactManifold& p_manifold);
 #endif // GDJ_CONFIG_EDITOR
 
-	void flush_contacts();
+	void _flush_contacts();
 
-	void flush_area_enters();
+	void _flush_area_enters();
 
-	void flush_area_shifts();
+	void _flush_area_shifts();
 
-	void flush_area_exits();
+	void _flush_area_exits();
 
 	ManifoldsByShapePair manifolds_by_shape_pair;
 

--- a/src/spaces/jolt_debug_geometry_3d.hpp
+++ b/src/spaces/jolt_debug_geometry_3d.hpp
@@ -15,7 +15,6 @@ public:
 	};
 
 private:
-	// NOLINTNEXTLINE(readability-identifier-naming)
 	static void _bind_methods();
 
 public:

--- a/src/spaces/jolt_debug_renderer_3d.cpp
+++ b/src/spaces/jolt_debug_renderer_3d.cpp
@@ -156,8 +156,8 @@ int32_t JoltDebugRenderer3D::submit(const RID& p_mesh) {
 }
 
 void JoltDebugRenderer3D::DrawLine(JPH::Vec3 p_from, JPH::Vec3 p_to, JPH::Color p_color) {
-	reserve_lines(1);
-	add_line(to_godot(p_from), to_godot(p_to), to_godot(p_color).to_abgr32());
+	_reserve_lines(1);
+	_add_line(to_godot(p_from), to_godot(p_to), to_godot(p_color).to_abgr32());
 }
 
 void JoltDebugRenderer3D::DrawTriangle(
@@ -166,9 +166,9 @@ void JoltDebugRenderer3D::DrawTriangle(
 	JPH::Vec3 p_vertex3,
 	JPH::Color p_color
 ) {
-	reserve_triangles(1);
+	_reserve_triangles(1);
 
-	add_triangle(
+	_add_triangle(
 		to_godot(p_vertex3),
 		to_godot(p_vertex2),
 		to_godot(p_vertex1),
@@ -255,9 +255,9 @@ void JoltDebugRenderer3D::DrawGeometry(
 
 	if (p_draw_mode == JPH::DebugRenderer::EDrawMode::Solid) {
 		if (p_cull_mode != JPH::DebugRenderer::ECullMode::Off) {
-			reserve_triangles(model_triangle_count);
+			_reserve_triangles(model_triangle_count);
 		} else {
-			reserve_triangles(model_triangle_count * 2);
+			_reserve_triangles(model_triangle_count * 2);
 		}
 
 		for (int32_t i = 0; i < model_triangle_count; ++i) {
@@ -269,19 +269,19 @@ void JoltDebugRenderer3D::DrawGeometry(
 
 			switch (p_cull_mode) {
 				case JPH::DebugRenderer::ECullMode::CullBackFace: {
-					add_triangle(v2, v1, v0, model_color_abgr);
+					_add_triangle(v2, v1, v0, model_color_abgr);
 				} break;
 				case JPH::DebugRenderer::ECullMode::CullFrontFace: {
-					add_triangle(v0, v1, v2, model_color_abgr);
+					_add_triangle(v0, v1, v2, model_color_abgr);
 				} break;
 				case JPH::DebugRenderer::ECullMode::Off: {
-					add_triangle(v0, v1, v2, model_color_abgr);
-					add_triangle(v2, v1, v0, model_color_abgr);
+					_add_triangle(v0, v1, v2, model_color_abgr);
+					_add_triangle(v2, v1, v0, model_color_abgr);
 				} break;
 			}
 		}
 	} else {
-		reserve_lines(model_triangle_count * 3);
+		_reserve_lines(model_triangle_count * 3);
 
 		for (int32_t i = 0; i < model_triangle_count; ++i) {
 			const int32_t vertex_offset = i * 3;
@@ -290,9 +290,9 @@ void JoltDebugRenderer3D::DrawGeometry(
 			const Vector3 v1 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 1]);
 			const Vector3 v2 = to_godot(p_model_matrix * model_vertices_ptr[vertex_offset + 2]);
 
-			add_line(v0, v1, model_color_abgr);
-			add_line(v1, v2, model_color_abgr);
-			add_line(v2, v0, model_color_abgr);
+			_add_line(v0, v1, model_color_abgr);
+			_add_line(v1, v2, model_color_abgr);
+			_add_line(v2, v0, model_color_abgr);
 		}
 	}
 }
@@ -306,7 +306,7 @@ void JoltDebugRenderer3D::DrawText3D(
 	ERR_FAIL_NOT_IMPL();
 }
 
-void JoltDebugRenderer3D::reserve_triangles(int32_t p_extra_capacity) {
+void JoltDebugRenderer3D::_reserve_triangles(int32_t p_extra_capacity) {
 	if (triangle_count + p_extra_capacity <= triangle_capacity) {
 		return;
 	}
@@ -318,7 +318,7 @@ void JoltDebugRenderer3D::reserve_triangles(int32_t p_extra_capacity) {
 	triangle_attributes.resize(vertex_count * DEBUG_ATTRIBUTE_STRIDE);
 }
 
-void JoltDebugRenderer3D::reserve_lines(int32_t p_extra_capacity) {
+void JoltDebugRenderer3D::_reserve_lines(int32_t p_extra_capacity) {
 	if (line_count + p_extra_capacity <= line_capacity) {
 		return;
 	}
@@ -330,7 +330,7 @@ void JoltDebugRenderer3D::reserve_lines(int32_t p_extra_capacity) {
 	line_attributes.resize(vertex_count * DEBUG_ATTRIBUTE_STRIDE);
 }
 
-void JoltDebugRenderer3D::add_triangle(
+void JoltDebugRenderer3D::_add_triangle(
 	const Vector3& p_vertex1,
 	const Vector3& p_vertex2,
 	const Vector3& p_vertex3,
@@ -356,7 +356,7 @@ void JoltDebugRenderer3D::add_triangle(
 	triangle_count++;
 }
 
-void JoltDebugRenderer3D::add_line(
+void JoltDebugRenderer3D::_add_line(
 	const Vector3& p_from,
 	const Vector3& p_to,
 	uint32_t p_color_abgr

--- a/src/spaces/jolt_debug_renderer_3d.hpp
+++ b/src/spaces/jolt_debug_renderer_3d.hpp
@@ -80,18 +80,18 @@ private:
 		float p_height = 0.5f
 	) override;
 
-	void reserve_triangles(int32_t p_extra_capacity);
+	void _reserve_triangles(int32_t p_extra_capacity);
 
-	void reserve_lines(int32_t p_extra_capacity);
+	void _reserve_lines(int32_t p_extra_capacity);
 
-	void add_triangle(
+	void _add_triangle(
 		const Vector3& p_vertex1,
 		const Vector3& p_vertex2,
 		const Vector3& p_vertex3,
 		uint32_t p_color_abgr
 	);
 
-	void add_line(const Vector3& p_from, const Vector3& p_to, uint32_t p_color_abgr);
+	void _add_line(const Vector3& p_from, const Vector3& p_to, uint32_t p_color_abgr);
 
 	inline static JoltDebugRenderer3D* singleton = nullptr;
 

--- a/src/spaces/jolt_job_system.cpp
+++ b/src/spaces/jolt_job_system.cpp
@@ -70,12 +70,12 @@ void JoltJobSystem::Job::queue() {
 	// HACK(mihe): Ideally we would use Jolt's actual job name here, but I'd rather not incur the
 	// overhead of a memory allocation or thread-safe lookup every time we create/queue a task. So
 	// instead we use the same cached description for all of them.
-	static const String description("JoltPhysics");
+	static const String name("JoltPhysics");
 
-	task_id = WorkerThreadPool::get_singleton()->add_native_task(&execute, this, true, description);
+	task_id = WorkerThreadPool::get_singleton()->add_native_task(&_execute, this, true, name);
 }
 
-void JoltJobSystem::Job::execute(void* p_user_data) {
+void JoltJobSystem::Job::_execute(void* p_user_data) {
 	auto* job = static_cast<Job*>(p_user_data);
 
 	job->Execute();

--- a/src/spaces/jolt_job_system.hpp
+++ b/src/spaces/jolt_job_system.hpp
@@ -36,7 +36,7 @@ private:
 		Job& operator=(Job&& p_other) = delete;
 
 	private:
-		static void execute(void* p_user_data);
+		static void _execute(void* p_user_data);
 
 		inline static std::atomic<Job*> completed_head = nullptr;
 

--- a/src/spaces/jolt_layer_mapper.cpp
+++ b/src/spaces/jolt_layer_mapper.cpp
@@ -92,7 +92,7 @@ constexpr void decode_collision(
 } // namespace
 
 JoltLayerMapper::JoltLayerMapper() {
-	allocate_object_layer(0);
+	_allocate_object_layer(0);
 }
 
 JPH::ObjectLayer JoltLayerMapper::to_object_layer(
@@ -122,7 +122,7 @@ JPH::ObjectLayer JoltLayerMapper::to_object_layer(
 			)
 		);
 
-		object_layer = allocate_object_layer(collision);
+		object_layer = _allocate_object_layer(collision);
 	}
 
 	return encode_layers(p_broad_phase_layer, object_layer);
@@ -211,7 +211,7 @@ bool JoltLayerMapper::ShouldCollide(
 	return matrix.should_collide(broad_phase_layer1, p_broad_phase_layer2);
 }
 
-JPH::ObjectLayer JoltLayerMapper::allocate_object_layer(uint64_t p_collision) {
+JPH::ObjectLayer JoltLayerMapper::_allocate_object_layer(uint64_t p_collision) {
 	const JPH::ObjectLayer new_object_layer = next_object_layer++;
 
 	collisions_by_layer.resize(new_object_layer + 1);

--- a/src/spaces/jolt_layer_mapper.hpp
+++ b/src/spaces/jolt_layer_mapper.hpp
@@ -35,7 +35,7 @@ private:
 	bool ShouldCollide(JPH::ObjectLayer p_encoded_layer1, JPH::BroadPhaseLayer p_broad_phase_layer2)
 		const override;
 
-	JPH::ObjectLayer allocate_object_layer(uint64_t p_collision);
+	JPH::ObjectLayer _allocate_object_layer(uint64_t p_collision);
 
 	InlineVector<uint64_t, 32> collisions_by_layer;
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -233,7 +233,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	cast_motion(
+	_cast_motion_impl(
 		*jolt_shape,
 		transform_com,
 		scale,
@@ -509,14 +509,14 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	const Vector3 direction = p_motion.normalized();
 
 	Vector3 recovery;
-	const bool recovered = body_motion_recover(p_body, transform, direction, p_margin, recovery);
+	const bool recovered = _body_motion_recover(p_body, transform, direction, p_margin, recovery);
 
 	transform.origin += recovery;
 
 	float safe_fraction = 1.0f;
 	float unsafe_fraction = 1.0f;
 
-	const bool hit = body_motion_cast(
+	const bool hit = _body_motion_cast(
 		p_body,
 		transform,
 		scale,
@@ -529,7 +529,7 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	bool collided = false;
 
 	if (hit || (recovered && p_recovery_as_collision)) {
-		collided = body_motion_collide(
+		collided = _body_motion_collide(
 			p_body,
 			transform.translated(p_motion * unsafe_fraction),
 			direction,
@@ -560,7 +560,7 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	return collided;
 }
 
-bool JoltPhysicsDirectSpaceState3D::cast_motion(
+bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 	const JPH::Shape& p_jolt_shape,
 	const Transform3D& p_transform_com,
 	const Vector3& p_scale,
@@ -697,7 +697,7 @@ bool JoltPhysicsDirectSpaceState3D::cast_motion(
 	return collided;
 }
 
-bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
+bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_direction,
@@ -806,7 +806,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_recover(
 	return recovered;
 }
 
-bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
+bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_scale,
@@ -848,7 +848,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
 		float shape_safe_fraction = 1.0f;
 		float shape_unsafe_fraction = 1.0f;
 
-		collided |= cast_motion(
+		collided |= _cast_motion_impl(
 			*jolt_shape,
 			transform_com_unscaled,
 			scale,
@@ -870,7 +870,7 @@ bool JoltPhysicsDirectSpaceState3D::body_motion_cast(
 	return collided;
 }
 
-bool JoltPhysicsDirectSpaceState3D::body_motion_collide(
+bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
 	const Vector3& p_direction,

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -8,7 +8,6 @@ class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3DExte
 	GDCLASS_NO_WARN(JoltPhysicsDirectSpaceState3D, PhysicsDirectSpaceState3DExtension)
 
 private:
-	// NOLINTNEXTLINE(readability-identifier-naming)
 	static void _bind_methods() { }
 
 public:
@@ -103,7 +102,7 @@ public:
 	JoltSpace3D& get_space() const { return *space; }
 
 private:
-	bool cast_motion(
+	bool _cast_motion_impl(
 		const JPH::Shape& p_jolt_shape,
 		const Transform3D& p_transform_com,
 		const Vector3& p_scale,
@@ -118,7 +117,7 @@ private:
 		float& p_closest_unsafe
 	) const;
 
-	bool body_motion_recover(
+	bool _body_motion_recover(
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_direction,
@@ -126,7 +125,7 @@ private:
 		Vector3& p_recovery
 	) const;
 
-	bool body_motion_cast(
+	bool _body_motion_cast(
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_scale,
@@ -136,7 +135,7 @@ private:
 		float& p_unsafe_fraction
 	) const;
 
-	bool body_motion_collide(
+	bool _body_motion_collide(
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_direction,

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -85,7 +85,7 @@ JoltSpace3D::~JoltSpace3D() {
 void JoltSpace3D::step(float p_step) {
 	last_step = p_step;
 
-	pre_step(p_step);
+	_pre_step(p_step);
 
 	switch (physics_system->Update(p_step, 1, temp_allocator, job_system)) {
 		case JPH::EPhysicsUpdateError::None: {
@@ -120,7 +120,7 @@ void JoltSpace3D::step(float p_step) {
 		} break;
 	}
 
-	post_step(p_step);
+	_post_step(p_step);
 
 	has_stepped = true;
 }
@@ -396,7 +396,7 @@ void JoltSpace3D::set_max_debug_contacts(int32_t p_count) {
 
 #endif // GDJ_CONFIG_EDITOR
 
-void JoltSpace3D::pre_step(float p_step) {
+void JoltSpace3D::_pre_step(float p_step) {
 	body_accessor.acquire_all(true);
 
 	contact_listener->pre_step();
@@ -418,7 +418,7 @@ void JoltSpace3D::pre_step(float p_step) {
 	body_accessor.release();
 }
 
-void JoltSpace3D::post_step(float p_step) {
+void JoltSpace3D::_post_step(float p_step) {
 	body_accessor.acquire_all(true);
 
 	contact_listener->post_step();

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -99,9 +99,9 @@ public:
 #endif // GDJ_CONFIG_EDITOR
 
 private:
-	void pre_step(float p_step);
+	void _pre_step(float p_step);
 
-	void post_step(float p_step);
+	void _post_step(float p_step);
 
 	JoltBodyWriter3D body_accessor;
 


### PR DESCRIPTION
Since we're already mostly aligned with Godot's code standard, I figured we might as well take the plunge and go with the underscore prefix for private/protected methods as well. This helps get rid of some `NOLINT` suppressions strewn throughout the code, for things like `_bind_methods`, which there would likely have to be more of as we start adding more custom nodes.