### PR TITLE
Added `JoltHingeJoint3D`

### DIFF
--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -1,0 +1,326 @@
+#include "jolt_hinge_joint_3d.hpp"
+
+#include "servers/jolt_physics_server_3d.hpp"
+
+namespace {
+
+using ServerParam = PhysicsServer3D::HingeJointParam;
+using ServerFlag = PhysicsServer3D::HingeJointFlag;
+using ServerParamJolt = JoltPhysicsServer3D::HingeJointParamJolt;
+using ServerFlagJolt = JoltPhysicsServer3D::HingeJointFlagJolt;
+
+} // namespace
+
+void JoltHingeJoint3D::_bind_methods() {
+	BIND_METHOD(JoltHingeJoint3D, get_limit_enabled);
+	BIND_METHOD(JoltHingeJoint3D, set_limit_enabled, "enabled");
+
+	BIND_METHOD(JoltHingeJoint3D, get_limit_upper);
+	BIND_METHOD(JoltHingeJoint3D, set_limit_upper, "value");
+
+	BIND_METHOD(JoltHingeJoint3D, get_limit_lower);
+	BIND_METHOD(JoltHingeJoint3D, set_limit_lower, "value");
+
+	BIND_METHOD(JoltHingeJoint3D, get_limit_spring_enabled);
+	BIND_METHOD(JoltHingeJoint3D, set_limit_spring_enabled, "enabled");
+
+	BIND_METHOD(JoltHingeJoint3D, get_limit_spring_frequency);
+	BIND_METHOD(JoltHingeJoint3D, set_limit_spring_frequency, "value");
+
+	BIND_METHOD(JoltHingeJoint3D, get_limit_spring_damping);
+	BIND_METHOD(JoltHingeJoint3D, set_limit_spring_damping, "value");
+
+	BIND_METHOD(JoltHingeJoint3D, get_motor_enabled);
+	BIND_METHOD(JoltHingeJoint3D, set_motor_enabled, "enabled");
+
+	BIND_METHOD(JoltHingeJoint3D, get_motor_target_velocity);
+	BIND_METHOD(JoltHingeJoint3D, set_motor_target_velocity, "value");
+
+	BIND_METHOD(JoltHingeJoint3D, get_motor_max_torque);
+	BIND_METHOD(JoltHingeJoint3D, set_motor_max_torque, "value");
+
+	BIND_METHOD(JoltHingeJoint3D, get_linear_impulse);
+	BIND_METHOD(JoltHingeJoint3D, get_angular_impulse);
+
+	ADD_GROUP("Limit", "limit_");
+
+	BIND_PROPERTY("limit_enabled", Variant::BOOL);
+	BIND_PROPERTY_RANGED("limit_upper", Variant::FLOAT, "-180,180,0.1,radians");
+	BIND_PROPERTY_RANGED("limit_lower", Variant::FLOAT, "-180,180,0.1,radians");
+
+	ADD_GROUP("Limit Spring", "limit_spring_");
+
+	BIND_PROPERTY("limit_spring_enabled", Variant::BOOL);
+	BIND_PROPERTY("limit_spring_frequency", Variant::FLOAT, "suffix:hz");
+	BIND_PROPERTY("limit_spring_damping", Variant::FLOAT);
+
+	ADD_GROUP("Motor", "motor_");
+
+	BIND_PROPERTY("motor_enabled", Variant::BOOL);
+	BIND_PROPERTY("motor_target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("motor_max_torque", Variant::FLOAT, "suffix:Nm");
+}
+
+void JoltHingeJoint3D::set_limit_enabled(bool p_enabled) {
+	if (limit_enabled == p_enabled) {
+		return;
+	}
+
+	limit_enabled = p_enabled;
+
+	_flag_changed(FLAG_USE_LIMIT);
+}
+
+void JoltHingeJoint3D::set_limit_upper(double p_value) {
+	if (limit_upper == p_value) {
+		return;
+	}
+
+	limit_upper = p_value;
+
+	_param_changed(PARAM_LIMIT_UPPER);
+}
+
+void JoltHingeJoint3D::set_limit_lower(double p_value) {
+	if (limit_lower == p_value) {
+		return;
+	}
+
+	limit_lower = p_value;
+
+	_param_changed(PARAM_LIMIT_LOWER);
+}
+
+void JoltHingeJoint3D::set_limit_spring_enabled(bool p_enabled) {
+	if (limit_spring_enabled == p_enabled) {
+		return;
+	}
+
+	limit_spring_enabled = p_enabled;
+
+	_flag_changed(FLAG_USE_LIMIT_SPRING);
+}
+
+void JoltHingeJoint3D::set_limit_spring_frequency(double p_value) {
+	if (limit_spring_frequency == p_value) {
+		return;
+	}
+
+	limit_spring_frequency = p_value;
+
+	_param_changed(PARAM_LIMIT_SPRING_FREQUENCY);
+}
+
+void JoltHingeJoint3D::set_limit_spring_damping(double p_value) {
+	if (limit_spring_damping == p_value) {
+		return;
+	}
+
+	limit_spring_damping = p_value;
+
+	_param_changed(PARAM_LIMIT_SPRING_DAMPING);
+}
+
+void JoltHingeJoint3D::set_motor_enabled(bool p_enabled) {
+	if (motor_enabled == p_enabled) {
+		return;
+	}
+
+	motor_enabled = p_enabled;
+
+	_flag_changed(FLAG_ENABLE_MOTOR);
+}
+
+void JoltHingeJoint3D::set_motor_target_velocity(double p_value) {
+	if (motor_target_velocity == p_value) {
+		return;
+	}
+
+	motor_target_velocity = p_value;
+
+	_param_changed(PARAM_MOTOR_TARGET_VELOCITY);
+}
+
+void JoltHingeJoint3D::set_motor_max_torque(double p_value) {
+	if (motor_max_torque == p_value) {
+		return;
+	}
+
+	motor_max_torque = p_value;
+
+	_param_changed(PARAM_MOTOR_MAX_TORQUE);
+}
+
+Vector3 JoltHingeJoint3D::get_linear_impulse() const {
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
+
+	return physics_server->hinge_joint_get_linear_impulse(rid);
+}
+
+Vector3 JoltHingeJoint3D::get_angular_impulse() const {
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
+
+	return physics_server->hinge_joint_get_angular_impulse(rid);
+}
+
+void JoltHingeJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	const Transform3D global_xform = get_global_transform().orthonormalized();
+
+	auto get_local_xform = [&](const PhysicsBody3D& p_body) {
+		return (p_body.get_global_transform().affine_inverse() * global_xform).orthonormalized();
+	};
+
+	physics_server->joint_make_hinge(
+		rid,
+		p_body_a->get_rid(),
+		get_local_xform(*p_body_a),
+		p_body_b != nullptr ? p_body_b->get_rid() : RID(),
+		p_body_b != nullptr ? get_local_xform(*p_body_b) : global_xform
+	);
+
+	_update_param(PARAM_LIMIT_UPPER);
+	_update_param(PARAM_LIMIT_LOWER);
+	_update_param(PARAM_MOTOR_TARGET_VELOCITY);
+
+	_update_jolt_param(PARAM_LIMIT_SPRING_FREQUENCY);
+	_update_jolt_param(PARAM_LIMIT_SPRING_DAMPING);
+	_update_jolt_param(PARAM_MOTOR_MAX_TORQUE);
+
+	_update_flag(FLAG_USE_LIMIT);
+	_update_flag(FLAG_ENABLE_MOTOR);
+
+	_update_jolt_flag(FLAG_USE_LIMIT_SPRING);
+}
+
+void JoltHingeJoint3D::_update_param(Param p_param) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	double* value = nullptr;
+
+	switch (p_param) {
+		case PARAM_LIMIT_UPPER: {
+			value = &limit_upper;
+		} break;
+		case PARAM_LIMIT_LOWER: {
+			value = &limit_lower;
+		} break;
+		case PARAM_MOTOR_TARGET_VELOCITY: {
+			value = &motor_target_velocity;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+
+	physics_server->hinge_joint_set_param(rid, ServerParam(p_param), *value);
+}
+
+void JoltHingeJoint3D::_update_jolt_param(Param p_param) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(physics_server);
+
+	double* value = nullptr;
+
+	switch (p_param) {
+		case PARAM_LIMIT_SPRING_FREQUENCY: {
+			value = &limit_spring_frequency;
+		} break;
+		case PARAM_LIMIT_SPRING_DAMPING: {
+			value = &limit_spring_damping;
+		} break;
+		case PARAM_MOTOR_MAX_TORQUE: {
+			value = &motor_max_torque;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled Jolt parameter: '%d'", p_param));
+		} break;
+	}
+
+	physics_server->hinge_joint_set_jolt_param(rid, ServerParamJolt(p_param), *value);
+}
+
+void JoltHingeJoint3D::_update_flag(Flag p_flag) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	bool* value = nullptr;
+
+	switch (p_flag) {
+		case FLAG_USE_LIMIT: {
+			value = &limit_enabled;
+		} break;
+		case FLAG_ENABLE_MOTOR: {
+			value = &motor_enabled;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+
+	physics_server->hinge_joint_set_flag(rid, ServerFlag(p_flag), *value);
+}
+
+void JoltHingeJoint3D::_update_jolt_flag(Flag p_flag) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(physics_server);
+
+	bool* value = nullptr;
+
+	switch (p_flag) {
+		case FLAG_USE_LIMIT_SPRING: {
+			value = &limit_spring_enabled;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled Jolt flag: '%d'", p_flag));
+		} break;
+	}
+
+	physics_server->hinge_joint_set_jolt_flag(rid, ServerFlagJolt(p_flag), *value);
+}
+
+void JoltHingeJoint3D::_param_changed(Param p_param) {
+	switch (p_param) {
+		case PARAM_LIMIT_UPPER:
+		case PARAM_LIMIT_LOWER:
+		case PARAM_MOTOR_TARGET_VELOCITY: {
+			_update_param(p_param);
+		} break;
+		case PARAM_LIMIT_SPRING_FREQUENCY:
+		case PARAM_LIMIT_SPRING_DAMPING:
+		case PARAM_MOTOR_MAX_TORQUE: {
+			_update_jolt_param(p_param);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+}
+
+void JoltHingeJoint3D::_flag_changed(Flag p_flag) {
+	switch (p_flag) {
+		case FLAG_USE_LIMIT:
+		case FLAG_ENABLE_MOTOR: {
+			_update_flag(p_flag);
+		} break;
+		case FLAG_USE_LIMIT_SPRING: {
+			_update_jolt_flag(p_flag);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+}

--- a/src/joints/jolt_hinge_joint_3d.hpp
+++ b/src/joints/jolt_hinge_joint_3d.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "joints/jolt_joint_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
+
+class JoltHingeJoint3D final : public JoltJoint3D {
+	GDCLASS_NO_WARN(JoltHingeJoint3D, JoltJoint3D)
+
+public:
+	enum Param {
+		PARAM_LIMIT_UPPER = PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER,
+		PARAM_LIMIT_LOWER = PhysicsServer3D::HINGE_JOINT_LIMIT_LOWER,
+		PARAM_LIMIT_SPRING_FREQUENCY = JoltPhysicsServer3D::HINGE_JOINT_LIMIT_SPRING_FREQUENCY,
+		PARAM_LIMIT_SPRING_DAMPING = JoltPhysicsServer3D::HINGE_JOINT_LIMIT_SPRING_DAMPING,
+		PARAM_MOTOR_TARGET_VELOCITY = PhysicsServer3D::HINGE_JOINT_MOTOR_TARGET_VELOCITY,
+		PARAM_MOTOR_MAX_TORQUE = JoltPhysicsServer3D::HINGE_JOINT_MOTOR_MAX_TORQUE
+	};
+
+	enum Flag {
+		FLAG_USE_LIMIT = PhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT,
+		FLAG_USE_LIMIT_SPRING = JoltPhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT_SPRING,
+		FLAG_ENABLE_MOTOR = PhysicsServer3D::HINGE_JOINT_FLAG_ENABLE_MOTOR,
+	};
+
+private:
+	static void _bind_methods();
+
+public:
+	double get_param(Param p_param) const;
+
+	void set_param(Param p_param, double p_value);
+
+	bool get_flag(Flag p_flag) const;
+
+	void set_flag(Flag p_flag, bool p_enabled);
+
+	bool get_limit_enabled() const { return limit_enabled; }
+
+	void set_limit_enabled(bool p_enabled);
+
+	double get_limit_upper() const { return limit_upper; }
+
+	void set_limit_upper(double p_value);
+
+	double get_limit_lower() const { return limit_lower; }
+
+	void set_limit_lower(double p_value);
+
+	bool get_limit_spring_enabled() const { return limit_spring_enabled; }
+
+	void set_limit_spring_enabled(bool p_enabled);
+
+	double get_limit_spring_frequency() const { return limit_spring_frequency; }
+
+	void set_limit_spring_frequency(double p_value);
+
+	double get_limit_spring_damping() const { return limit_spring_damping; }
+
+	void set_limit_spring_damping(double p_value);
+
+	bool get_motor_enabled() const { return motor_enabled; }
+
+	void set_motor_enabled(bool p_enabled);
+
+	double get_motor_target_velocity() const { return motor_target_velocity; }
+
+	void set_motor_target_velocity(double p_value);
+
+	double get_motor_max_torque() const { return motor_max_torque; }
+
+	void set_motor_max_torque(double p_value);
+
+	Vector3 get_linear_impulse() const;
+
+	Vector3 get_angular_impulse() const;
+
+private:
+	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;
+
+	void _update_param(Param p_param);
+
+	void _update_jolt_param(Param p_param);
+
+	void _update_flag(Flag p_flag);
+
+	void _update_jolt_flag(Flag p_flag);
+
+	void _param_changed(Param p_param);
+
+	void _flag_changed(Flag p_flag);
+
+	double limit_upper = 0.0;
+
+	double limit_lower = 0.0;
+
+	double limit_spring_frequency = 2.0;
+
+	double limit_spring_damping = 1.0;
+
+	double motor_target_velocity = 0.0;
+
+	double motor_max_torque = INFINITY;
+
+	bool limit_enabled = false;
+
+	bool limit_spring_enabled = false;
+
+	bool motor_enabled = false;
+};

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
 #include "joints/jolt_joint_impl_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
 
 class JoltHingeJointImpl3D final : public JoltJointImpl3D {
+	using Parameter = PhysicsServer3D::HingeJointParam;
+
+	using JoltParameter = JoltPhysicsServer3D::HingeJointParamJolt;
+
+	using Flag = PhysicsServer3D::HingeJointFlag;
+
+	using JoltFlag = JoltPhysicsServer3D::HingeJointFlagJolt;
+
 public:
 	JoltHingeJointImpl3D(
 		const JoltJointImpl3D& p_old_joint,
@@ -17,33 +26,47 @@ public:
 		return PhysicsServer3D::JOINT_TYPE_HINGE;
 	}
 
-	double get_param(PhysicsServer3D::HingeJointParam p_param) const;
+	double get_parameter(Parameter p_param) const;
 
-	void set_param(PhysicsServer3D::HingeJointParam p_param, double p_value, bool p_lock = true);
+	void set_parameter(Parameter p_param, double p_value, bool p_lock = true);
 
-	bool get_flag(PhysicsServer3D::HingeJointFlag p_flag) const;
+	double get_jolt_param(JoltParameter p_param) const;
 
-	void set_flag(PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled, bool p_lock = true);
+	void set_jolt_param(JoltParameter p_param, double p_value, bool p_lock = true);
+
+	bool get_flag(Flag p_flag) const;
+
+	void set_flag(Flag p_flag, bool p_enabled, bool p_lock = true);
+
+	bool get_jolt_flag(JoltFlag p_flag) const;
+
+	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+
+	Vector3 get_linear_impulse() const;
+
+	Vector3 get_angular_impulse() const;
 
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* _build_hinge(
+	JPH::Constraint* _build_hinge(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b,
 		float p_limit
-	);
+	) const;
 
-	static JPH::Constraint* _build_fixed(
+	JPH::Constraint* _build_fixed(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b
-	);
+	) const;
 
-	bool _is_fixed() const { return limit_lower == limit_upper; }
+	bool _is_sprung() const { return limit_spring_enabled && limit_spring_frequency > 0.0; }
+
+	bool _is_fixed() const { return limits_enabled && limit_lower == limit_upper && !_is_sprung(); }
 
 	void _update_motor_state();
 
@@ -52,6 +75,8 @@ private:
 	void _update_motor_limit();
 
 	void _limits_changed(bool p_lock = true);
+
+	void _limit_spring_changed(bool p_lock = true);
 
 	void _motor_state_changed();
 
@@ -63,11 +88,17 @@ private:
 
 	double limit_upper = 0.0;
 
+	double limit_spring_frequency = 0.0;
+
+	double limit_spring_damping = 0.0;
+
 	double motor_target_speed = 0.0f;
 
-	double motor_max_impulse = 0.0;
+	double motor_max_torque = 0.0;
 
-	bool use_limits = false;
+	bool limits_enabled = false;
+
+	bool limit_spring_enabled = false;
 
 	bool motor_enabled = false;
 };

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -245,6 +245,8 @@ bool JoltJoint3D::_configure() {
 		return false;
 	}
 
+	valid = true;
+
 	PhysicsBody3D* body_a = get_body_a();
 	PhysicsBody3D* body_b = get_body_b();
 
@@ -280,6 +282,8 @@ void JoltJoint3D::_destroy() {
 	physics_server->joint_clear(rid);
 
 	_disconnect_bodies();
+
+	valid = false;
 }
 
 void JoltJoint3D::_update_enabled() {

--- a/src/joints/jolt_joint_3d.hpp
+++ b/src/joints/jolt_joint_3d.hpp
@@ -50,6 +50,10 @@ protected:
 
 	static JoltPhysicsServer3D* _get_jolt_physics_server();
 
+	bool _is_valid() const { return valid; }
+
+	bool _is_invalid() const { return !valid; }
+
 	virtual void _configure(
 		[[maybe_unused]] PhysicsBody3D* p_body_a,
 		[[maybe_unused]] PhysicsBody3D* p_body_b
@@ -102,6 +106,8 @@ protected:
 	int32_t velocity_iterations = 0;
 
 	int32_t position_iterations = 0;
+
+	bool valid = false;
 
 	bool enabled = true;
 

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -13,15 +13,7 @@ String JoltJointGizmoPlugin3D::_get_gizmo_name() const {
 }
 
 void JoltJointGizmoPlugin3D::_redraw(const Ref<EditorNode3DGizmo>& p_gizmo) {
-	auto* joint = Object::cast_to<JoltJoint3D>(p_gizmo->get_node_3d());
-
 	p_gizmo->clear();
-
-	PhysicsBody3D* body_a = joint->get_body_a();
-	QUIET_FAIL_NULL(body_a);
-
-	PhysicsBody3D* body_b = joint->get_body_b();
-	QUIET_FAIL_NULL(body_b);
 
 	if (!created_materials) {
 		// HACK(mihe): Ideally we would do this in the constructor, but the documentation generation
@@ -39,22 +31,20 @@ void JoltJointGizmoPlugin3D::_redraw(const Ref<EditorNode3DGizmo>& p_gizmo) {
 	Ref<Material> material_body_a = get_material(U"joint_body_a", p_gizmo);
 	Ref<Material> material_body_b = get_material(U"joint_body_b", p_gizmo);
 
-	if (Object::cast_to<JoltPinJoint3D>(joint) != nullptr) {
-		constexpr float size = 0.25f;
+	PackedVector3Array points;
+	points.resize(6);
 
-		PackedVector3Array points;
-		points.resize(6);
+	constexpr float size = 0.25f;
 
-		points[0] = Vector3(+size, 0, 0);
-		points[1] = Vector3(-size, 0, 0);
-		points[2] = Vector3(0, +size, 0);
-		points[3] = Vector3(0, -size, 0);
-		points[4] = Vector3(0, 0, +size);
-		points[5] = Vector3(0, 0, -size);
+	points[0] = Vector3(+size, 0, 0);
+	points[1] = Vector3(-size, 0, 0);
+	points[2] = Vector3(0, +size, 0);
+	points[3] = Vector3(0, -size, 0);
+	points[4] = Vector3(0, 0, +size);
+	points[5] = Vector3(0, 0, -size);
 
-		p_gizmo->add_collision_segments(points);
-		p_gizmo->add_lines(points, material_common);
-	}
+	p_gizmo->add_collision_segments(points);
+	p_gizmo->add_lines(points, material_common);
 }
 
 #endif // GDJ_CONFIG_EDITOR

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,3 +1,4 @@
+#include "joints/jolt_hinge_joint_3d.hpp"
 #include "joints/jolt_joint_gizmo_plugin_3d.hpp"
 #include "joints/jolt_pin_joint_3d.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
@@ -40,6 +41,7 @@ void on_initialize(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<JoltDebugGeometry3D>();
 			ClassDB::register_class<JoltJoint3D>();
 			ClassDB::register_class<JoltPinJoint3D>();
+			ClassDB::register_class<JoltHingeJoint3D>();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 #ifdef GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -23,8 +23,31 @@
 #include "spaces/jolt_space_3d.hpp"
 
 void JoltPhysicsServer3D::_bind_methods() {
-	BIND_METHOD(JoltPhysicsServer3D, joint_get_enabled);
-	BIND_METHOD(JoltPhysicsServer3D, joint_set_enabled);
+	BIND_METHOD(JoltPhysicsServer3D, joint_get_enabled, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, joint_set_enabled, "joint", "enabled");
+
+	BIND_METHOD(JoltPhysicsServer3D, joint_get_solver_velocity_iterations, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, joint_set_solver_velocity_iterations, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, joint_get_solver_position_iterations, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, joint_set_solver_position_iterations, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, pin_joint_get_linear_impulse, "joint");
+
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_jolt_param, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_set_jolt_param, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_jolt_flag, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_set_jolt_flag, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_linear_impulse, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_angular_impulse, "joint");
+
+	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(HINGE_JOINT_MOTOR_MAX_TORQUE);
+
+	BIND_ENUM_CONSTANT(HINGE_JOINT_FLAG_USE_LIMIT_SPRING);
 }
 
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
@@ -1393,7 +1416,7 @@ void JoltPhysicsServer3D::_hinge_joint_set_param(
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
 	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
 
-	return hinge_joint->set_param(p_param, p_value);
+	return hinge_joint->set_parameter(p_param, p_value);
 }
 
 double JoltPhysicsServer3D::_hinge_joint_get_param(const RID& p_joint, HingeJointParam p_param)
@@ -1404,7 +1427,7 @@ double JoltPhysicsServer3D::_hinge_joint_get_param(const RID& p_joint, HingeJoin
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
 	const auto* hinge_joint = static_cast<const JoltHingeJointImpl3D*>(joint);
 
-	return hinge_joint->get_param(p_param);
+	return hinge_joint->get_parameter(p_param);
 }
 
 void JoltPhysicsServer3D::_hinge_joint_set_flag(
@@ -1785,12 +1808,12 @@ int32_t JoltPhysicsServer3D::joint_get_solver_velocity_iterations(const RID& p_j
 
 void JoltPhysicsServer3D::joint_set_solver_velocity_iterations(
 	const RID& p_joint,
-	int32_t p_iterations
+	int32_t p_value
 ) {
 	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
-	return joint->set_solver_velocity_iterations(p_iterations);
+	return joint->set_solver_velocity_iterations(p_value);
 }
 
 int32_t JoltPhysicsServer3D::joint_get_solver_position_iterations(const RID& p_joint) {
@@ -1802,12 +1825,12 @@ int32_t JoltPhysicsServer3D::joint_get_solver_position_iterations(const RID& p_j
 
 void JoltPhysicsServer3D::joint_set_solver_position_iterations(
 	const RID& p_joint,
-	int32_t p_iterations
+	int32_t p_value
 ) {
 	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 
-	return joint->set_solver_position_iterations(p_iterations);
+	return joint->set_solver_position_iterations(p_value);
 }
 
 Vector3 JoltPhysicsServer3D::pin_joint_get_linear_impulse(const RID& p_joint) {
@@ -1818,4 +1841,76 @@ Vector3 JoltPhysicsServer3D::pin_joint_get_linear_impulse(const RID& p_joint) {
 	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
 
 	return pin_joint->get_linear_impulse();
+}
+
+double JoltPhysicsServer3D::hinge_joint_get_jolt_param(
+	const RID& p_joint,
+	HingeJointParamJolt p_param
+) const {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
+
+	return hinge_joint->get_jolt_param(p_param);
+}
+
+void JoltPhysicsServer3D::hinge_joint_set_jolt_param(
+	const RID& p_joint,
+	HingeJointParamJolt p_param,
+	double p_value
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
+
+	return hinge_joint->set_jolt_param(p_param, p_value);
+}
+
+bool JoltPhysicsServer3D::hinge_joint_get_jolt_flag(const RID& p_joint, HingeJointFlagJolt p_flag)
+	const {
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
+	const auto* hinge_joint = static_cast<const JoltHingeJointImpl3D*>(joint);
+
+	return hinge_joint->get_jolt_flag(p_flag);
+}
+
+void JoltPhysicsServer3D::hinge_joint_set_jolt_flag(
+	const RID& p_joint,
+	HingeJointFlagJolt p_flag,
+	bool p_enabled
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
+
+	return hinge_joint->set_jolt_flag(p_flag, p_enabled);
+}
+
+Vector3 JoltPhysicsServer3D::hinge_joint_get_linear_impulse(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
+
+	return hinge_joint->get_linear_impulse();
+}
+
+Vector3 JoltPhysicsServer3D::hinge_joint_get_angular_impulse(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
+	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
+
+	return hinge_joint->get_angular_impulse();
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -10,6 +10,17 @@ class JoltSpace3D;
 class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
 	GDCLASS_NO_WARN(JoltPhysicsServer3D, PhysicsServer3DExtension)
 
+public:
+	enum HingeJointParamJolt {
+		HINGE_JOINT_LIMIT_SPRING_FREQUENCY = 100,
+		HINGE_JOINT_LIMIT_SPRING_DAMPING,
+		HINGE_JOINT_MOTOR_MAX_TORQUE,
+	};
+
+	enum HingeJointFlagJolt {
+		HINGE_JOINT_FLAG_USE_LIMIT_SPRING = 100
+	};
+
 private:
 	static void _bind_methods();
 
@@ -573,13 +584,29 @@ public:
 
 	int32_t joint_get_solver_velocity_iterations(const RID& p_joint);
 
-	void joint_set_solver_velocity_iterations(const RID& p_joint, int32_t p_iterations);
+	void joint_set_solver_velocity_iterations(const RID& p_joint, int32_t p_value);
 
 	int32_t joint_get_solver_position_iterations(const RID& p_joint);
 
-	void joint_set_solver_position_iterations(const RID& p_joint, int32_t p_iterations);
+	void joint_set_solver_position_iterations(const RID& p_joint, int32_t p_value);
 
 	Vector3 pin_joint_get_linear_impulse(const RID& p_joint);
+
+	double hinge_joint_get_jolt_param(const RID& p_joint, HingeJointParamJolt p_param) const;
+
+	void hinge_joint_set_jolt_param(
+		const RID& p_joint,
+		HingeJointParamJolt p_param,
+		double p_value
+	);
+
+	bool hinge_joint_get_jolt_flag(const RID& p_joint, HingeJointFlagJolt p_flag) const;
+
+	void hinge_joint_set_jolt_flag(const RID& p_joint, HingeJointFlagJolt p_flag, bool p_enabled);
+
+	Vector3 hinge_joint_get_linear_impulse(const RID& p_joint);
+
+	Vector3 hinge_joint_get_angular_impulse(const RID& p_joint);
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
@@ -600,3 +627,6 @@ private:
 
 	bool flushing_queries = false;
 };
+
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointFlagJolt);


### PR DESCRIPTION
Fixes #347.

This adds a substitute node for `HingeJoint3D`, called `JoltHingeJoint3D`, that mostly matches the `HingeJoint3D` interface, with the following differences:

- You can enable/disable the joint, using its `enabled` property
- You can fetch its last applied impulses, using its `get_linear_impulse` and `get_angular_impulse` methods
- You can override the solver velocity/position iterations for the joint
- You specify the motor limit in terms of max torque, and not max torque impulse, since an impulse is timestep-dependent
- You control the soft limits in terms of frequency/damping, and not bias/softness/restitution

The first and second point together allow for creating breakable joints.

There are also a couple of other Jolt-specific features that can/will be added to this later, like max friction torque and positional motors with springs, but I'm mostly concerned with getting feature-parity with `HingeJoint3D` right now.

Note that this PR doesn't include the proper editor gizmo for this joint, and instead it uses the same gizmo as `PinJoint3D`. I'll sort that out later.