### PR TITLE
Fixed `body_test_motion` crashing when passing a null `result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Breaking changes are denoted with ⚠️.
 
 - Fixed issue where linear axis locks could be budged a bit if enough force was applied.
 - Fixed issue where `CharacterBody3D` and other kinematic bodies wouldn't respect locked axes.
+- Fixed issue where omitting or explicitly passing `null` to the `result` parameter for the
+  `body_test_motion` method in `PhysicsServer3D` would lead to a crash.
 
 ## [0.4.1] - 2023-07-08
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -141,8 +141,7 @@ private:
 		const Vector3& p_direction,
 		float p_margin,
 		int32_t p_max_collisions,
-		PhysicsServer3DExtensionMotionCollision* p_collisions,
-		int32_t& p_collision_count
+		PhysicsServer3DExtensionMotionResult* p_result
 	) const;
 
 	JoltSpace3D* space = nullptr;


### PR DESCRIPTION
Fixes #499.