### PR TITLE
Updated godot-cpp to 6478e0f9f7 (4.1)

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT f5077b47711589c8fa6c3d4a907572c58fc6d9f6
+	GIT_COMMIT 6478e0f9f778dd70c1364d6a1ffaf2d1a44a16a4
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@f5077b47711589c8fa6c3d4a907572c58fc6d9f6 aka 4.1-stable to godot-jolt/godot-cpp@6478e0f9f778dd70c1364d6a1ffaf2d1a44a16a4 aka 4.1-stable (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/f5077b47711589c8fa6c3d4a907572c58fc6d9f6...6478e0f9f778dd70c1364d6a1ffaf2d1a44a16a4)).

This disables the [automatic removal](https://github.com/godotengine/godot-cpp/blob/749b0b9ae03ecac470027b17c6414e7a0e730923/src/godot.cpp#L405) of editor plugins, which is currently causing a use-after-free and is not needed for the use-cases of this extension.