### PR TITLE
Added `JoltPinJoint3D` along with editor/gizmo plugin

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -136,6 +136,8 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 	);
 
 	space->add_joint(this);
+
+	_update_enabled();
 }
 
 JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(

--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -138,6 +138,7 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 
 	_update_enabled();
+	_update_iterations();
 }
 
 JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -427,6 +427,8 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 
 	space->add_joint(this);
 
+	_update_enabled();
+
 	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
 		_update_motor_state(axis);
 		_update_motor_velocity(axis);

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -428,6 +428,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 
 	_update_enabled();
+	_update_iterations();
 
 	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
 		_update_motor_state(axis);

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -212,6 +212,7 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 
 	_update_enabled();
+	_update_iterations();
 	_update_motor_state();
 	_update_motor_velocity();
 	_update_motor_limit();

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -211,6 +211,7 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 
 	space->add_joint(this);
 
+	_update_enabled();
 	_update_motor_state();
 	_update_motor_velocity();
 	_update_motor_limit();

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -1,0 +1,327 @@
+#include "jolt_joint_3d.hpp"
+
+#include "servers/jolt_physics_server_3d.hpp"
+
+namespace {
+
+JoltPhysicsServer3D* get_physics_server() {
+	static auto* singleton = dynamic_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
+	return singleton;
+}
+
+} // namespace
+
+void JoltJoint3D::_bind_methods() {
+	BIND_METHOD(JoltJoint3D, get_enabled);
+	BIND_METHOD(JoltJoint3D, set_enabled);
+
+	BIND_METHOD(JoltJoint3D, get_node_a);
+	BIND_METHOD(JoltJoint3D, set_node_a);
+
+	BIND_METHOD(JoltJoint3D, get_node_b);
+	BIND_METHOD(JoltJoint3D, set_node_b);
+
+	BIND_METHOD(JoltJoint3D, get_exclude_nodes_from_collision);
+	BIND_METHOD(JoltJoint3D, set_exclude_nodes_from_collision);
+
+	BIND_METHOD(JoltJoint3D, get_solver_velocity_iterations);
+	BIND_METHOD(JoltJoint3D, set_solver_velocity_iterations);
+
+	BIND_METHOD(JoltJoint3D, get_solver_position_iterations);
+	BIND_METHOD(JoltJoint3D, set_solver_position_iterations);
+
+	BIND_METHOD(JoltJoint3D, body_exiting_tree);
+
+	BIND_PROPERTY_HINTED(
+		"node_a",
+		Variant::NODE_PATH,
+		PROPERTY_HINT_NODE_PATH_VALID_TYPES,
+		"PhysicsBody3D"
+	);
+
+	BIND_PROPERTY_HINTED(
+		"node_b",
+		Variant::NODE_PATH,
+		PROPERTY_HINT_NODE_PATH_VALID_TYPES,
+		"PhysicsBody3D"
+	);
+
+	BIND_PROPERTY("enabled", Variant::BOOL);
+
+	BIND_PROPERTY("exclude_nodes_from_collision", Variant::BOOL);
+
+	BIND_PROPERTY_RANGED("solver_velocity_iterations", Variant::INT, U"0,64,or_greater");
+	BIND_PROPERTY_RANGED("solver_position_iterations", Variant::INT, U"0,64,or_greater");
+}
+
+JoltJoint3D::JoltJoint3D() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	rid = physics_server->joint_create();
+}
+
+JoltJoint3D::~JoltJoint3D() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->free_rid(rid);
+}
+
+void JoltJoint3D::set_node_a(NodePath p_path) {
+	if (node_a == p_path) {
+		return;
+	}
+
+	_nodes_changing();
+	node_a = p_path;
+	_nodes_changed();
+}
+
+void JoltJoint3D::set_node_b(NodePath p_path) {
+	if (node_b == p_path) {
+		return;
+	}
+
+	_nodes_changing();
+	node_b = p_path;
+	_nodes_changed();
+}
+
+PhysicsBody3D* JoltJoint3D::get_body_a() const {
+	return Object::cast_to<PhysicsBody3D>(get_node_or_null(node_a));
+}
+
+PhysicsBody3D* JoltJoint3D::get_body_b() const {
+	return Object::cast_to<PhysicsBody3D>(get_node_or_null(node_b));
+}
+
+void JoltJoint3D::set_enabled(bool p_enabled) {
+	if (enabled == p_enabled) {
+		return;
+	}
+
+	enabled = p_enabled;
+
+	_enabled_changed();
+}
+
+void JoltJoint3D::set_exclude_nodes_from_collision(bool p_excluded) {
+	if (collision_excluded == p_excluded) {
+		return;
+	}
+
+	collision_excluded = p_excluded;
+
+	_collision_exclusion_changed();
+}
+
+void JoltJoint3D::set_solver_velocity_iterations(int32_t p_iterations) {
+	if (velocity_iterations == p_iterations) {
+		return;
+	}
+
+	velocity_iterations = p_iterations;
+
+	_velocity_iterations_changed();
+}
+
+void JoltJoint3D::set_solver_position_iterations(int32_t p_iterations) {
+	if (position_iterations == p_iterations) {
+		return;
+	}
+
+	position_iterations = p_iterations;
+
+	_position_iterations_changed();
+}
+
+void JoltJoint3D::body_exiting_tree() {
+	_destroy();
+}
+
+PackedStringArray JoltJoint3D::_get_configuration_warnings() const {
+	PackedStringArray warnings = Node3D::_get_configuration_warnings();
+
+	if (!warning.is_empty()) {
+		warnings.push_back(warning);
+	}
+
+	return warnings;
+}
+
+void JoltJoint3D::_notification(int32_t p_what) {
+	Node3D::_notification(p_what);
+
+	switch (p_what) {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			_build();
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			_destroy();
+		} break;
+	}
+}
+
+void JoltJoint3D::_connect_bodies() {
+	PhysicsBody3D* body_a = get_body_a();
+	PhysicsBody3D* body_b = get_body_b();
+
+	static const StringName exit_signal("tree_exiting");
+
+	const Callable exit_callable(this, "body_exiting_tree");
+
+	if (body_a) {
+		body_a->connect(exit_signal, exit_callable);
+	}
+
+	if (body_b) {
+		body_b->connect(exit_signal, exit_callable);
+	}
+}
+
+void JoltJoint3D::_disconnect_bodies() {
+	PhysicsBody3D* body_a = get_body_a();
+	PhysicsBody3D* body_b = get_body_b();
+
+	static const StringName exit_signal("tree_exiting");
+
+	const Callable exit_callable(this, "body_exiting_tree");
+
+	if (body_a != nullptr && body_a->is_connected(exit_signal, exit_callable)) {
+		body_a->disconnect(exit_signal, exit_callable);
+	}
+
+	if (body_b != nullptr && body_b->is_connected(exit_signal, exit_callable)) {
+		body_b->disconnect(exit_signal, exit_callable);
+	}
+}
+
+bool JoltJoint3D::_validate() {
+	PhysicsBody3D* body_a = get_body_a();
+	PhysicsBody3D* body_b = get_body_b();
+
+	const bool valid_node_a = !node_a.is_empty();
+	const bool valid_node_b = !node_b.is_empty();
+
+	const bool valid_body_a = body_a != nullptr;
+	const bool valid_body_b = body_b != nullptr;
+
+	String new_warning;
+
+	if (valid_node_a && !valid_body_a) {
+		new_warning = U"Node A must be of type PhysicsBody3D";
+	} else if (valid_node_b && !valid_body_b) {
+		new_warning = U"Node B must be of type PhysicsBody3D";
+	} else if (!valid_node_a && !valid_node_b) {
+		new_warning = U"Joint does not connect any nodes";
+	} else if (body_a == body_b) {
+		new_warning = U"Node A and Node B must be different nodes";
+	}
+
+	if (warning != new_warning) {
+		warning = new_warning;
+		_configuration_warnings_changed();
+	}
+
+	return warning.is_empty();
+}
+
+bool JoltJoint3D::_configure() {
+	if (!_validate()) {
+		return false;
+	}
+
+	PhysicsBody3D* body_a = get_body_a();
+	PhysicsBody3D* body_b = get_body_b();
+
+	if (body_a) {
+		_configure(body_a, body_b);
+	} else if (body_b) {
+		_configure(body_b, nullptr);
+	}
+
+	return true;
+}
+
+bool JoltJoint3D::_build() {
+	if (!_configure()) {
+		return false;
+	}
+
+	_update_enabled();
+	_update_collision_exclusion();
+	_update_velocity_iterations();
+	_update_position_iterations();
+
+	_connect_bodies();
+
+	return true;
+}
+
+void JoltJoint3D::_destroy() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->joint_disable_collisions_between_bodies(rid, false);
+	physics_server->joint_clear(rid);
+
+	_disconnect_bodies();
+}
+
+void JoltJoint3D::_update_enabled() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->joint_set_enabled(rid, enabled);
+}
+
+void JoltJoint3D::_update_collision_exclusion() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->joint_disable_collisions_between_bodies(rid, collision_excluded);
+}
+
+void JoltJoint3D::_update_velocity_iterations() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->joint_set_solver_velocity_iterations(rid, velocity_iterations);
+}
+
+void JoltJoint3D::_update_position_iterations() {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->joint_set_solver_position_iterations(rid, position_iterations);
+}
+
+void JoltJoint3D::_nodes_changing() {
+	_destroy();
+}
+
+void JoltJoint3D::_nodes_changed() {
+	_build();
+}
+
+void JoltJoint3D::_configuration_warnings_changed() {
+	update_configuration_warnings();
+}
+
+void JoltJoint3D::_enabled_changed() {
+	_update_enabled();
+}
+
+void JoltJoint3D::_collision_exclusion_changed() {
+	_update_collision_exclusion();
+}
+
+void JoltJoint3D::_velocity_iterations_changed() {
+	_update_velocity_iterations();
+}
+
+void JoltJoint3D::_position_iterations_changed() {
+	_update_position_iterations();
+}

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -68,7 +68,7 @@ JoltJoint3D::~JoltJoint3D() {
 	physics_server->free_rid(rid);
 }
 
