### PR TITLE
Refactored bind macros to allow normal suffixed properties

### DIFF
--- a/src/misc/bind_macros.hpp
+++ b/src/misc/bind_macros.hpp
@@ -22,14 +22,6 @@
 	)                       \
 	(__VA_ARGS__)
 
-#define BIND_PROPERTY(m_name, m_type) \
-	ClassDB::add_property(            \
-		get_class_static(),           \
-		PropertyInfo(m_type, m_name), \
-		"set_" m_name,                \
-		"get_" m_name                 \
-	)
-
 #define BIND_PROPERTY_HINTED(m_name, m_type, m_hint, m_hint_str) \
 	ClassDB::add_property(                                       \
 		get_class_static(),                                      \
@@ -38,13 +30,18 @@
 		"get_" m_name                                            \
 	)
 
-#define BIND_PROPERTY_RANGED(m_name, m_type, m_hint_str)               \
-	ClassDB::add_property(                                             \
-		get_class_static(),                                            \
-		PropertyInfo(m_type, m_name, PROPERTY_HINT_RANGE, m_hint_str), \
-		"set_" m_name,                                                 \
-		"get_" m_name                                                  \
-	)
+#define BIND_PROPERTY_RANGED(m_name, m_type, m_hint_str) \
+	BIND_PROPERTY_HINTED(m_name, m_type, PROPERTY_HINT_RANGE, m_hint_str)
 
 #define BIND_PROPERTY_ENUM(m_name, m_hint_str) \
 	BIND_PROPERTY_HINTED(m_name, Variant::INT, PROPERTY_HINT_ENUM, m_hint_str)
+
+#define BIND_PROPERTY_0(m_name, m_type) BIND_PROPERTY_HINTED(m_name, m_type, PROPERTY_HINT_NONE, "")
+
+#define BIND_PROPERTY_1(m_name, m_type, m_hint_str) \
+	BIND_PROPERTY_HINTED(m_name, m_type, PROPERTY_HINT_NONE, m_hint_str)
+
+#define BIND_PROPERTY_SELECT(_1, _2, _3, m_macro, ...) m_macro
+
+#define BIND_PROPERTY(...) \
+	BIND_PROPERTY_SELECT(__VA_ARGS__, BIND_PROPERTY_1, BIND_PROPERTY_0)(__VA_ARGS__)


### PR DESCRIPTION
All this does is allow:

```cpp
BIND_PROPERTY("some_property", Variant::FLOAT, "suffix:m/s");
```

... as opposed to doing:

```cpp
BIND_PROPERTY_HINTED("some_property", Variant::FLOAT, PROPERTY_HINT_NONE, "suffix:m/s");
```

This of course allows for more than just suffixes, but that is its only relevance right now.