### PR TITLE
Renamed joint impulse methods

### DIFF
--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -39,8 +39,8 @@ void JoltHingeJoint3D::_bind_methods() {
 	BIND_METHOD(JoltHingeJoint3D, get_motor_max_torque);
 	BIND_METHOD(JoltHingeJoint3D, set_motor_max_torque, "value");
 
-	BIND_METHOD(JoltHingeJoint3D, get_linear_impulse);
-	BIND_METHOD(JoltHingeJoint3D, get_angular_impulse);
+	BIND_METHOD(JoltHingeJoint3D, get_impulse);
+	BIND_METHOD(JoltHingeJoint3D, get_torque_impulse);
 
 	ADD_GROUP("Limit", "limit_");
 
@@ -151,18 +151,18 @@ void JoltHingeJoint3D::set_motor_max_torque(double p_value) {
 	_param_changed(PARAM_MOTOR_MAX_TORQUE);
 }
 
-Vector3 JoltHingeJoint3D::get_linear_impulse() const {
+Vector3 JoltHingeJoint3D::get_impulse() const {
 	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
 	QUIET_FAIL_NULL_D(physics_server);
 
-	return physics_server->hinge_joint_get_linear_impulse(rid);
+	return physics_server->hinge_joint_get_impulse(rid);
 }
 
-Vector3 JoltHingeJoint3D::get_angular_impulse() const {
+Vector3 JoltHingeJoint3D::get_torque_impulse() const {
 	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
 	QUIET_FAIL_NULL_D(physics_server);
 
-	return physics_server->hinge_joint_get_angular_impulse(rid);
+	return physics_server->hinge_joint_get_torque_impulse(rid);
 }
 
 void JoltHingeJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {

--- a/src/joints/jolt_hinge_joint_3d.hpp
+++ b/src/joints/jolt_hinge_joint_3d.hpp
@@ -70,9 +70,9 @@ public:
 
 	void set_motor_max_torque(double p_value);
 
-	Vector3 get_linear_impulse() const;
+	Vector3 get_impulse() const;
 
-	Vector3 get_angular_impulse() const;
+	Vector3 get_torque_impulse() const;
 
 private:
 	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -216,7 +216,7 @@ void JoltHingeJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p
 	}
 }
 
-Vector3 JoltHingeJointImpl3D::get_linear_impulse() const {
+Vector3 JoltHingeJointImpl3D::get_impulse() const {
 	ERR_FAIL_NULL_D(jolt_ref);
 
 	if (_is_fixed()) {
@@ -228,7 +228,7 @@ Vector3 JoltHingeJointImpl3D::get_linear_impulse() const {
 	}
 }
 
-Vector3 JoltHingeJointImpl3D::get_angular_impulse() const {
+Vector3 JoltHingeJointImpl3D::get_torque_impulse() const {
 	ERR_FAIL_NULL_D(jolt_ref);
 
 	if (_is_fixed()) {

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -42,9 +42,9 @@ public:
 
 	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
 
-	Vector3 get_linear_impulse() const;
+	Vector3 get_impulse() const;
 
-	Vector3 get_angular_impulse() const;
+	Vector3 get_torque_impulse() const;
 
 	void rebuild(bool p_lock = true) override;
 

--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -3,14 +3,14 @@
 #include "servers/jolt_physics_server_3d.hpp"
 
 void JoltPinJoint3D::_bind_methods() {
-	BIND_METHOD(JoltPinJoint3D, get_linear_impulse);
+	BIND_METHOD(JoltPinJoint3D, get_impulse);
 }
 
-Vector3 JoltPinJoint3D::get_linear_impulse() const {
+Vector3 JoltPinJoint3D::get_impulse() const {
 	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
 	QUIET_FAIL_NULL_D(physics_server);
 
-	return physics_server->pin_joint_get_linear_impulse(rid);
+	return physics_server->pin_joint_get_impulse(rid);
 }
 
 void JoltPinJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -9,7 +9,7 @@ private:
 	static void _bind_methods();
 
 public:
-	Vector3 get_linear_impulse() const;
+	Vector3 get_impulse() const;
 
 private:
 	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -94,7 +94,7 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 	}
 }
 
-Vector3 JoltPinJointImpl3D::get_linear_impulse() const {
+Vector3 JoltPinJointImpl3D::get_impulse() const {
 	ERR_FAIL_NULL_D(jolt_ref);
 
 	auto* constraint = static_cast<JPH::PointConstraint*>(jolt_ref.GetPtr());

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -30,7 +30,7 @@ public:
 
 	void set_param(PhysicsServer3D::PinJointParam p_param, double p_value);
 
-	Vector3 get_linear_impulse() const;
+	Vector3 get_impulse() const;
 
 	void rebuild(bool p_lock = true) override;
 

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -32,7 +32,7 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_METHOD(JoltPhysicsServer3D, joint_get_solver_position_iterations, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, joint_set_solver_position_iterations, "joint", "value");
 
-	BIND_METHOD(JoltPhysicsServer3D, pin_joint_get_linear_impulse, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, pin_joint_get_impulse, "joint");
 
 	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_jolt_param, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_set_jolt_param, "joint", "value");
@@ -40,8 +40,8 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_jolt_flag, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_set_jolt_flag, "joint", "value");
 
-	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_linear_impulse, "joint");
-	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_angular_impulse, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_impulse, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_torque_impulse, "joint");
 
 	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_FREQUENCY);
 	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_DAMPING);
@@ -1833,14 +1833,14 @@ void JoltPhysicsServer3D::joint_set_solver_position_iterations(
 	return joint->set_solver_position_iterations(p_value);
 }
 
-Vector3 JoltPhysicsServer3D::pin_joint_get_linear_impulse(const RID& p_joint) {
+Vector3 JoltPhysicsServer3D::pin_joint_get_impulse(const RID& p_joint) {
 	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_PIN);
 	auto* pin_joint = static_cast<JoltPinJointImpl3D*>(joint);
 
-	return pin_joint->get_linear_impulse();
+	return pin_joint->get_impulse();
 }
 
 double JoltPhysicsServer3D::hinge_joint_get_jolt_param(
@@ -1895,22 +1895,22 @@ void JoltPhysicsServer3D::hinge_joint_set_jolt_flag(
 	return hinge_joint->set_jolt_flag(p_flag, p_enabled);
 }
 
-Vector3 JoltPhysicsServer3D::hinge_joint_get_linear_impulse(const RID& p_joint) {
+Vector3 JoltPhysicsServer3D::hinge_joint_get_impulse(const RID& p_joint) {
 	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
 	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
 
-	return hinge_joint->get_linear_impulse();
+	return hinge_joint->get_impulse();
 }
 
-Vector3 JoltPhysicsServer3D::hinge_joint_get_angular_impulse(const RID& p_joint) {
+Vector3 JoltPhysicsServer3D::hinge_joint_get_torque_impulse(const RID& p_joint) {
 	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_D(joint);
 
 	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_HINGE);
 	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
 
-	return hinge_joint->get_angular_impulse();
+	return hinge_joint->get_torque_impulse();
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -590,7 +590,7 @@ public:
 
 	void joint_set_solver_position_iterations(const RID& p_joint, int32_t p_value);
 
-	Vector3 pin_joint_get_linear_impulse(const RID& p_joint);
+	Vector3 pin_joint_get_impulse(const RID& p_joint);
 
 	double hinge_joint_get_jolt_param(const RID& p_joint, HingeJointParamJolt p_param) const;
 
@@ -604,9 +604,9 @@ public:
 
 	void hinge_joint_set_jolt_flag(const RID& p_joint, HingeJointFlagJolt p_flag, bool p_enabled);
 
-	Vector3 hinge_joint_get_linear_impulse(const RID& p_joint);
+	Vector3 hinge_joint_get_impulse(const RID& p_joint);
 
-	Vector3 hinge_joint_get_angular_impulse(const RID& p_joint);
+	Vector3 hinge_joint_get_torque_impulse(const RID& p_joint);
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;


### PR DESCRIPTION
To better line up with the naming scheme Godot uses, I decided to rename the `get_linear_impulse` and `get_angular_impulse` methods found in the new substitute joints (`JoltPinJoint3D` and `JoltHingeJoint3D`) to instead be `get_impulse` and `get_torque_impulse` respectively.