### PR TITLE
Added `JoltConeTwistJoint3D`

### DIFF
--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -1,0 +1,330 @@
+#include "jolt_cone_twist_joint_3d.hpp"
+
+#include "servers/jolt_physics_server_3d.hpp"
+
+namespace {
+
+using ServerParam = PhysicsServer3D::ConeTwistJointParam;
+using ServerParamJolt = JoltPhysicsServer3D::ConeTwistJointParamJolt;
+using ServerFlagJolt = JoltPhysicsServer3D::ConeTwistJointFlagJolt;
+
+} // namespace
+
+void JoltConeTwistJoint3D::_bind_methods() {
+	BIND_METHOD(JoltConeTwistJoint3D, get_swing_limit_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, set_swing_limit_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, get_twist_limit_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, set_twist_limit_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, get_swing_limit_span);
+	BIND_METHOD(JoltConeTwistJoint3D, set_swing_limit_span);
+	BIND_METHOD(JoltConeTwistJoint3D, get_twist_limit_span);
+	BIND_METHOD(JoltConeTwistJoint3D, set_twist_limit_span);
+	BIND_METHOD(JoltConeTwistJoint3D, get_swing_motor_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, set_swing_motor_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, get_twist_motor_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, set_twist_motor_enabled);
+	BIND_METHOD(JoltConeTwistJoint3D, get_swing_motor_target_velocity_y);
+	BIND_METHOD(JoltConeTwistJoint3D, set_swing_motor_target_velocity_y);
+	BIND_METHOD(JoltConeTwistJoint3D, get_swing_motor_target_velocity_z);
+	BIND_METHOD(JoltConeTwistJoint3D, set_swing_motor_target_velocity_z);
+	BIND_METHOD(JoltConeTwistJoint3D, get_twist_motor_target_velocity);
+	BIND_METHOD(JoltConeTwistJoint3D, set_twist_motor_target_velocity);
+	BIND_METHOD(JoltConeTwistJoint3D, get_swing_motor_max_torque);
+	BIND_METHOD(JoltConeTwistJoint3D, set_swing_motor_max_torque);
+	BIND_METHOD(JoltConeTwistJoint3D, get_twist_motor_max_torque);
+	BIND_METHOD(JoltConeTwistJoint3D, set_twist_motor_max_torque);
+	BIND_METHOD(JoltConeTwistJoint3D, get_applied_force);
+	BIND_METHOD(JoltConeTwistJoint3D, get_applied_torque);
+
+	ADD_GROUP("Swing Limit", "swing_limit_");
+
+	BIND_PROPERTY("swing_limit_enabled", Variant::BOOL);
+	BIND_PROPERTY_RANGED("swing_limit_span", Variant::FLOAT, "-180,180,0.1,radians");
+
+	ADD_GROUP("Twist Limit", "twist_limit_");
+
+	BIND_PROPERTY("twist_limit_enabled", Variant::BOOL);
+	BIND_PROPERTY_RANGED("twist_limit_span", Variant::FLOAT, "-180,180,0.1,radians");
+
+	ADD_GROUP("Swing Motor", "swing_motor_");
+
+	BIND_PROPERTY("swing_motor_enabled", Variant::BOOL);
+	BIND_PROPERTY("swing_motor_target_velocity_y", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("swing_motor_target_velocity_z", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("swing_motor_max_torque", Variant::FLOAT, "suffix:Nm");
+
+	ADD_GROUP("Twist Motor", "twist_motor_");
+
+	BIND_PROPERTY("twist_motor_enabled", Variant::BOOL);
+	BIND_PROPERTY("twist_motor_target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("twist_motor_max_torque", Variant::FLOAT, "suffix:Nm");
+}
+
+void JoltConeTwistJoint3D::set_swing_limit_enabled(bool p_enabled) {
+	if (swing_limit_enabled == p_enabled) {
+		return;
+	}
+
+	swing_limit_enabled = p_enabled;
+
+	_flag_changed(FLAG_USE_SWING_LIMIT);
+}
+
+void JoltConeTwistJoint3D::set_twist_limit_enabled(bool p_enabled) {
+	if (twist_limit_enabled == p_enabled) {
+		return;
+	}
+
+	twist_limit_enabled = p_enabled;
+
+	_flag_changed(FLAG_USE_TWIST_LIMIT);
+}
+
+void JoltConeTwistJoint3D::set_swing_limit_span(double p_value) {
+	if (swing_limit_span == p_value) {
+		return;
+	}
+
+	swing_limit_span = p_value;
+
+	_param_changed(PARAM_SWING_LIMIT_SPAN);
+}
+
+void JoltConeTwistJoint3D::set_twist_limit_span(double p_value) {
+	if (twist_limit_span == p_value) {
+		return;
+	}
+
+	twist_limit_span = p_value;
+
+	_param_changed(PARAM_TWIST_LIMIT_SPAN);
+}
+
+void JoltConeTwistJoint3D::set_swing_motor_enabled(bool p_enabled) {
+	if (swing_motor_enabled == p_enabled) {
+		return;
+	}
+
+	swing_motor_enabled = p_enabled;
+
+	_flag_changed(FLAG_ENABLE_SWING_MOTOR);
+}
+
+void JoltConeTwistJoint3D::set_twist_motor_enabled(bool p_enabled) {
+	if (twist_motor_enabled == p_enabled) {
+		return;
+	}
+
+	twist_motor_enabled = p_enabled;
+
+	_flag_changed(FLAG_ENABLE_TWIST_MOTOR);
+}
+
+void JoltConeTwistJoint3D::set_swing_motor_target_velocity_y(double p_value) {
+	if (swing_motor_target_velocity_y == p_value) {
+		return;
+	}
+
+	swing_motor_target_velocity_y = p_value;
+
+	_param_changed(PARAM_SWING_MOTOR_TARGET_VELOCITY_Y);
+}
+
+void JoltConeTwistJoint3D::set_swing_motor_target_velocity_z(double p_value) {
+	if (swing_motor_target_velocity_z == p_value) {
+		return;
+	}
+
+	swing_motor_target_velocity_z = p_value;
+
+	_param_changed(PARAM_SWING_MOTOR_TARGET_VELOCITY_Z);
+}
+
+void JoltConeTwistJoint3D::set_twist_motor_target_velocity(double p_value) {
+	if (twist_motor_target_velocity == p_value) {
+		return;
+	}
+
+	twist_motor_target_velocity = p_value;
+
+	_param_changed(PARAM_TWIST_MOTOR_TARGET_VELOCITY);
+}
+
+void JoltConeTwistJoint3D::set_swing_motor_max_torque(double p_value) {
+	if (swing_motor_max_torque == p_value) {
+		return;
+	}
+
+	swing_motor_max_torque = p_value;
+
+	_param_changed(PARAM_SWING_MOTOR_MAX_TORQUE);
+}
+
+void JoltConeTwistJoint3D::set_twist_motor_max_torque(double p_value) {
+	if (twist_motor_max_torque == p_value) {
+		return;
+	}
+
+	twist_motor_max_torque = p_value;
+
+	_param_changed(PARAM_TWIST_MOTOR_MAX_TORQUE);
+}
+
+float JoltConeTwistJoint3D::get_applied_force() const {
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
+
+	return physics_server->cone_twist_joint_get_applied_force(rid);
+}
+
+float JoltConeTwistJoint3D::get_applied_torque() const {
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(physics_server);
+
+	return physics_server->cone_twist_joint_get_applied_torque(rid);
+}
+
+void JoltConeTwistJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	physics_server->joint_make_cone_twist(
+		rid,
+		p_body_a->get_rid(),
+		_get_body_local_transform(*p_body_a),
+		p_body_b != nullptr ? p_body_b->get_rid() : RID(),
+		p_body_b != nullptr ? _get_body_local_transform(*p_body_b)
+							: get_global_transform().orthonormalized()
+	);
+
+	_update_param(PARAM_SWING_LIMIT_SPAN);
+	_update_param(PARAM_TWIST_LIMIT_SPAN);
+
+	_update_jolt_param(PARAM_SWING_MOTOR_TARGET_VELOCITY_Y);
+	_update_jolt_param(PARAM_SWING_MOTOR_TARGET_VELOCITY_Z);
+	_update_jolt_param(PARAM_TWIST_MOTOR_TARGET_VELOCITY);
+	_update_jolt_param(PARAM_SWING_MOTOR_MAX_TORQUE);
+	_update_jolt_param(PARAM_TWIST_MOTOR_MAX_TORQUE);
+
+	_update_jolt_flag(FLAG_USE_SWING_LIMIT);
+	_update_jolt_flag(FLAG_USE_TWIST_LIMIT);
+	_update_jolt_flag(FLAG_ENABLE_SWING_MOTOR);
+	_update_jolt_flag(FLAG_ENABLE_TWIST_MOTOR);
+}
+
+void JoltConeTwistJoint3D::_update_param(Param p_param) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	PhysicsServer3D* physics_server = _get_physics_server();
+	ERR_FAIL_NULL(physics_server);
+
+	double* value = nullptr;
+
+	switch (p_param) {
+		case PARAM_SWING_LIMIT_SPAN: {
+			value = &swing_limit_span;
+		} break;
+		case PARAM_TWIST_LIMIT_SPAN: {
+			value = &twist_limit_span;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+
+	physics_server->cone_twist_joint_set_param(rid, ServerParam(p_param), *value);
+}
+
+void JoltConeTwistJoint3D::_update_jolt_param(Param p_param) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(physics_server);
+
+	double* value = nullptr;
+
+	switch (p_param) {
+		case PARAM_SWING_MOTOR_TARGET_VELOCITY_Y: {
+			value = &swing_motor_target_velocity_y;
+		} break;
+		case PARAM_SWING_MOTOR_TARGET_VELOCITY_Z: {
+			value = &swing_motor_target_velocity_z;
+		} break;
+		case PARAM_TWIST_MOTOR_TARGET_VELOCITY: {
+			value = &twist_motor_target_velocity;
+		} break;
+		case PARAM_SWING_MOTOR_MAX_TORQUE: {
+			value = &swing_motor_max_torque;
+		} break;
+		case PARAM_TWIST_MOTOR_MAX_TORQUE: {
+			value = &twist_motor_max_torque;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+
+	physics_server->cone_twist_joint_set_jolt_param(rid, ServerParamJolt(p_param), *value);
+}
+
+void JoltConeTwistJoint3D::_update_jolt_flag(Flag p_flag) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* physics_server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(physics_server);
+
+	bool* value = nullptr;
+
+	switch (p_flag) {
+		case FLAG_USE_SWING_LIMIT: {
+			value = &swing_limit_enabled;
+		} break;
+		case FLAG_USE_TWIST_LIMIT: {
+			value = &twist_limit_enabled;
+		} break;
+		case FLAG_ENABLE_SWING_MOTOR: {
+			value = &swing_motor_enabled;
+		} break;
+		case FLAG_ENABLE_TWIST_MOTOR: {
+			value = &twist_motor_enabled;
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+
+	physics_server->cone_twist_joint_set_jolt_flag(rid, ServerFlagJolt(p_flag), *value);
+}
+
+void JoltConeTwistJoint3D::_param_changed(Param p_param) {
+	switch (p_param) {
+		case PARAM_SWING_LIMIT_SPAN:
+		case PARAM_TWIST_LIMIT_SPAN: {
+			_update_param(p_param);
+		} break;
+		case PARAM_SWING_MOTOR_TARGET_VELOCITY_Y:
+		case PARAM_SWING_MOTOR_TARGET_VELOCITY_Z:
+		case PARAM_TWIST_MOTOR_TARGET_VELOCITY:
+		case PARAM_SWING_MOTOR_MAX_TORQUE:
+		case PARAM_TWIST_MOTOR_MAX_TORQUE: {
+			_update_jolt_param(p_param);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+}
+
+void JoltConeTwistJoint3D::_flag_changed(Flag p_flag) {
+	switch (p_flag) {
+		case FLAG_USE_SWING_LIMIT:
+		case FLAG_USE_TWIST_LIMIT:
+		case FLAG_ENABLE_SWING_MOTOR:
+		case FLAG_ENABLE_TWIST_MOTOR: {
+			_update_jolt_flag(p_flag);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+}

--- a/src/joints/jolt_cone_twist_joint_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_3d.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "joints/jolt_joint_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
+
+class JoltConeTwistJoint3D final : public JoltJoint3D {
+	GDCLASS_NO_WARN(JoltConeTwistJoint3D, JoltJoint3D)
+
+public:
+	// clang-format off
+
+	enum Param {
+		PARAM_SWING_LIMIT_SPAN = PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN,
+		PARAM_TWIST_LIMIT_SPAN = PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN,
+		PARAM_SWING_MOTOR_TARGET_VELOCITY_Y = JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Y,
+		PARAM_SWING_MOTOR_TARGET_VELOCITY_Z = JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Z,
+		PARAM_TWIST_MOTOR_TARGET_VELOCITY = JoltPhysicsServer3D::CONE_TWIST_JOINT_TWIST_MOTOR_TARGET_VELOCITY,
+		PARAM_SWING_MOTOR_MAX_TORQUE = JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_MAX_TORQUE,
+		PARAM_TWIST_MOTOR_MAX_TORQUE = JoltPhysicsServer3D::CONE_TWIST_JOINT_TWIST_MOTOR_MAX_TORQUE
+	};
+
+	enum Flag {
+		FLAG_USE_SWING_LIMIT = JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_SWING_LIMIT,
+		FLAG_USE_TWIST_LIMIT = JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_TWIST_LIMIT,
+		FLAG_ENABLE_SWING_MOTOR = JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_SWING_MOTOR,
+		FLAG_ENABLE_TWIST_MOTOR = JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_TWIST_MOTOR
+	};
+
+	// clang-format on
+
+private:
+	static void _bind_methods();
+
+public:
+	bool get_swing_limit_enabled() const { return swing_limit_enabled; }
+
+	void set_swing_limit_enabled(bool p_enabled);
+
+	bool get_twist_limit_enabled() const { return twist_limit_enabled; }
+
+	void set_twist_limit_enabled(bool p_enabled);
+
+	double get_swing_limit_span() const { return swing_limit_span; }
+
+	void set_swing_limit_span(double p_value);
+
+	double get_twist_limit_span() const { return twist_limit_span; }
+
+	void set_twist_limit_span(double p_value);
+
+	bool get_swing_motor_enabled() const { return swing_motor_enabled; }
+
+	void set_swing_motor_enabled(bool p_enabled);
+
+	bool get_twist_motor_enabled() const { return twist_motor_enabled; }
+
+	void set_twist_motor_enabled(bool p_enabled);
+
+	double get_swing_motor_target_velocity_y() const { return swing_motor_target_velocity_y; }
+
+	void set_swing_motor_target_velocity_y(double p_value);
+
+	double get_swing_motor_target_velocity_z() const { return swing_motor_target_velocity_z; }
+
+	void set_swing_motor_target_velocity_z(double p_value);
+
+	double get_twist_motor_target_velocity() const { return twist_motor_target_velocity; }
+
+	void set_twist_motor_target_velocity(double p_value);
+
+	double get_swing_motor_max_torque() const { return swing_motor_max_torque; }
+
+	void set_swing_motor_max_torque(double p_value);
+
+	double get_twist_motor_max_torque() const { return twist_motor_max_torque; }
+
+	void set_twist_motor_max_torque(double p_value);
+
+	float get_applied_force() const;
+
+	float get_applied_torque() const;
+
+private:
+	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;
+
+	void _update_param(Param p_param);
+
+	void _update_jolt_param(Param p_param);
+
+	void _update_jolt_flag(Flag p_flag);
+
+	void _param_changed(Param p_param);
+
+	void _flag_changed(Flag p_flag);
+
+	double swing_limit_span = Math::deg_to_rad(45.0f);
+
+	double twist_limit_span = Math::deg_to_rad(45.0f);
+
+	double swing_motor_target_velocity_y = 0.0;
+
+	double swing_motor_target_velocity_z = 0.0;
+
+	double twist_motor_target_velocity = 0.0;
+
+	double swing_motor_max_torque = INFINITY;
+
+	double twist_motor_max_torque = INFINITY;
+
+	bool swing_limit_enabled = true;
+
+	bool twist_limit_enabled = false;
+
+	bool swing_motor_enabled = false;
+
+	bool twist_motor_enabled = false;
+};

--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -26,10 +26,10 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 double JoltConeTwistJointImpl3D::get_param(PhysicsServer3D::ConeTwistJointParam p_param) const {
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
-			return swing_span;
+			return swing_limit_span;
 		}
 		case PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN: {
-			return twist_span;
+			return twist_limit_span;
 		}
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
 			return DEFAULT_BIAS;
@@ -53,11 +53,11 @@ void JoltConeTwistJointImpl3D::set_param(
 ) {
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
-			swing_span = p_value;
+			swing_limit_span = p_value;
 			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN: {
-			twist_span = p_value;
+			twist_limit_span = p_value;
 			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
@@ -96,6 +96,137 @@ void JoltConeTwistJointImpl3D::set_param(
 	}
 }
 
+double JoltConeTwistJointImpl3D::get_jolt_param(JoltParameter p_param) const {
+	switch (p_param) {
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Y: {
+			return swing_motor_target_speed_y;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Z: {
+			return swing_motor_target_speed_z;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_TWIST_MOTOR_TARGET_VELOCITY: {
+			return twist_motor_target_speed;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_MAX_TORQUE: {
+			return swing_motor_max_torque;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_TWIST_MOTOR_MAX_TORQUE: {
+			return twist_motor_max_torque;
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		}
+	}
+}
+
+void JoltConeTwistJointImpl3D::set_jolt_param(
+	JoltParameter p_param,
+	double p_value,
+	[[maybe_unused]] bool p_lock
+) {
+	switch (p_param) {
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Y: {
+			swing_motor_target_speed_y = p_value;
+			_motor_velocity_changed();
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Z: {
+			swing_motor_target_speed_z = p_value;
+			_motor_velocity_changed();
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_TWIST_MOTOR_TARGET_VELOCITY: {
+			twist_motor_target_speed = p_value;
+			_motor_velocity_changed();
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_MAX_TORQUE: {
+			swing_motor_max_torque = p_value;
+			_swing_motor_limit_changed();
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_TWIST_MOTOR_MAX_TORQUE: {
+			twist_motor_max_torque = p_value;
+			_twist_motor_limit_changed();
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+}
+
+bool JoltConeTwistJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
+	switch (p_flag) {
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_SWING_LIMIT: {
+			return swing_limit_enabled;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_TWIST_LIMIT: {
+			return twist_limit_enabled;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_SWING_MOTOR: {
+			return swing_motor_enabled;
+		}
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_TWIST_MOTOR: {
+			return twist_motor_enabled;
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		}
+	}
+}
+
+void JoltConeTwistJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock) {
+	switch (p_flag) {
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_SWING_LIMIT: {
+			swing_limit_enabled = p_enabled;
+			_limits_changed(p_lock);
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_TWIST_LIMIT: {
+			twist_limit_enabled = p_enabled;
+			_limits_changed(p_lock);
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_SWING_MOTOR: {
+			swing_motor_enabled = p_enabled;
+			_swing_motor_state_changed();
+		} break;
+		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_TWIST_MOTOR: {
+			twist_motor_enabled = p_enabled;
+			_twist_motor_state_changed();
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+}
+
+float JoltConeTwistJointImpl3D::get_applied_force() const {
+	auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_D(constraint);
+
+	JoltSpace3D* space = get_space();
+	ERR_FAIL_NULL_D(space);
+
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
+	return constraint->GetTotalLambdaPosition().Length() / last_step;
+}
+
+float JoltConeTwistJointImpl3D::get_applied_torque() const {
+	auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_D(constraint);
+
+	JoltSpace3D* space = get_space();
+	ERR_FAIL_NULL_D(space);
+
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
+	const Vector3 rotation_lambda = Vector3(
+		constraint->GetTotalLambdaTwist(),
+		constraint->GetTotalLambdaSwingY(),
+		constraint->GetTotalLambdaSwingZ()
+	);
+
+	return rotation_lambda.length() / last_step;
+}
+
 void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 	destroy();
 
@@ -131,14 +262,19 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 		jolt_body_b,
 		shifted_ref_a,
 		shifted_ref_b,
-		(float)swing_span,
-		(float)twist_span
+		(float)swing_limit_span,
+		(float)twist_limit_span
 	);
 
 	space->add_joint(this);
 
 	_update_enabled();
 	_update_iterations();
+	_update_swing_motor_state();
+	_update_twist_motor_state();
+	_update_motor_velocity();
+	_update_swing_motor_limit();
+	_update_twist_motor_limit();
 }
 
 JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(
@@ -146,39 +282,44 @@ JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(
 	JPH::Body* p_jolt_body_b,
 	const Transform3D& p_shifted_ref_a,
 	const Transform3D& p_shifted_ref_b,
-	float p_swing_limit,
-	float p_twist_limit
-) {
+	float p_swing_limit_span,
+	float p_twist_limit_span
+) const {
 	JPH::SwingTwistConstraintSettings constraint_settings;
 
-	if (p_twist_limit >= 0 && p_twist_limit <= JPH::JPH_PI) {
-		constraint_settings.mTwistMinAngle = -p_twist_limit;
-		constraint_settings.mTwistMaxAngle = p_twist_limit;
+	const bool twist_span_valid = p_twist_limit_span >= 0 && p_twist_limit_span <= JPH::JPH_PI;
+	const bool swing_span_valid = p_swing_limit_span >= 0 && p_swing_limit_span <= JPH::JPH_PI;
+
+	if (twist_limit_enabled && twist_span_valid) {
+		constraint_settings.mTwistMinAngle = -p_twist_limit_span;
+		constraint_settings.mTwistMaxAngle = p_twist_limit_span;
 	} else {
 		constraint_settings.mTwistMinAngle = -JPH::JPH_PI;
 		constraint_settings.mTwistMaxAngle = JPH::JPH_PI;
 	}
 
-	if (p_swing_limit >= 0 && p_swing_limit <= JPH::JPH_PI) {
-		constraint_settings.mNormalHalfConeAngle = p_swing_limit;
-		constraint_settings.mPlaneHalfConeAngle = p_swing_limit;
+	if (swing_limit_enabled && swing_span_valid) {
+		constraint_settings.mNormalHalfConeAngle = p_swing_limit_span;
+		constraint_settings.mPlaneHalfConeAngle = p_swing_limit_span;
 	} else {
 		constraint_settings.mNormalHalfConeAngle = JPH::JPH_PI;
 		constraint_settings.mPlaneHalfConeAngle = JPH::JPH_PI;
 
-		// NOTE(mihe): As far as I can tell this emulates the behavior of Godot Physics, where the
-		// twist axis becomes unbounded if the swing span is a nonsensical value.
-		constraint_settings.mTwistMinAngle = -JPH::JPH_PI;
-		constraint_settings.mTwistMaxAngle = JPH::JPH_PI;
+		if (!swing_span_valid) {
+			// NOTE(mihe): As far as I can tell this emulates the behavior of Godot Physics, where
+			// the twist span also becomes unbounded if the swing span is a nonsensical value.
+			constraint_settings.mTwistMinAngle = -JPH::JPH_PI;
+			constraint_settings.mTwistMaxAngle = JPH::JPH_PI;
+		}
 	}
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mPosition1 = to_jolt(p_shifted_ref_a.origin);
-	constraint_settings.mTwistAxis1 = to_jolt(-p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mPlaneAxis1 = to_jolt(-p_shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mTwistAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mPlaneAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mPosition2 = to_jolt(p_shifted_ref_b.origin);
-	constraint_settings.mTwistAxis2 = to_jolt(-p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mPlaneAxis2 = to_jolt(-p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mTwistAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
+	constraint_settings.mPlaneAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
 
 	if (p_jolt_body_b != nullptr) {
 		return constraint_settings.Create(*p_jolt_body_a, *p_jolt_body_b);
@@ -187,6 +328,70 @@ JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(
 	}
 }
 
+void JoltConeTwistJointImpl3D::_update_swing_motor_state() {
+	if (auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr())) {
+		constraint->SetSwingMotorState(
+			swing_motor_enabled ? JPH::EMotorState::Velocity : JPH::EMotorState::Off
+		);
+	}
+}
+
+void JoltConeTwistJointImpl3D::_update_twist_motor_state() {
+	if (auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr())) {
+		constraint->SetTwistMotorState(
+			twist_motor_enabled ? JPH::EMotorState::Velocity : JPH::EMotorState::Off
+		);
+	}
+}
+
+void JoltConeTwistJointImpl3D::_update_motor_velocity() {
+	if (auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr())) {
+		// HACK(mihe): For reasons I don't entirely understand we're forced to flip the directions
+		// of these for it to make sense with the direction of the joint's actual axes.
+		constraint->SetTargetAngularVelocityCS(
+			{(float)-twist_motor_target_speed,
+			 (float)-swing_motor_target_speed_y,
+			 (float)-swing_motor_target_speed_z}
+		);
+	}
+}
+
+void JoltConeTwistJointImpl3D::_update_swing_motor_limit() {
+	if (auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr())) {
+		JPH::MotorSettings& motor_settings = constraint->GetSwingMotorSettings();
+		motor_settings.mMinTorqueLimit = (float)-swing_motor_max_torque;
+		motor_settings.mMaxTorqueLimit = (float)swing_motor_max_torque;
+	}
+}
+
+void JoltConeTwistJointImpl3D::_update_twist_motor_limit() {
+	if (auto* constraint = static_cast<JPH::SwingTwistConstraint*>(jolt_ref.GetPtr())) {
+		JPH::MotorSettings& motor_settings = constraint->GetTwistMotorSettings();
+		motor_settings.mMinTorqueLimit = (float)-twist_motor_max_torque;
+		motor_settings.mMaxTorqueLimit = (float)twist_motor_max_torque;
+	}
+}
+
 void JoltConeTwistJointImpl3D::_limits_changed(bool p_lock) {
 	rebuild(p_lock);
+}
+
+void JoltConeTwistJointImpl3D::_swing_motor_state_changed() {
+	_update_swing_motor_state();
+}
+
+void JoltConeTwistJointImpl3D::_twist_motor_state_changed() {
+	_update_twist_motor_state();
+}
+
+void JoltConeTwistJointImpl3D::_motor_velocity_changed() {
+	_update_motor_velocity();
+}
+
+void JoltConeTwistJointImpl3D::_swing_motor_limit_changed() {
+	_update_swing_motor_limit();
+}
+
+void JoltConeTwistJointImpl3D::_twist_motor_limit_changed() {
+	_update_twist_motor_limit();
 }

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
 #include "joints/jolt_joint_impl_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
 
 class JoltConeTwistJointImpl3D final : public JoltJointImpl3D {
+	using Parameter = PhysicsServer3D::ConeTwistJointParam;
+
+	using JoltParameter = JoltPhysicsServer3D::ConeTwistJointParamJolt;
+
+	using JoltFlag = JoltPhysicsServer3D::ConeTwistJointFlagJolt;
+
 public:
 	JoltConeTwistJointImpl3D(
 		const JoltJointImpl3D& p_old_joint,
@@ -25,21 +32,71 @@ public:
 		bool p_lock = true
 	);
 
+	double get_jolt_param(JoltParameter p_param) const;
+
+	void set_jolt_param(JoltParameter p_param, double p_value, bool p_lock = true);
+
+	bool get_jolt_flag(JoltFlag p_flag) const;
+
+	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+
+	float get_applied_force() const;
+
+	float get_applied_torque() const;
+
 	void rebuild(bool p_lock = true) override;
 
 private:
-	static JPH::Constraint* _build_swing_twist(
+	JPH::Constraint* _build_swing_twist(
 		JPH::Body* p_jolt_body_a,
 		JPH::Body* p_jolt_body_b,
 		const Transform3D& p_shifted_ref_a,
 		const Transform3D& p_shifted_ref_b,
-		float p_swing_limit,
-		float p_twist_limit
-	);
+		float p_swing_limit_span,
+		float p_twist_limit_span
+	) const;
+
+	void _update_swing_motor_state();
+
+	void _update_twist_motor_state();
+
+	void _update_motor_velocity();
+
+	void _update_swing_motor_limit();
+
+	void _update_twist_motor_limit();
 
 	void _limits_changed(bool p_lock = true);
 
-	double swing_span = 0.0;
+	void _swing_motor_state_changed();
 
-	double twist_span = 0.0;
+	void _twist_motor_state_changed();
+
+	void _motor_velocity_changed();
+
+	void _swing_motor_limit_changed();
+
+	void _twist_motor_limit_changed();
+
+	double swing_limit_span = 0.0;
+
+	double twist_limit_span = 0.0;
+
+	double swing_motor_target_speed_y = 0.0;
+
+	double swing_motor_target_speed_z = 0.0;
+
+	double twist_motor_target_speed = 0.0;
+
+	double swing_motor_max_torque = 0.0;
+
+	double twist_motor_max_torque = 0.0;
+
+	bool swing_limit_enabled = true;
+
+	bool twist_limit_enabled = false;
+
+	bool swing_motor_enabled = false;
+
+	bool twist_motor_enabled = false;
 };

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,3 +1,4 @@
+#include "joints/jolt_cone_twist_joint_3d.hpp"
 #include "joints/jolt_hinge_joint_3d.hpp"
 #include "joints/jolt_joint_gizmo_plugin_3d.hpp"
 #include "joints/jolt_pin_joint_3d.hpp"
@@ -44,6 +45,7 @@ void on_initialize(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<JoltPinJoint3D>();
 			ClassDB::register_class<JoltHingeJoint3D>();
 			ClassDB::register_class<JoltSliderJoint3D>();
+			ClassDB::register_class<JoltConeTwistJoint3D>();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 #ifdef GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -2006,3 +2006,77 @@ float JoltPhysicsServer3D::slider_joint_get_applied_torque(const RID& p_joint) {
 
 	return slider_joint->get_applied_torque();
 }
+
+double JoltPhysicsServer3D::cone_twist_joint_get_jolt_param(
+	const RID& p_joint,
+	ConeTwistJointParamJolt p_param
+) const {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
+
+	return cone_twist_joint->get_jolt_param(p_param);
+}
+
+void JoltPhysicsServer3D::cone_twist_joint_set_jolt_param(
+	const RID& p_joint,
+	ConeTwistJointParamJolt p_param,
+	double p_value
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
+
+	return cone_twist_joint->set_jolt_param(p_param, p_value);
+}
+
+bool JoltPhysicsServer3D::cone_twist_joint_get_jolt_flag(
+	const RID& p_joint,
+	ConeTwistJointFlagJolt p_flag
+) const {
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	const auto* cone_twist_joint = static_cast<const JoltConeTwistJointImpl3D*>(joint);
+
+	return cone_twist_joint->get_jolt_flag(p_flag);
+}
+
+void JoltPhysicsServer3D::cone_twist_joint_set_jolt_flag(
+	const RID& p_joint,
+	ConeTwistJointFlagJolt p_flag,
+	bool p_enabled
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
+
+	return cone_twist_joint->set_jolt_flag(p_flag, p_enabled);
+}
+
+float JoltPhysicsServer3D::cone_twist_joint_get_applied_force(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
+
+	return cone_twist_joint->get_applied_force();
+}
+
+float JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
+
+	return cone_twist_joint->get_applied_torque();
+}

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -34,6 +34,21 @@ public:
 		SLIDER_JOINT_FLAG_ENABLE_MOTOR
 	};
 
+	enum ConeTwistJointParamJolt {
+		CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Y = 100,
+		CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Z,
+		CONE_TWIST_JOINT_TWIST_MOTOR_TARGET_VELOCITY,
+		CONE_TWIST_JOINT_SWING_MOTOR_MAX_TORQUE,
+		CONE_TWIST_JOINT_TWIST_MOTOR_MAX_TORQUE
+	};
+
+	enum ConeTwistJointFlagJolt {
+		CONE_TWIST_JOINT_FLAG_USE_SWING_LIMIT = 100,
+		CONE_TWIST_JOINT_FLAG_USE_TWIST_LIMIT,
+		CONE_TWIST_JOINT_FLAG_ENABLE_SWING_MOTOR,
+		CONE_TWIST_JOINT_FLAG_ENABLE_TWIST_MOTOR
+	};
+
 private:
 	static void _bind_methods();
 
@@ -637,6 +652,27 @@ public:
 
 	float slider_joint_get_applied_torque(const RID& p_joint);
 
+	double cone_twist_joint_get_jolt_param(const RID& p_joint, ConeTwistJointParamJolt p_param)
+		const;
+
+	void cone_twist_joint_set_jolt_param(
+		const RID& p_joint,
+		ConeTwistJointParamJolt p_param,
+		double p_value
+	);
+
+	bool cone_twist_joint_get_jolt_flag(const RID& p_joint, ConeTwistJointFlagJolt p_flag) const;
+
+	void cone_twist_joint_set_jolt_flag(
+		const RID& p_joint,
+		ConeTwistJointFlagJolt p_flag,
+		bool p_enabled
+	);
+
+	float cone_twist_joint_get_applied_force(const RID& p_joint);
+
+	float cone_twist_joint_get_applied_torque(const RID& p_joint);
+
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 
@@ -661,3 +697,5 @@ VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointFlagJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointParamJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointFlagJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointParamJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointFlagJolt);


### PR DESCRIPTION
Fixes #348.

This adds a substitute node for `ConeTwistJoint3D`, called `JoltConeTwistJoint3D`, that mostly matches the `ConeTwistJoint3D` interface, with the following differences:

- You can enable/disable the joint, using its `enabled` property
- You can fetch its last applied force/torque, using `get_applied_force()` and `get_applied_torque()`
- You can override the solver velocity/position iterations for the joint
- You can configure a motor for all three axes
- You can _not_ configure any motion parameters, like bias, softness and relaxation

The first and second point together allow for creating breakable joints.

There are also a couple of other Jolt-specific features that can/will be added to this later, like max friction torque and positional motors with springs, but I'm mostly concerned with getting feature-parity with `ConeTwistJoint3D` right now.

Note that this PR doesn't include the proper editor gizmo for this joint, and instead it uses the same gizmo as `PinJoint3D`. I'll sort that out later.