### PR TITLE
Renamed the `get_impulse` method in `PinJoint3D`

### DIFF
--- a/src/joints/jolt_pin_joint_3d.cpp
+++ b/src/joints/jolt_pin_joint_3d.cpp
@@ -3,10 +3,10 @@
 #include "servers/jolt_physics_server_3d.hpp"
 
 void JoltPinJoint3D::_bind_methods() {
-	BIND_METHOD(JoltPinJoint3D, get_impulse);
+	BIND_METHOD(JoltPinJoint3D, get_applied_force);
 }
 
-float JoltPinJoint3D::get_impulse() const {
+float JoltPinJoint3D::get_applied_force() const {
 	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
 	QUIET_FAIL_NULL_D(physics_server);
 

--- a/src/joints/jolt_pin_joint_3d.hpp
+++ b/src/joints/jolt_pin_joint_3d.hpp
@@ -9,7 +9,7 @@ private:
 	static void _bind_methods();
 
 public:
-	float get_impulse() const;
+	float get_applied_force() const;
 
 private:
 	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;


### PR DESCRIPTION
Complements #510.

It seems I forgot to rename the actual `PinJoint3D` method `get_impulse` to `get_applied_force`, so this PR does just that.