### PR TITLE
Added proper binding of method arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ else()
 		PRIVATE -Wcast-qual # Enable warnings about casting away qualifiers
 		PRIVATE -Wshadow # Enable variable/type shadowing warnings
 		PRIVATE -Wundef # Enable warnings about undefined identifiers in `#if` directives
+		PRIVATE -Wno-gnu-zero-variadic-macro-arguments # Disable zero variadic macro args warning
 		PRIVATE -pthread # Use POSIX threads
 		PRIVATE -ffast-math # Enable aggressive floating-point optimizations
 		PRIVATE -fno-exceptions # Disable support for exception-handling

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -4,22 +4,22 @@
 
 void JoltJoint3D::_bind_methods() {
 	BIND_METHOD(JoltJoint3D, get_enabled);
-	BIND_METHOD(JoltJoint3D, set_enabled);
+	BIND_METHOD(JoltJoint3D, set_enabled, "enabled");
 
 	BIND_METHOD(JoltJoint3D, get_node_a);
-	BIND_METHOD(JoltJoint3D, set_node_a);
+	BIND_METHOD(JoltJoint3D, set_node_a, "path");
 
 	BIND_METHOD(JoltJoint3D, get_node_b);
-	BIND_METHOD(JoltJoint3D, set_node_b);
+	BIND_METHOD(JoltJoint3D, set_node_b, "path");
 
 	BIND_METHOD(JoltJoint3D, get_exclude_nodes_from_collision);
-	BIND_METHOD(JoltJoint3D, set_exclude_nodes_from_collision);
+	BIND_METHOD(JoltJoint3D, set_exclude_nodes_from_collision, "excluded");
 
 	BIND_METHOD(JoltJoint3D, get_solver_velocity_iterations);
-	BIND_METHOD(JoltJoint3D, set_solver_velocity_iterations);
+	BIND_METHOD(JoltJoint3D, set_solver_velocity_iterations, "iterations");
 
 	BIND_METHOD(JoltJoint3D, get_solver_position_iterations);
-	BIND_METHOD(JoltJoint3D, set_solver_position_iterations);
+	BIND_METHOD(JoltJoint3D, set_solver_position_iterations, "iterations");
 
 	BIND_METHOD(JoltJoint3D, body_exiting_tree);
 

--- a/src/misc/bind_macros.hpp
+++ b/src/misc/bind_macros.hpp
@@ -1,6 +1,26 @@
 #pragma once
 
-#define BIND_METHOD(m_class, m_name) ClassDB::bind_method(D_METHOD(#m_name), &m_class::m_name)
+#define BIND_METHOD_0_ARGS(m_class, m_name) \
+	ClassDB::bind_method(D_METHOD(#m_name), &m_class::m_name)
+
+#define BIND_METHOD_N_ARGS(m_class, m_name, ...) \
+	ClassDB::bind_method(D_METHOD(#m_name, __VA_ARGS__), &m_class::m_name)
+
+#define BIND_METHOD_SELECT(_1, _2, _3, _4, _5, _6, _7, _8, _9, m_macro, ...) m_macro
+
+#define BIND_METHOD(...)    \
+	BIND_METHOD_SELECT(     \
+		__VA_ARGS__,        \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_N_ARGS, \
+		BIND_METHOD_0_ARGS  \
+	)                       \
+	(__VA_ARGS__)
 
 #define BIND_PROPERTY(m_name, m_type) \
 	ClassDB::add_property(            \

--- a/src/spaces/jolt_debug_geometry_3d.cpp
+++ b/src/spaces/jolt_debug_geometry_3d.cpp
@@ -6,40 +6,40 @@
 
 void JoltDebugGeometry3D::_bind_methods() {
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_bodies);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_bodies);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_bodies, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_shapes);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_shapes);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_shapes, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraints);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraints);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraints, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_bounding_boxes);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_bounding_boxes);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_bounding_boxes, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_centers_of_mass);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_centers_of_mass);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_centers_of_mass, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_transforms);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_transforms);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_transforms, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_velocities);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_velocities);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_velocities, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraint_reference_frames);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_reference_frames);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_reference_frames, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraint_limits);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_limits);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_limits, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_as_wireframe);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_as_wireframe);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_as_wireframe, "enabled");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_with_color_scheme);
-	BIND_METHOD(JoltDebugGeometry3D, set_draw_with_color_scheme);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_with_color_scheme, "color_scheme");
 
 	BIND_METHOD(JoltDebugGeometry3D, get_material_depth_test);
-	BIND_METHOD(JoltDebugGeometry3D, set_material_depth_test);
+	BIND_METHOD(JoltDebugGeometry3D, set_material_depth_test, "enabled");
 
 	ADD_GROUP("Draw", "draw_");
 


### PR DESCRIPTION
This changes the `BIND_METHOD` macro, aka `ClassDB::bind_method` to overload based on the number of arguments passed to it, which now allows for passing the names of the method's arguments, which means the arguments won't show up as `_unnamed_arg*` in the editor anymore, for things like `JoltDebugGeometry3D` and the custom joints.