### PR TITLE
Fixed joint force/torque being NaN on first iteration

### DIFF
--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -222,12 +222,15 @@ float JoltHingeJointImpl3D::get_applied_force() const {
 	JoltSpace3D* space = get_space();
 	ERR_FAIL_NULL_D(space);
 
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
 	if (_is_fixed()) {
 		auto* constraint = static_cast<JPH::FixedConstraint*>(jolt_ref.GetPtr());
-		return constraint->GetTotalLambdaPosition().Length() / space->get_last_step();
+		return constraint->GetTotalLambdaPosition().Length() / last_step;
 	} else {
 		auto* constraint = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
-		return constraint->GetTotalLambdaPosition().Length() / space->get_last_step();
+		return constraint->GetTotalLambdaPosition().Length() / last_step;
 	}
 }
 
@@ -237,12 +240,15 @@ float JoltHingeJointImpl3D::get_applied_torque() const {
 	JoltSpace3D* space = get_space();
 	ERR_FAIL_NULL_D(space);
 
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
 	if (_is_fixed()) {
 		auto* constraint = static_cast<JPH::FixedConstraint*>(jolt_ref.GetPtr());
-		return constraint->GetTotalLambdaRotation().Length() / space->get_last_step();
+		return constraint->GetTotalLambdaRotation().Length() / last_step;
 	} else {
 		auto* constraint = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr());
-		return constraint->GetTotalLambdaRotation().Length() / space->get_last_step();
+		return constraint->GetTotalLambdaRotation().Length() / last_step;
 	}
 }
 

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -101,7 +101,10 @@ float JoltPinJointImpl3D::get_applied_force() const {
 	JoltSpace3D* space = get_space();
 	ERR_FAIL_NULL_D(space);
 
-	return constraint->GetTotalLambdaPosition().Length() / space->get_last_step();
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
+	return constraint->GetTotalLambdaPosition().Length() / last_step;
 }
 
 void JoltPinJointImpl3D::rebuild(bool p_lock) {


### PR DESCRIPTION
When calling `get_applied_force` or `get_applied_torque` from `_physics_process` or `_integrate_forces` you'd end up with NaN if done from the absolute first tick, since there wouldn't be any valid `get_last_step()` from the physics space.

This PR resolves this by simply returning 0 from those two methods if `get_last_step()` is 0 as well.