### PR TITLE
Added `JoltSliderJoint3D`

### DIFF
--- a/src/joints/jolt_slider_joint_3d.cpp
+++ b/src/joints/jolt_slider_joint_3d.cpp
@@ -1,0 +1,308 @@
+#include "jolt_slider_joint_3d.hpp"
+
+#include "servers/jolt_physics_server_3d.hpp"
+
+namespace {
+
+using ServerParam = PhysicsServer3D::SliderJointParam;
+using ServerParamJolt = JoltPhysicsServer3D::SliderJointParamJolt;
+using ServerFlagJolt = JoltPhysicsServer3D::SliderJointFlagJolt;
+
+} // namespace
+
+void JoltSliderJoint3D::_bind_methods() {
+	BIND_METHOD(JoltSliderJoint3D, get_limit_enabled);
+	BIND_METHOD(JoltSliderJoint3D, set_limit_enabled, "enabled");
+
+	BIND_METHOD(JoltSliderJoint3D, get_limit_upper);
+	BIND_METHOD(JoltSliderJoint3D, set_limit_upper, "value");
+
+	BIND_METHOD(JoltSliderJoint3D, get_limit_lower);
+	BIND_METHOD(JoltSliderJoint3D, set_limit_lower, "value");
+
+	BIND_METHOD(JoltSliderJoint3D, get_limit_spring_enabled);
+	BIND_METHOD(JoltSliderJoint3D, set_limit_spring_enabled, "enabled");
+
+	BIND_METHOD(JoltSliderJoint3D, get_limit_spring_frequency);
+	BIND_METHOD(JoltSliderJoint3D, set_limit_spring_frequency, "value");
+
+	BIND_METHOD(JoltSliderJoint3D, get_limit_spring_damping);
+	BIND_METHOD(JoltSliderJoint3D, set_limit_spring_damping, "value");
+
+	BIND_METHOD(JoltSliderJoint3D, get_motor_enabled);
+	BIND_METHOD(JoltSliderJoint3D, set_motor_enabled, "enabled");
+
+	BIND_METHOD(JoltSliderJoint3D, get_motor_target_velocity);
+	BIND_METHOD(JoltSliderJoint3D, set_motor_target_velocity, "value");
+
+	BIND_METHOD(JoltSliderJoint3D, get_motor_max_force);
+	BIND_METHOD(JoltSliderJoint3D, set_motor_max_force, "value");
+
+	BIND_METHOD(JoltSliderJoint3D, get_applied_force);
+	BIND_METHOD(JoltSliderJoint3D, get_applied_torque);
+
+	ADD_GROUP("Limit", "limit_");
+
+	BIND_PROPERTY("limit_enabled", Variant::BOOL);
+	BIND_PROPERTY("limit_upper", Variant::FLOAT, "suffix:m");
+	BIND_PROPERTY("limit_lower", Variant::FLOAT, "suffix:m");
+
+	ADD_GROUP("Limit Spring", "limit_spring_");
+
+	BIND_PROPERTY("limit_spring_enabled", Variant::BOOL);
+	BIND_PROPERTY("limit_spring_frequency", Variant::FLOAT, "suffix:hz");
+	BIND_PROPERTY("limit_spring_damping", Variant::FLOAT);
+
+	ADD_GROUP("Motor", "motor_");
+
+	BIND_PROPERTY("motor_enabled", Variant::BOOL);
+	BIND_PROPERTY("motor_target_velocity", Variant::FLOAT, U"suffix:m/s");
+	BIND_PROPERTY("motor_max_force", Variant::FLOAT, "suffix:N");
+}
+
+void JoltSliderJoint3D::set_limit_enabled(bool p_enabled) {
+	if (limit_enabled == p_enabled) {
+		return;
+	}
+
+	limit_enabled = p_enabled;
+
+	_flag_changed(FLAG_USE_LIMIT);
+}
+
+void JoltSliderJoint3D::set_limit_upper(double p_value) {
+	if (limit_upper == p_value) {
+		return;
+	}
+
+	limit_upper = p_value;
+
+	_param_changed(PARAM_LIMIT_UPPER);
+}
+
+void JoltSliderJoint3D::set_limit_lower(double p_value) {
+	if (limit_lower == p_value) {
+		return;
+	}
+
+	limit_lower = p_value;
+
+	_param_changed(PARAM_LIMIT_LOWER);
+}
+
+void JoltSliderJoint3D::set_limit_spring_enabled(bool p_enabled) {
+	if (limit_spring_enabled == p_enabled) {
+		return;
+	}
+
+	limit_spring_enabled = p_enabled;
+
+	_flag_changed(FLAG_USE_LIMIT_SPRING);
+}
+
+void JoltSliderJoint3D::set_limit_spring_frequency(double p_value) {
+	if (limit_spring_frequency == p_value) {
+		return;
+	}
+
+	limit_spring_frequency = p_value;
+
+	_param_changed(PARAM_LIMIT_SPRING_FREQUENCY);
+}
+
+void JoltSliderJoint3D::set_limit_spring_damping(double p_value) {
+	if (limit_spring_damping == p_value) {
+		return;
+	}
+
+	limit_spring_damping = p_value;
+
+	_param_changed(PARAM_LIMIT_SPRING_DAMPING);
+}
+
+void JoltSliderJoint3D::set_motor_enabled(bool p_enabled) {
+	if (motor_enabled == p_enabled) {
+		return;
+	}
+
+	motor_enabled = p_enabled;
+
+	_flag_changed(FLAG_ENABLE_MOTOR);
+}
+
+void JoltSliderJoint3D::set_motor_target_velocity(double p_value) {
+	if (motor_target_velocity == p_value) {
+		return;
+	}
+
+	motor_target_velocity = p_value;
+
+	_param_changed(PARAM_MOTOR_TARGET_VELOCITY);
+}
+
+void JoltSliderJoint3D::set_motor_max_force(double p_value) {
+	if (motor_max_force == p_value) {
+		return;
+	}
+
+	motor_max_force = p_value;
+
+	_param_changed(PARAM_MOTOR_MAX_FORCE);
+}
+
+float JoltSliderJoint3D::get_applied_force() const {
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
+
+	return physics_server->slider_joint_get_applied_force(rid);
+}
+
+float JoltSliderJoint3D::get_applied_torque() const {
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
+
+	return physics_server->slider_joint_get_applied_torque(rid);
+}
+
+void JoltSliderJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	const Transform3D global_xform = get_global_transform().orthonormalized();
+
+	auto get_local_xform = [&](const PhysicsBody3D& p_body) {
+		return (p_body.get_global_transform().affine_inverse() * global_xform).orthonormalized();
+	};
+
+	physics_server->joint_make_slider(
+		rid,
+		p_body_a->get_rid(),
+		get_local_xform(*p_body_a),
+		p_body_b != nullptr ? p_body_b->get_rid() : RID(),
+		p_body_b != nullptr ? get_local_xform(*p_body_b) : global_xform
+	);
+
+	_update_param(PARAM_LIMIT_UPPER);
+	_update_param(PARAM_LIMIT_LOWER);
+
+	_update_jolt_param(PARAM_LIMIT_SPRING_FREQUENCY);
+	_update_jolt_param(PARAM_LIMIT_SPRING_DAMPING);
+	_update_jolt_param(PARAM_MOTOR_TARGET_VELOCITY);
+	_update_jolt_param(PARAM_MOTOR_MAX_FORCE);
+
+	_update_jolt_flag(FLAG_USE_LIMIT);
+	_update_jolt_flag(FLAG_USE_LIMIT_SPRING);
+	_update_jolt_flag(FLAG_ENABLE_MOTOR);
+}
+
+void JoltSliderJoint3D::_update_param(Param p_param) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	double* value = nullptr;
+
+	switch (p_param) {
+		case PARAM_LIMIT_UPPER: {
+			value = &limit_upper;
+		} break;
+		case PARAM_LIMIT_LOWER: {
+			value = &limit_lower;
+		} break;
+		case PARAM_MOTOR_TARGET_VELOCITY: {
+			value = &motor_target_velocity;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+
+	physics_server->slider_joint_set_param(rid, ServerParam(p_param), *value);
+}
+
+void JoltSliderJoint3D::_update_jolt_param(Param p_param) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(physics_server);
+
+	double* value = nullptr;
+
+	switch (p_param) {
+		case PARAM_LIMIT_SPRING_FREQUENCY: {
+			value = &limit_spring_frequency;
+		} break;
+		case PARAM_LIMIT_SPRING_DAMPING: {
+			value = &limit_spring_damping;
+		} break;
+		case PARAM_MOTOR_TARGET_VELOCITY: {
+			value = &motor_target_velocity;
+		} break;
+		case PARAM_MOTOR_MAX_FORCE: {
+			value = &motor_max_force;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+
+	physics_server->slider_joint_set_jolt_param(rid, ServerParamJolt(p_param), *value);
+}
+
+void JoltSliderJoint3D::_update_jolt_flag(Flag p_flag) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(physics_server);
+
+	bool* value = nullptr;
+
+	switch (p_flag) {
+		case FLAG_USE_LIMIT: {
+			value = &limit_enabled;
+		} break;
+		case FLAG_USE_LIMIT_SPRING: {
+			value = &limit_spring_enabled;
+		} break;
+		case FLAG_ENABLE_MOTOR: {
+			value = &motor_enabled;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+
+	physics_server->slider_joint_set_jolt_flag(rid, ServerFlagJolt(p_flag), *value);
+}
+
+void JoltSliderJoint3D::_param_changed(Param p_param) {
+	switch (p_param) {
+		case PARAM_LIMIT_UPPER:
+		case PARAM_LIMIT_LOWER: {
+			_update_param(p_param);
+		} break;
+		case PARAM_LIMIT_SPRING_FREQUENCY:
+		case PARAM_LIMIT_SPRING_DAMPING:
+		case PARAM_MOTOR_TARGET_VELOCITY:
+		case PARAM_MOTOR_MAX_FORCE: {
+			_update_jolt_param(p_param);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+}
+
+void JoltSliderJoint3D::_flag_changed(Flag p_flag) {
+	switch (p_flag) {
+		case FLAG_USE_LIMIT:
+		case FLAG_USE_LIMIT_SPRING:
+		case FLAG_ENABLE_MOTOR: {
+			_update_jolt_flag(p_flag);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+}

--- a/src/joints/jolt_slider_joint_3d.hpp
+++ b/src/joints/jolt_slider_joint_3d.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "joints/jolt_joint_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
+
+class JoltSliderJoint3D final : public JoltJoint3D {
+	GDCLASS_NO_WARN(JoltSliderJoint3D, JoltJoint3D)
+
+public:
+	enum Param {
+		PARAM_LIMIT_UPPER = PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_UPPER,
+		PARAM_LIMIT_LOWER = PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_LOWER,
+		PARAM_LIMIT_SPRING_FREQUENCY = JoltPhysicsServer3D::SLIDER_JOINT_LIMIT_SPRING_FREQUENCY,
+		PARAM_LIMIT_SPRING_DAMPING = JoltPhysicsServer3D::SLIDER_JOINT_LIMIT_SPRING_DAMPING,
+		PARAM_MOTOR_TARGET_VELOCITY = JoltPhysicsServer3D::SLIDER_JOINT_MOTOR_TARGET_VELOCITY,
+		PARAM_MOTOR_MAX_FORCE = JoltPhysicsServer3D::SLIDER_JOINT_MOTOR_MAX_FORCE
+	};
+
+	enum Flag {
+		FLAG_USE_LIMIT = JoltPhysicsServer3D::SLIDER_JOINT_FLAG_USE_LIMIT,
+		FLAG_USE_LIMIT_SPRING = JoltPhysicsServer3D::SLIDER_JOINT_FLAG_USE_LIMIT_SPRING,
+		FLAG_ENABLE_MOTOR = JoltPhysicsServer3D::SLIDER_JOINT_FLAG_ENABLE_MOTOR,
+	};
+
+private:
+	static void _bind_methods();
+
+public:
+	bool get_limit_enabled() const { return limit_enabled; }
+
+	void set_limit_enabled(bool p_enabled);
+
+	double get_limit_upper() const { return limit_upper; }
+
+	void set_limit_upper(double p_value);
+
+	double get_limit_lower() const { return limit_lower; }
+
+	void set_limit_lower(double p_value);
+
+	bool get_limit_spring_enabled() const { return limit_spring_enabled; }
+
+	void set_limit_spring_enabled(bool p_enabled);
+
+	double get_limit_spring_frequency() const { return limit_spring_frequency; }
+
+	void set_limit_spring_frequency(double p_value);
+
+	double get_limit_spring_damping() const { return limit_spring_damping; }
+
+	void set_limit_spring_damping(double p_value);
+
+	bool get_motor_enabled() const { return motor_enabled; }
+
+	void set_motor_enabled(bool p_enabled);
+
+	double get_motor_target_velocity() const { return motor_target_velocity; }
+
+	void set_motor_target_velocity(double p_value);
+
+	double get_motor_max_force() const { return motor_max_force; }
+
+	void set_motor_max_force(double p_value);
+
+	float get_applied_force() const;
+
+	float get_applied_torque() const;
+
+private:
+	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;
+
+	void _update_param(Param p_param);
+
+	void _update_jolt_param(Param p_param);
+
+	void _update_jolt_flag(Flag p_flag);
+
+	void _param_changed(Param p_param);
+
+	void _flag_changed(Flag p_flag);
+
+	double limit_upper = 0.0;
+
+	double limit_lower = 0.0;
+
+	double limit_spring_frequency = 2.0;
+
+	double limit_spring_damping = 1.0;
+
+	double motor_target_velocity = 0.0;
+
+	double motor_max_force = INFINITY;
+
+	bool limit_enabled = false;
+
+	bool limit_spring_enabled = false;
+
+	bool motor_enabled = false;
+};

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
 #include "joints/jolt_joint_impl_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
 
 class JoltSliderJointImpl3D final : public JoltJointImpl3D {
+	using Parameter = PhysicsServer3D::SliderJointParam;
+
+	using JoltParameter = JoltPhysicsServer3D::SliderJointParamJolt;
+
+	using JoltFlag = JoltPhysicsServer3D::SliderJointFlagJolt;
+
 public:
 	JoltSliderJointImpl3D(
 		const JoltJointImpl3D& p_old_joint,
@@ -21,29 +28,71 @@ public:
 
 	void set_param(PhysicsServer3D::SliderJointParam p_param, double p_value, bool p_lock = true);
 
+	double get_jolt_param(JoltParameter p_param) const;
+
+	void set_jolt_param(JoltParameter p_param, double p_value, bool p_lock = true);
+
+	bool get_jolt_flag(JoltFlag p_flag) const;
+
+	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+
+	float get_applied_force() const;
+
+	float get_applied_torque() const;
+
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* _build_slider(
+	JPH::Constraint* _build_slider(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b,
 		float p_limit
-	);
+	) const;
 
-	static JPH::Constraint* _build_fixed(
+	JPH::Constraint* _build_fixed(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b
-	);
+	) const;
 
-	bool _is_fixed() const { return limit_lower == limit_upper; }
+	bool _is_sprung() const { return limit_spring_enabled && limit_spring_frequency > 0.0; }
+
+	bool _is_fixed() const { return limits_enabled && limit_lower == limit_upper && !_is_sprung(); }
+
+	void _update_motor_state();
+
+	void _update_motor_velocity();
+
+	void _update_motor_limit();
 
 	void _limits_changed(bool p_lock = true);
+
+	void _limit_spring_changed(bool p_lock = true);
+
+	void _motor_state_changed();
+
+	void _motor_speed_changed();
+
+	void _motor_limit_changed();
 
 	double limit_upper = 0.0;
 
 	double limit_lower = 0.0;
+
+	double limit_spring_frequency = 0.0;
+
+	double limit_spring_damping = 0.0;
+
+	double motor_target_speed = 0.0f;
+
+	double motor_max_force = 0.0;
+
+	bool limits_enabled = true;
+
+	bool limit_spring_enabled = false;
+
+	bool motor_enabled = false;
 };

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,6 +1,7 @@
 #include "joints/jolt_hinge_joint_3d.hpp"
 #include "joints/jolt_joint_gizmo_plugin_3d.hpp"
 #include "joints/jolt_pin_joint_3d.hpp"
+#include "joints/jolt_slider_joint_3d.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
 #include "servers/jolt_editor_plugin.hpp"
 #include "servers/jolt_globals.hpp"
@@ -42,6 +43,7 @@ void on_initialize(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<JoltJoint3D>();
 			ClassDB::register_class<JoltPinJoint3D>();
 			ClassDB::register_class<JoltHingeJoint3D>();
+			ClassDB::register_class<JoltSliderJoint3D>();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 #ifdef GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -43,11 +43,29 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_applied_force, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, hinge_joint_get_applied_torque, "joint");
 
+	BIND_METHOD(JoltPhysicsServer3D, slider_joint_get_jolt_param, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, slider_joint_set_jolt_param, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, slider_joint_get_jolt_flag, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, slider_joint_set_jolt_flag, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, slider_joint_get_applied_force, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, slider_joint_get_applied_torque, "joint");
+
 	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_FREQUENCY);
 	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_DAMPING);
 	BIND_ENUM_CONSTANT(HINGE_JOINT_MOTOR_MAX_TORQUE);
 
 	BIND_ENUM_CONSTANT(HINGE_JOINT_FLAG_USE_LIMIT_SPRING);
+
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_LIMIT_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_LIMIT_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_MOTOR_TARGET_VELOCITY);
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_MOTOR_MAX_FORCE);
+
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_FLAG_USE_LIMIT);
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_FLAG_USE_LIMIT_SPRING);
+	BIND_ENUM_CONSTANT(SLIDER_JOINT_FLAG_ENABLE_MOTOR);
 }
 
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
@@ -1915,4 +1933,76 @@ float JoltPhysicsServer3D::hinge_joint_get_applied_torque(const RID& p_joint) {
 	auto* hinge_joint = static_cast<JoltHingeJointImpl3D*>(joint);
 
 	return hinge_joint->get_applied_torque();
+}
+
+double JoltPhysicsServer3D::slider_joint_get_jolt_param(
+	const RID& p_joint,
+	SliderJointParamJolt p_param
+) const {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_SLIDER);
+	auto* slider_joint = static_cast<JoltSliderJointImpl3D*>(joint);
+
+	return slider_joint->get_jolt_param(p_param);
+}
+
+void JoltPhysicsServer3D::slider_joint_set_jolt_param(
+	const RID& p_joint,
+	SliderJointParamJolt p_param,
+	double p_value
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_SLIDER);
+	auto* slider_joint = static_cast<JoltSliderJointImpl3D*>(joint);
+
+	return slider_joint->set_jolt_param(p_param, p_value);
+}
+
+bool JoltPhysicsServer3D::slider_joint_get_jolt_flag(const RID& p_joint, SliderJointFlagJolt p_flag)
+	const {
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_SLIDER);
+	const auto* slider_joint = static_cast<const JoltSliderJointImpl3D*>(joint);
+
+	return slider_joint->get_jolt_flag(p_flag);
+}
+
+void JoltPhysicsServer3D::slider_joint_set_jolt_flag(
+	const RID& p_joint,
+	SliderJointFlagJolt p_flag,
+	bool p_enabled
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_SLIDER);
+	auto* slider_joint = static_cast<JoltSliderJointImpl3D*>(joint);
+
+	return slider_joint->set_jolt_flag(p_flag, p_enabled);
+}
+
+float JoltPhysicsServer3D::slider_joint_get_applied_force(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_SLIDER);
+	auto* slider_joint = static_cast<JoltSliderJointImpl3D*>(joint);
+
+	return slider_joint->get_applied_force();
+}
+
+float JoltPhysicsServer3D::slider_joint_get_applied_torque(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_SLIDER);
+	auto* slider_joint = static_cast<JoltSliderJointImpl3D*>(joint);
+
+	return slider_joint->get_applied_torque();
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -21,6 +21,19 @@ public:
 		HINGE_JOINT_FLAG_USE_LIMIT_SPRING = 100
 	};
 