-void JoltJoint3D::set_node_a(NodePath p_path) {
+void JoltJoint3D::set_node_a(const NodePath& p_path) {
 	if (node_a == p_path) {
 		return;
 	}
@@ -78,7 +78,7 @@ void JoltJoint3D::set_node_a(NodePath p_path) {
 	_nodes_changed();
 }
 
-void JoltJoint3D::set_node_b(NodePath p_path) {
+void JoltJoint3D::set_node_b(const NodePath& p_path) {
 	if (node_b == p_path) {
 		return;
 	}
@@ -161,6 +161,9 @@ void JoltJoint3D::_notification(int32_t p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			_destroy();
 		} break;
+
+		default: {
+		} break;
 	}
 }
 
@@ -172,11 +175,11 @@ void JoltJoint3D::_connect_bodies() {
 
 	const Callable exit_callable(this, "body_exiting_tree");
 
-	if (body_a) {
+	if (body_a != nullptr) {
 		body_a->connect(exit_signal, exit_callable);
 	}
 
-	if (body_b) {
+	if (body_b != nullptr) {
 		body_b->connect(exit_signal, exit_callable);
 	}
 }
@@ -236,9 +239,9 @@ bool JoltJoint3D::_configure() {
 	PhysicsBody3D* body_a = get_body_a();
 	PhysicsBody3D* body_b = get_body_b();
 
-	if (body_a) {
+	if (body_a != nullptr) {
 		_configure(body_a, body_b);
-	} else if (body_b) {
+	} else if (body_b != nullptr) {
 		_configure(body_b, nullptr);
 	}
 

--- a/src/joints/jolt_joint_3d.hpp
+++ b/src/joints/jolt_joint_3d.hpp
@@ -9,15 +9,15 @@ private:
 public:
 	JoltJoint3D();
 
-	~JoltJoint3D();
+	~JoltJoint3D() override;
 
 	NodePath get_node_a() const { return node_a; }
 
-	void set_node_a(NodePath p_path);
+	void set_node_a(const NodePath& p_path);
 
 	NodePath get_node_b() const { return node_b; }
 
-	void set_node_b(NodePath p_path);
+	void set_node_b(const NodePath& p_path);
 
 	PhysicsBody3D* get_body_a() const;
 

--- a/src/joints/jolt_joint_3d.hpp
+++ b/src/joints/jolt_joint_3d.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+class JoltJoint3D : public Node3D {
+	GDCLASS_NO_WARN(JoltJoint3D, Node3D)
+
+private:
+	static void _bind_methods();
+
+public:
+	JoltJoint3D();
+
+	~JoltJoint3D();
+
+	NodePath get_node_a() const { return node_a; }
+
+	void set_node_a(NodePath p_path);
+
+	NodePath get_node_b() const { return node_b; }
+
+	void set_node_b(NodePath p_path);
+
+	PhysicsBody3D* get_body_a() const;
+
+	PhysicsBody3D* get_body_b() const;
+
+	bool get_enabled() const { return enabled; }
+
+	void set_enabled(bool p_enabled);
+
+	bool get_exclude_nodes_from_collision() const { return collision_excluded; }
+
+	void set_exclude_nodes_from_collision(bool p_excluded);
+
+	int32_t get_solver_velocity_iterations() const { return velocity_iterations; }
+
+	void set_solver_velocity_iterations(int32_t p_iterations);
+
+	int32_t get_solver_position_iterations() const { return position_iterations; }
+
+	void set_solver_position_iterations(int32_t p_iterations);
+
+	void body_exiting_tree();
+
+	PackedStringArray _get_configuration_warnings() const override;
+
+protected:
+	virtual void _configure(
+		[[maybe_unused]] PhysicsBody3D* p_body_a,
+		[[maybe_unused]] PhysicsBody3D* p_body_b
+	) { }
+
+	void _notification(int32_t p_what);
+
+	void _connect_bodies();
+
+	void _disconnect_bodies();
+
+	bool _validate();
+
+	bool _configure();
+
+	bool _build();
+
+	void _destroy();
+
+	void _update_enabled();
+
+	void _update_collision_exclusion();
+
+	void _update_velocity_iterations();
+
+	void _update_position_iterations();
+
+	void _nodes_changing();
+
+	void _nodes_changed();
+
+	void _configuration_warnings_changed();
+
+	void _enabled_changed();
+
+	void _collision_exclusion_changed();
+
+	void _velocity_iterations_changed();
+
+	void _position_iterations_changed();
+
+	String warning;
+
+	RID rid;
+
+	NodePath node_a;
+
+	NodePath node_b;
+
+	int32_t velocity_iterations = 0;
+
+	int32_t position_iterations = 0;
+
+	bool enabled = true;
+
+	bool collision_excluded = true;
+};

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -39,7 +39,7 @@ void JoltJointGizmoPlugin3D::_redraw(const Ref<EditorNode3DGizmo>& p_gizmo) {
 	Ref<Material> material_body_a = get_material(U"joint_body_a", p_gizmo);
 	Ref<Material> material_body_b = get_material(U"joint_body_b", p_gizmo);
 
-	if (auto* pin_joint = Object::cast_to<JoltPinJoint3D>(joint)) {
+	if (Object::cast_to<JoltPinJoint3D>(joint) != nullptr) {
 		constexpr float size = 0.25f;
 
 		PackedVector3Array points;

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -1,0 +1,60 @@
+#include "jolt_joint_gizmo_plugin_3d.hpp"
+
+#ifdef GDJ_CONFIG_EDITOR
+
+#include "joints/jolt_pin_joint_3d.hpp"
+
+bool JoltJointGizmoPlugin3D::_has_gizmo(Node3D* p_node) const {
+	return Object::cast_to<JoltJoint3D>(p_node) != nullptr;
+}
+
+String JoltJointGizmoPlugin3D::_get_gizmo_name() const {
+	return U"JoltJoint3D";
+}
+
+void JoltJointGizmoPlugin3D::_redraw(const Ref<EditorNode3DGizmo>& p_gizmo) {
+	auto* joint = Object::cast_to<JoltJoint3D>(p_gizmo->get_node_3d());
+
+	p_gizmo->clear();
+
+	PhysicsBody3D* body_a = joint->get_body_a();
+	QUIET_FAIL_NULL(body_a);
+
+	PhysicsBody3D* body_b = joint->get_body_b();
+	QUIET_FAIL_NULL(body_b);
+
+	if (!created_materials) {
+		// HACK(mihe): Ideally we would do this in the constructor, but the documentation generation
+		// will instantiate this too early in the program's flow, leading to a bunch of errors about
+		// missing editor settings.
+
+		create_material(U"joint", Color(0.5f, 0.8f, 1.0f));
+		create_material(U"joint_body_a", Color(0.6f, 0.8f, 1.0f));
+		create_material(U"joint_body_b", Color(0.6f, 0.9f, 1.0f));
+
+		created_materials = true;
+	}
+
+	Ref<Material> material_common = get_material(U"joint", p_gizmo);
+	Ref<Material> material_body_a = get_material(U"joint_body_a", p_gizmo);
+	Ref<Material> material_body_b = get_material(U"joint_body_b", p_gizmo);
+
+	if (auto* pin_joint = Object::cast_to<JoltPinJoint3D>(joint)) {
+		constexpr float size = 0.25f;
+
+		PackedVector3Array points;
+		points.resize(6);
+
+		points[0] = Vector3(+size, 0, 0);
+		points[1] = Vector3(-size, 0, 0);
+		points[2] = Vector3(0, +size, 0);
+		points[3] = Vector3(0, -size, 0);
+		points[4] = Vector3(0, 0, +size);
+		points[5] = Vector3(0, 0, -size);
+
+		p_gizmo->add_collision_segments(points);
+		p_gizmo->add_lines(points, material_common);
+	}
+}
+
+#endif // GDJ_CONFIG_EDITOR

--- a/src/joints/jolt_joint_gizmo_plugin_3d.hpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef GDJ_CONFIG_EDITOR
+
+class JoltJointGizmoPlugin3D final : public EditorNode3DGizmoPlugin {
+	GDCLASS_NO_WARN(JoltJointGizmoPlugin3D, EditorNode3DGizmoPlugin)
+
+private:
+	static void _bind_methods() { }
+
+public:
+	bool _has_gizmo(Node3D* p_node) const override;
+
+	String _get_gizmo_name() const override;
+
+	void _redraw(const Ref<EditorNode3DGizmo>& p_gizmo) override;
+
+private:
+	bool created_materials = false;
+};
+
+#endif // GDJ_CONFIG_EDITOR

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -16,7 +16,8 @@ JoltJointImpl3D::JoltJointImpl3D(
 	const Transform3D& p_local_ref_a,
 	const Transform3D& p_local_ref_b
 )
-	: collision_disabled(p_old_joint.collision_disabled)
+	: enabled(p_old_joint.enabled)
+	, collision_disabled(p_old_joint.collision_disabled)
 	, body_a(p_body_a)
 	, body_b(p_body_b)
 	, rid(p_old_joint.rid)
@@ -60,6 +61,16 @@ JoltSpace3D* JoltJointImpl3D::get_space() const {
 	}
 
 	return space_a;
+}
+
+void JoltJointImpl3D::set_enabled(bool p_enabled) {
+	if (enabled == p_enabled) {
+		return;
+	}
+
+	enabled = p_enabled;
+
+	_enabled_changed();
 }
 
 int32_t JoltJointImpl3D::get_solver_priority() const {
@@ -134,6 +145,16 @@ void JoltJointImpl3D::_shift_reference_frames(
 
 	p_shifted_ref_a = Transform3D(shifted_basis_a, shifted_origin_a);
 	p_shifted_ref_b = Transform3D(basis_b, origin_b);
+}
+
+void JoltJointImpl3D::_update_enabled() {
+	if (jolt_ref != nullptr) {
+		jolt_ref->SetEnabled(enabled);
+	}
+}
+
+void JoltJointImpl3D::_enabled_changed() {
+	_update_enabled();
 }
 
 String JoltJointImpl3D::_bodies_to_string() const {

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -88,6 +88,26 @@ void JoltJointImpl3D::set_solver_priority(int32_t p_priority) {
 	}
 }
 
+void JoltJointImpl3D::set_solver_velocity_iterations(int32_t p_iterations) {
+	if (velocity_iterations == p_iterations) {
+		return;
+	}
+
+	velocity_iterations = p_iterations;
+
+	_iterations_changed();
+}
+
+void JoltJointImpl3D::set_solver_position_iterations(int32_t p_iterations) {
+	if (position_iterations == p_iterations) {
+		return;
+	}
+
+	position_iterations = p_iterations;
+
+	_iterations_changed();
+}
+
 void JoltJointImpl3D::set_collision_disabled(bool p_disabled) {
 	collision_disabled = p_disabled;
 
@@ -153,8 +173,19 @@ void JoltJointImpl3D::_update_enabled() {
 	}
 }
 
+void JoltJointImpl3D::_update_iterations() {
+	if (jolt_ref != nullptr) {
+		jolt_ref->SetNumVelocityStepsOverride(velocity_iterations);
+		jolt_ref->SetNumPositionStepsOverride(position_iterations);
+	}
+}
+
 void JoltJointImpl3D::_enabled_changed() {
 	_update_enabled();
+}
+
+void JoltJointImpl3D::_iterations_changed() {
+	_update_iterations();
 }
 
 String JoltJointImpl3D::_bodies_to_string() const {

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -27,6 +27,10 @@ public:
 
 	JPH::Constraint* get_jolt_ref() const { return jolt_ref; }
 
+	bool is_enabled() const { return enabled; }
+
+	void set_enabled(bool p_enabled);
+
 	int32_t get_solver_priority() const;
 
 	void set_solver_priority(int32_t p_priority);
@@ -47,7 +51,13 @@ protected:
 		Transform3D& p_shifted_ref_b
 	);
 
+	void _update_enabled();
+
+	void _enabled_changed();
+
 	String _bodies_to_string() const;
+
+	bool enabled = true;
 
 	bool collision_disabled = false;
 

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -35,6 +35,14 @@ public:
 
 	void set_solver_priority(int32_t p_priority);
 
+	int32_t get_solver_velocity_iterations() const { return velocity_iterations; }
+
+	void set_solver_velocity_iterations(int32_t p_iterations);
+
+	int32_t get_solver_position_iterations() const { return position_iterations; }
+
+	void set_solver_position_iterations(int32_t p_iterations);
+
 	bool is_collision_disabled() const { return collision_disabled; }
 
 	void set_collision_disabled(bool p_disabled);
@@ -53,13 +61,21 @@ protected:
 
 	void _update_enabled();
 
+	void _update_iterations();
+
 	void _enabled_changed();
+
+	void _iterations_changed();
 
 	String _bodies_to_string() const;
 
 	bool enabled = true;
 
 	bool collision_disabled = false;
+
+	int32_t velocity_iterations = 0;
+
+	int32_t position_iterations = 0;
 
 	JPH::Ref<JPH::Constraint> jolt_ref;
 

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -1,0 +1,38 @@
+#include "jolt_pin_joint_3d.hpp"
+
+#include "servers/jolt_physics_server_3d.hpp"
+
+namespace {
+
+JoltPhysicsServer3D* get_physics_server() {
+	static auto* singleton = dynamic_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
+	return singleton;
+}
+
+} // namespace
+
+void JoltPinJoint3D::_bind_methods() {
+	BIND_METHOD(JoltPinJoint3D, get_total_lambda_position);
+}
+
+Vector3 JoltPinJoint3D::get_total_lambda_position() const {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL_D(physics_server);
+
+	return physics_server->pin_joint_get_total_lambda_position(rid);
+}
+
+void JoltPinJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {
+	JoltPhysicsServer3D* physics_server = get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	const Vector3 global_position = get_global_position();
+
+	physics_server->joint_make_pin(
+		rid,
+		p_body_a->get_rid(),
+		p_body_a->to_local(global_position),
+		p_body_b != nullptr ? p_body_b->get_rid() : RID(),
+		p_body_b != nullptr ? p_body_b->to_local(global_position) : global_position
+	);
+}

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -12,14 +12,14 @@ JoltPhysicsServer3D* get_physics_server() {
 } // namespace
 
 void JoltPinJoint3D::_bind_methods() {
-	BIND_METHOD(JoltPinJoint3D, get_total_lambda_position);
+	BIND_METHOD(JoltPinJoint3D, get_linear_impulse);
 }
 
-Vector3 JoltPinJoint3D::get_total_lambda_position() const {
+Vector3 JoltPinJoint3D::get_linear_impulse() const {
 	JoltPhysicsServer3D* physics_server = get_physics_server();
 	ERR_FAIL_NULL_D(physics_server);
 
-	return physics_server->pin_joint_get_total_lambda_position(rid);
+	return physics_server->pin_joint_get_linear_impulse(rid);
 }
 
 void JoltPinJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -9,7 +9,7 @@ private:
 	static void _bind_methods();
 
 public:
-	Vector3 get_total_lambda_position() const;
+	Vector3 get_linear_impulse() const;
 
 private:
 	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "jolt_joint_3d.hpp"
+
+class JoltPinJoint3D final : public JoltJoint3D {
+	GDCLASS_NO_WARN(JoltPinJoint3D, JoltJoint3D)
+
+private:
+	static void _bind_methods();
+
+public:
+	Vector3 get_total_lambda_position() const;
+
+private:
+	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;
+};

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -94,6 +94,14 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 	}
 }
 
+Vector3 JoltPinJointImpl3D::get_total_lambda_position() const {
+	ERR_FAIL_NULL_D(jolt_ref);
+
+	auto* constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());
+
+	return to_godot(constraint->GetTotalLambdaPosition());
+}
+
 void JoltPinJointImpl3D::rebuild(bool p_lock) {
 	destroy();
 
@@ -129,6 +137,7 @@ void JoltPinJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 
 	_update_enabled();
+	_update_iterations();
 }
 
 JPH::Constraint* JoltPinJointImpl3D::_build_pin(

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -127,6 +127,8 @@ void JoltPinJointImpl3D::rebuild(bool p_lock) {
 	jolt_ref = _build_pin(jolt_body_a, jolt_body_b, shifted_ref_a, shifted_ref_b);
 
 	space->add_joint(this);
+
+	_update_enabled();
 }
 
 JPH::Constraint* JoltPinJointImpl3D::_build_pin(

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -94,7 +94,7 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 	}
 }
 
-Vector3 JoltPinJointImpl3D::get_total_lambda_position() const {
+Vector3 JoltPinJointImpl3D::get_linear_impulse() const {
 	ERR_FAIL_NULL_D(jolt_ref);
 
 	auto* constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -30,7 +30,7 @@ public:
 
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
 
-	Vector3 get_total_lambda_position() const;
+	Vector3 get_linear_impulse() const;
 
 	void rebuild(bool p_lock = true) override;
 

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -30,6 +30,8 @@ public:
 
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
 
+	Vector3 get_total_lambda_position() const;
+
 	void rebuild(bool p_lock = true) override;
 
 private:

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -395,6 +395,7 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 	space->add_joint(this);
 
 	_update_enabled();
+	_update_iterations();
 }
 
 JPH::Constraint* JoltSliderJointImpl3D::_build_slider(

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -393,6 +393,8 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 	}
 
 	space->add_joint(this);
+
+	_update_enabled();
 }
 
 JPH::Constraint* JoltSliderJointImpl3D::_build_slider(

--- a/src/misc/bind_macros.hpp
+++ b/src/misc/bind_macros.hpp
@@ -18,5 +18,13 @@
 		"get_" m_name                                            \
 	)
 
+#define BIND_PROPERTY_RANGED(m_name, m_type, m_hint_str)               \
+	ClassDB::add_property(                                             \
+		get_class_static(),                                            \
+		PropertyInfo(m_type, m_name, PROPERTY_HINT_RANGE, m_hint_str), \
+		"set_" m_name,                                                 \
+		"get_" m_name                                                  \
+	)
+
 #define BIND_PROPERTY_ENUM(m_name, m_hint_str) \
 	BIND_PROPERTY_HINTED(m_name, Variant::INT, PROPERTY_HINT_ENUM, m_hint_str)

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -18,6 +18,7 @@
 #include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/object.hpp>
 #include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/physics_body3d.hpp>
 #include <godot_cpp/classes/physics_direct_body_state3d_extension.hpp>
 #include <godot_cpp/classes/physics_direct_space_state3d_extension.hpp>
 #include <godot_cpp/classes/physics_server3d_extension.hpp>

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -13,6 +13,11 @@
 #include <gdextension_interface.h>
 
 #include <godot_cpp/classes/camera3d.hpp>
+#include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_node3d_gizmo.hpp>
+#include <godot_cpp/classes/editor_node3d_gizmo_plugin.hpp>
+#include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/geometry_instance3d.hpp>
 #include <godot_cpp/classes/mesh.hpp>
@@ -31,6 +36,7 @@
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
 #include <godot_cpp/classes/standard_material3d.hpp>
+#include <godot_cpp/classes/theme.hpp>
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/classes/worker_thread_pool.hpp>
 #include <godot_cpp/classes/world3d.hpp>

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,3 +1,4 @@
+#include "joints/jolt_pin_joint_3d.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
 #include "servers/jolt_globals.hpp"
 #include "servers/jolt_physics_server_3d.hpp"
@@ -35,6 +36,8 @@ void on_initialize(ModuleInitializationLevel p_level) {
 			JoltProjectSettings::register_settings();
 
 			ClassDB::register_class<JoltDebugGeometry3D>();
+			ClassDB::register_class<JoltJoint3D>();
+			ClassDB::register_class<JoltPinJoint3D>();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 		} break;

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,5 +1,7 @@
+#include "joints/jolt_joint_gizmo_plugin_3d.hpp"
 #include "joints/jolt_pin_joint_3d.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
+#include "servers/jolt_editor_plugin.hpp"
 #include "servers/jolt_globals.hpp"
 #include "servers/jolt_physics_server_3d.hpp"
 #include "servers/jolt_physics_server_factory_3d.hpp"
@@ -40,6 +42,11 @@ void on_initialize(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<JoltPinJoint3D>();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
+#ifdef GDJ_CONFIG_EDITOR
+			ClassDB::register_class<JoltJointGizmoPlugin3D>();
+			ClassDB::register_class<JoltEditorPlugin>();
+			EditorPlugins::add_by_type<JoltEditorPlugin>();
+#endif // GDJ_CONFIG_EDITOR
 		} break;
 	}
 }

--- a/src/servers/jolt_editor_plugin.cpp
+++ b/src/servers/jolt_editor_plugin.cpp
@@ -1,0 +1,36 @@
+#include "jolt_editor_plugin.hpp"
+
+#ifdef GDJ_CONFIG_EDITOR
+
+void JoltEditorPlugin::_enter_tree() {
+	EditorInterface* editor_interface = get_editor_interface();
+	Control* base_control = editor_interface->get_base_control();
+
+	// HACK(mihe): For whatever reason the editor startup time takes a significant hit with every
+	// icon added unless we duplicate the theme first and manipulate that instead.
+	Ref<Theme> theme = base_control->get_theme()->duplicate();
+
+	Ref<Texture2D> icon_pin = theme->get_icon("PinJoint3D", "EditorIcons");
+	Ref<Texture2D> icon_hinge = theme->get_icon("HingeJoint3D", "EditorIcons");
+	Ref<Texture2D> icon_slider = theme->get_icon("SliderJoint3D", "EditorIcons");
+	Ref<Texture2D> icon_cone_twist = theme->get_icon("ConeTwistJoint3D", "EditorIcons");
+	Ref<Texture2D> icon_6dof = theme->get_icon("Generic6DOFJoint3D", "EditorIcons");
+
+	theme->set_icon("JoltPinJoint3D", "EditorIcons", icon_pin);
+	theme->set_icon("JoltHingeJoint3D", "EditorIcons", icon_hinge);
+	theme->set_icon("JoltSliderJoint3D", "EditorIcons", icon_slider);
+	theme->set_icon("JoltConeTwistJoint3D", "EditorIcons", icon_cone_twist);
+	theme->set_icon("JoltGeneric6DOFJoint3D", "EditorIcons", icon_6dof);
+
+	base_control->set_theme(theme);
+
+	joint_gizmo_plugin.instantiate();
+	add_node_3d_gizmo_plugin(joint_gizmo_plugin);
+}
+
+void JoltEditorPlugin::_exit_tree() {
+	remove_node_3d_gizmo_plugin(joint_gizmo_plugin);
+	joint_gizmo_plugin.unref();
+}
+
+#endif // GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_editor_plugin.hpp
+++ b/src/servers/jolt_editor_plugin.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef GDJ_CONFIG_EDITOR
+
+#include "joints/jolt_joint_gizmo_plugin_3d.hpp"
+
+class JoltEditorPlugin final : public EditorPlugin {
+	GDCLASS_NO_WARN(JoltEditorPlugin, EditorPlugin)
+
+private:
+	static void _bind_methods() { }
+
+public:
+	void _enter_tree() override;
+
+	void _exit_tree() override;
+
+private:
+	Ref<JoltJointGizmoPlugin3D> joint_gizmo_plugin;
+};
+
+#endif // GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1809,3 +1809,13 @@ void JoltPhysicsServer3D::joint_set_solver_position_iterations(
 
 	return joint->set_solver_position_iterations(p_iterations);
 }
+
+Vector3 JoltPhysicsServer3D::pin_joint_get_total_lambda_position(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
+	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
+
+	return pin_joint->get_total_lambda_position();
+}

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1775,3 +1775,37 @@ void JoltPhysicsServer3D::joint_set_enabled(const RID& p_joint, bool p_enabled) 
 
 	joint->set_enabled(p_enabled);
 }
+
+int32_t JoltPhysicsServer3D::joint_get_solver_velocity_iterations(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	return joint->get_solver_velocity_iterations();
+}
+
+void JoltPhysicsServer3D::joint_set_solver_velocity_iterations(
+	const RID& p_joint,
+	int32_t p_iterations
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	return joint->set_solver_velocity_iterations(p_iterations);
+}
+
+int32_t JoltPhysicsServer3D::joint_get_solver_position_iterations(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	return joint->get_solver_position_iterations();
+}
+
+void JoltPhysicsServer3D::joint_set_solver_position_iterations(
+	const RID& p_joint,
+	int32_t p_iterations
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	return joint->set_solver_position_iterations(p_iterations);
+}

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1810,12 +1810,12 @@ void JoltPhysicsServer3D::joint_set_solver_position_iterations(
 	return joint->set_solver_position_iterations(p_iterations);
 }
 
-Vector3 JoltPhysicsServer3D::pin_joint_get_total_lambda_position(const RID& p_joint) {
+Vector3 JoltPhysicsServer3D::pin_joint_get_linear_impulse(const RID& p_joint) {
 	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
 	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
 
-	return pin_joint->get_total_lambda_position();
+	return pin_joint->get_linear_impulse();
 }

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -22,6 +22,11 @@
 #include "spaces/jolt_physics_direct_space_state_3d.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
+void JoltPhysicsServer3D::_bind_methods() {
+	BIND_METHOD(JoltPhysicsServer3D, joint_get_enabled);
+	BIND_METHOD(JoltPhysicsServer3D, joint_set_enabled);
+}
+
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
 	JoltShapeImpl3D* shape = memnew(JoltWorldBoundaryShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);
@@ -1755,4 +1760,18 @@ void JoltPhysicsServer3D::free_joint(JoltJointImpl3D* p_joint) {
 
 	joint_owner.free(p_joint->get_rid());
 	memdelete_safely(p_joint);
+}
+
+bool JoltPhysicsServer3D::joint_get_enabled(const RID& p_joint) const {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	return joint->is_enabled();
+}
+
+void JoltPhysicsServer3D::joint_set_enabled(const RID& p_joint, bool p_enabled) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	joint->set_enabled(p_enabled);
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -571,6 +571,14 @@ public:
 
 	void joint_set_enabled(const RID& p_joint, bool p_enabled);
 
+	int32_t joint_get_solver_velocity_iterations(const RID& p_joint);
+
+	void joint_set_solver_velocity_iterations(const RID& p_joint, int32_t p_iterations);
+
+	int32_t joint_get_solver_position_iterations(const RID& p_joint);
+
+	void joint_set_solver_position_iterations(const RID& p_joint, int32_t p_iterations);
+
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -11,7 +11,7 @@ class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
 	GDCLASS_NO_WARN(JoltPhysicsServer3D, PhysicsServer3DExtension)
 
 private:
-	static void _bind_methods() { }
+	static void _bind_methods();
 
 public:
 	RID _world_boundary_shape_create() override;
@@ -566,6 +566,10 @@ public:
 	JoltShapeImpl3D* get_shape(const RID& p_rid) const { return shape_owner.get_or_null(p_rid); }
 
 	JoltJointImpl3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
+
+	bool joint_get_enabled(const RID& p_joint) const;
+
+	void joint_set_enabled(const RID& p_joint, bool p_enabled);
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -579,6 +579,8 @@ public:
 
 	void joint_set_solver_position_iterations(const RID& p_joint, int32_t p_iterations);
 
+	Vector3 pin_joint_get_total_lambda_position(const RID& p_joint);
+
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -579,7 +579,7 @@ public:
 
 	void joint_set_solver_position_iterations(const RID& p_joint, int32_t p_iterations);
 
-	Vector3 pin_joint_get_total_lambda_position(const RID& p_joint);
+	Vector3 pin_joint_get_linear_impulse(const RID& p_joint);
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;


### PR DESCRIPTION
Fixes #346.

This adds a substitute node for `PinJoint3D`, called `JoltPinJoint3D`, that matches the `PinJoint3D` interface, while adding a couple of things on top, which are as follows:

- The ability to enable/disable the joint, using its `enabled` property
- The ability to fetch its last applied impulse, using its `get_linear_impulse` method
- The ability to override the solver velocity/position iterations for that specific joint

The first and second points together allow for creating breakable joints.

Note that this also introduces an editor plugin, which is responsible for setting the editor icons for these new joint nodes, as well as registering a new gizmo plugin, which draws the editor gizmos for them.