### PR TITLE
Allowed `JoltPinJoint3D` to be used with Godot Physics

### DIFF
--- a/src/joints/jolt_joint_3d.hpp
+++ b/src/joints/jolt_joint_3d.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+class JoltPhysicsServer3D;
+
 class JoltJoint3D : public Node3D {
 	GDCLASS_NO_WARN(JoltJoint3D, Node3D)
 
@@ -44,6 +46,10 @@ public:
 	PackedStringArray _get_configuration_warnings() const override;
 
 protected:
+	static PhysicsServer3D* _get_physics_server();
+
+	static JoltPhysicsServer3D* _get_jolt_physics_server();
+
 	virtual void _configure(
 		[[maybe_unused]] PhysicsBody3D* p_body_a,
 		[[maybe_unused]] PhysicsBody3D* p_body_b

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -2,28 +2,19 @@
 
 #include "servers/jolt_physics_server_3d.hpp"
 
-namespace {
-
-JoltPhysicsServer3D* get_physics_server() {
-	static auto* singleton = dynamic_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
-	return singleton;
-}
-
-} // namespace
-
 void JoltPinJoint3D::_bind_methods() {
 	BIND_METHOD(JoltPinJoint3D, get_linear_impulse);
 }
 
 Vector3 JoltPinJoint3D::get_linear_impulse() const {
-	JoltPhysicsServer3D* physics_server = get_physics_server();
-	ERR_FAIL_NULL_D(physics_server);
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
 
 	return physics_server->pin_joint_get_linear_impulse(rid);
 }
 
 void JoltPinJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {
-	JoltPhysicsServer3D* physics_server = get_physics_server();
+	PhysicsServer3D* physics_server = _get_physics_server();
 	ERR_FAIL_NULL(physics_server);
 
 	const Vector3 global_position = get_global_position();


### PR DESCRIPTION
Since `JoltPinJoint3D` is effectively a superset of `PinJoint3D`, I figured it might be useful to be able to still use `JoltPinJoint3D` when switching over to Godot Physics, just without the Jolt-specific functionality.

This PR does exactly that, by no-op'ing anything Jolt-specific when not using `JoltPhysicsServer3D`, like enabling/disabling the joint, or using `get_linear_impulse`.

Note that this is mostly meant to be a development feature, to do things like sanity check that the two implementations behave in a similar manner, so it will still emit an error about there not being a Jolt-based physics server available.