+	enum SliderJointParamJolt {
+		SLIDER_JOINT_LIMIT_SPRING_FREQUENCY = 100,
+		SLIDER_JOINT_LIMIT_SPRING_DAMPING,
+		SLIDER_JOINT_MOTOR_TARGET_VELOCITY,
+		SLIDER_JOINT_MOTOR_MAX_FORCE
+	};
+
+	enum SliderJointFlagJolt {
+		SLIDER_JOINT_FLAG_USE_LIMIT = 100,
+		SLIDER_JOINT_FLAG_USE_LIMIT_SPRING,
+		SLIDER_JOINT_FLAG_ENABLE_MOTOR
+	};
+
 private:
 	static void _bind_methods();
 
@@ -608,6 +621,22 @@ public:
 
 	float hinge_joint_get_applied_torque(const RID& p_joint);
 
+	double slider_joint_get_jolt_param(const RID& p_joint, SliderJointParamJolt p_param) const;
+
+	void slider_joint_set_jolt_param(
+		const RID& p_joint,
+		SliderJointParamJolt p_param,
+		double p_value
+	);
+
+	bool slider_joint_get_jolt_flag(const RID& p_joint, SliderJointFlagJolt p_flag) const;
+
+	void slider_joint_set_jolt_flag(const RID& p_joint, SliderJointFlagJolt p_flag, bool p_enabled);
+
+	float slider_joint_get_applied_force(const RID& p_joint);
+
+	float slider_joint_get_applied_torque(const RID& p_joint);
+
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 
@@ -630,3 +659,5 @@ private:
 
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointFlagJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointParamJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointFlagJolt);


### PR DESCRIPTION
Fixes #349.

This adds a substitute node for `SliderJoint3D`, called `JoltSliderJoint3D`, that mostly matches the `SliderJoint3D` interface, with the following differences:

- You can enable/disable the joint, using its `enabled` property
- You can fetch its last applied force/torque, using `get_applied_force()` and `get_applied_torque()`
- You can override the solver velocity/position iterations for the joint
- You control the soft limits in terms of frequency/damping, instead of softness/restitution/damping
- You can configure a motor
- You can _not_ rotate around the sliding axis

The first and second point together allow for creating breakable joints.

There are also a couple of other Jolt-specific features that can/will be added to this later, like max friction force and positional motors with springs, but I'm mostly concerned with getting feature-parity with `SliderJoint3D` right now.

Note that this PR doesn't include the proper editor gizmo for this joint, and instead it uses the same gizmo as `PinJoint3D`. I'll sort that out later.