### PR TITLE
Added `JoltGeneric6DOFJoint3D`

### DIFF
--- a/src/joints/jolt_generic_6dof_joint.cpp
+++ b/src/joints/jolt_generic_6dof_joint.cpp
@@ -1,0 +1,694 @@
+#include "jolt_generic_6dof_joint.hpp"
+
+namespace {
+
+using ServerAxis = Vector3::Axis;
+using ServerParam = PhysicsServer3D::G6DOFJointAxisParam;
+using ServerParamJolt = JoltPhysicsServer3D::G6DOFJointAxisParamJolt;
+using ServerFlag = JoltPhysicsServer3D::G6DOFJointAxisFlag;
+using ServerFlagJolt = JoltPhysicsServer3D::G6DOFJointAxisFlagJolt;
+
+} // namespace
+
+void JoltGeneric6DOFJoint3D::_bind_methods() {
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_param_x, "param");
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_param_x, "param", "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_param_y, "param");
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_param_y, "param", "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_param_z, "param");
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_param_z, "param", "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_flag_x, "flag");
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_flag_x, "flag", "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_flag_y, "flag");
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_flag_y, "flag", "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_flag_z, "flag");
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_flag_z, "flag", "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_x_upper);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_x_upper, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_x_lower);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_x_lower, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_y_upper);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_y_upper, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_y_lower);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_y_lower, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_z_upper);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_z_upper, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_z_lower);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_z_lower, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_x_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_x_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_x_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_x_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_y_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_y_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_y_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_y_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_z_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_z_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_z_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_z_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_x_target_velocity);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_x_target_velocity, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_x_max_force);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_x_max_force, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_y_target_velocity);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_y_target_velocity, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_y_max_force);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_y_max_force, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_z_target_velocity);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_z_target_velocity, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_z_max_force);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_z_max_force, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_x_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_x_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_x_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_x_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_x_equilibrium_point);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_x_equilibrium_point, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_y_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_y_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_y_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_y_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_y_equilibrium_point);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_y_equilibrium_point, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_z_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_z_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_z_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_z_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_z_equilibrium_point);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_z_equilibrium_point, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_limit_spring_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_limit_spring_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_motor_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_motor_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_linear_spring_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_linear_spring_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_x_upper);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_x_upper, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_x_lower);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_x_lower, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_y_upper);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_y_upper, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_y_lower);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_y_lower, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_z_upper);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_z_upper, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_z_lower);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_z_lower, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_x_target_velocity);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_x_target_velocity, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_x_max_torque);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_x_max_torque, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_y_target_velocity);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_y_target_velocity, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_y_max_torque);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_y_max_torque, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_z_target_velocity);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_z_target_velocity, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_z_max_torque);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_z_max_torque, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_x_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_x_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_x_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_x_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_x_equilibrium_point);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_x_equilibrium_point, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_y_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_y_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_y_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_y_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_y_equilibrium_point);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_y_equilibrium_point, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_z_frequency);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_z_frequency, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_z_damping);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_z_damping, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_z_equilibrium_point);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_z_equilibrium_point, "value");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_limit_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_limit_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_motor_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_motor_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_x_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_x_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_y_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_y_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_angular_spring_z_enabled);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, set_angular_spring_z_enabled, "enabled");
+
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_applied_force);
+	BIND_METHOD(JoltGeneric6DOFJoint3D, get_applied_torque);
+
+	ADD_GROUP("Linear Limit", "linear_limit_");
+
+	BIND_SUBPROPERTY("linear_limit_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_limit_x", "upper", Variant::FLOAT, "suffix:m");
+	BIND_SUBPROPERTY("linear_limit_x", "lower", Variant::FLOAT, "suffix:m");
+
+	BIND_SUBPROPERTY("linear_limit_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_limit_y", "upper", Variant::FLOAT, "suffix:m");
+	BIND_SUBPROPERTY("linear_limit_y", "lower", Variant::FLOAT, "suffix:m");
+
+	BIND_SUBPROPERTY("linear_limit_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_limit_z", "upper", Variant::FLOAT, "suffix:m");
+	BIND_SUBPROPERTY("linear_limit_z", "lower", Variant::FLOAT, "suffix:m");
+
+	ADD_GROUP("Linear Limit Spring", "linear_limit_spring_");
+
+	BIND_SUBPROPERTY("linear_limit_spring_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_limit_spring_x", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("linear_limit_spring_x", "damping", Variant::FLOAT);
+
+	BIND_SUBPROPERTY("linear_limit_spring_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_limit_spring_y", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("linear_limit_spring_y", "damping", Variant::FLOAT);
+
+	BIND_SUBPROPERTY("linear_limit_spring_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_limit_spring_z", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("linear_limit_spring_z", "damping", Variant::FLOAT);
+
+	ADD_GROUP("Linear Motor", "linear_motor_");
+
+	BIND_SUBPROPERTY("linear_motor_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_motor_x", "target_velocity", Variant::FLOAT, "suffix:m/s");
+	BIND_SUBPROPERTY("linear_motor_x", "max_force", Variant::FLOAT, "suffix:N");
+
+	BIND_SUBPROPERTY("linear_motor_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_motor_y", "target_velocity", Variant::FLOAT, "suffix:m/s");
+	BIND_SUBPROPERTY("linear_motor_y", "max_force", Variant::FLOAT, "suffix:N");
+
+	BIND_SUBPROPERTY("linear_motor_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_motor_z", "target_velocity", Variant::FLOAT, "suffix:m/s");
+	BIND_SUBPROPERTY("linear_motor_z", "max_force", Variant::FLOAT, "suffix:N");
+
+	ADD_GROUP("Linear Spring", "linear_spring_");
+
+	BIND_SUBPROPERTY("linear_spring_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_spring_x", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("linear_spring_x", "damping", Variant::FLOAT);
+	BIND_SUBPROPERTY("linear_spring_x", "equilibrium_point", Variant::FLOAT, "suffix:m");
+
+	BIND_SUBPROPERTY("linear_spring_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_spring_y", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("linear_spring_y", "damping", Variant::FLOAT);
+	BIND_SUBPROPERTY("linear_spring_y", "equilibrium_point", Variant::FLOAT, "suffix:m");
+
+	BIND_SUBPROPERTY("linear_spring_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("linear_spring_z", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("linear_spring_z", "damping", Variant::FLOAT);
+	BIND_SUBPROPERTY("linear_spring_z", "equilibrium_point", Variant::FLOAT, "suffix:m");
+
+	ADD_GROUP("Angular Limit", "angular_limit_");
+
+	BIND_SUBPROPERTY("angular_limit_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_limit_x", "upper", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_limit_x", "lower", Variant::FLOAT, "radians");
+
+	BIND_SUBPROPERTY("angular_limit_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_limit_y", "upper", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_limit_y", "lower", Variant::FLOAT, "radians");
+
+	BIND_SUBPROPERTY("angular_limit_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_limit_z", "upper", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_limit_z", "lower", Variant::FLOAT, "radians");
+
+	ADD_GROUP("Angular Motor", "angular_motor_");
+
+	BIND_SUBPROPERTY("angular_motor_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_motor_x", "target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_SUBPROPERTY("angular_motor_x", "max_torque", Variant::FLOAT, "suffix:Nm");
+
+	BIND_SUBPROPERTY("angular_motor_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_motor_y", "target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_SUBPROPERTY("angular_motor_y", "max_torque", Variant::FLOAT, "suffix:Nm");
+
+	BIND_SUBPROPERTY("angular_motor_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_motor_z", "target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_SUBPROPERTY("angular_motor_z", "max_torque", Variant::FLOAT, "suffix:Nm");
+
+	ADD_GROUP("Angular Spring", "angular_spring_");
+
+	BIND_SUBPROPERTY("angular_spring_x", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_spring_x", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("angular_spring_x", "damping", Variant::FLOAT);
+	BIND_SUBPROPERTY("angular_spring_x", "equilibrium_point", Variant::FLOAT, "radians");
+
+	BIND_SUBPROPERTY("angular_spring_y", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_spring_y", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("angular_spring_y", "damping", Variant::FLOAT);
+	BIND_SUBPROPERTY("angular_spring_y", "equilibrium_point", Variant::FLOAT, "radians");
+
+	BIND_SUBPROPERTY("angular_spring_z", "enabled", Variant::BOOL);
+	BIND_SUBPROPERTY("angular_spring_z", "frequency", Variant::FLOAT, "suffix:hz");
+	BIND_SUBPROPERTY("angular_spring_z", "damping", Variant::FLOAT);
+	BIND_SUBPROPERTY("angular_spring_z", "equilibrium_point", Variant::FLOAT, "radians");
+
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_UPPER);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_LOWER);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_MOTOR_MAX_FORCE);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_LIMIT_UPPER);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_LIMIT_LOWER);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_MOTOR_MAX_TORQUE);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_LINEAR_LIMIT);
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_LINEAR_LIMIT_SPRING);
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_LINEAR_MOTOR);
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_LINEAR_SPRING);
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_ANGULAR_LIMIT);
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_ANGULAR_MOTOR);
+	BIND_ENUM_CONSTANT(FLAG_ENABLE_ANGULAR_SPRING);
+}
+
+JoltGeneric6DOFJoint3D::JoltGeneric6DOFJoint3D() {
+	std::fill_n(linear_limit_spring_frequency, AXIS_COUNT, 2.0);
+	std::fill_n(linear_limit_spring_damping, AXIS_COUNT, 0.0);
+	std::fill_n(linear_motor_max_force, AXIS_COUNT, INFINITY);
+	std::fill_n(linear_spring_frequency, AXIS_COUNT, 2.0);
+	std::fill_n(linear_spring_damping, AXIS_COUNT, 0.0);
+	std::fill_n(angular_motor_max_torque, AXIS_COUNT, INFINITY);
+	std::fill_n(angular_spring_frequency, AXIS_COUNT, 2.0);
+	std::fill_n(angular_spring_damping, AXIS_COUNT, 0.0);
+	std::fill_n(linear_limit_enabled, AXIS_COUNT, true);
+	std::fill_n(angular_limit_enabled, AXIS_COUNT, true);
+}
+
+double JoltGeneric6DOFJoint3D::get_param(Axis p_axis, Param p_param) const {
+	const double* value = _get_param_ptr(p_axis, p_param);
+	QUIET_FAIL_NULL_D(value);
+
+	return *value;
+}
+
+void JoltGeneric6DOFJoint3D::set_param(Axis p_axis, Param p_param, double p_value) {
+	double* value = _get_param_ptr(p_axis, p_param);
+	QUIET_FAIL_NULL(value);
+
+	if (*value == p_value) {
+		return;
+	}
+
+	*value = p_value;
+
+	_param_changed(p_axis, p_param);
+}
+
+bool JoltGeneric6DOFJoint3D::get_flag(Axis p_axis, Flag p_flag) const {
+	const bool* value = _get_flag_ptr(p_axis, p_flag);
+	QUIET_FAIL_NULL_D(value);
+
+	return *value;
+}
+
+void JoltGeneric6DOFJoint3D::set_flag(Axis p_axis, Flag p_flag, bool p_enabled) {
+	bool* value = _get_flag_ptr(p_axis, p_flag);
+	QUIET_FAIL_NULL(value);
+
+	if (*value == p_enabled) {
+		return;
+	}
+
+	*value = p_enabled;
+
+	_flag_changed(p_axis, p_flag);
+}
+
+float JoltGeneric6DOFJoint3D::get_applied_force() const {
+	JoltPhysicsServer3D* server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(server);
+
+	return server->generic_6dof_joint_get_applied_force(rid);
+}
+
+float JoltGeneric6DOFJoint3D::get_applied_torque() const {
+	JoltPhysicsServer3D* server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL_D(server);
+
+	return server->generic_6dof_joint_get_applied_torque(rid);
+}
+
+void JoltGeneric6DOFJoint3D::_configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) {
+	PhysicsServer3D* server = _get_physics_server();
+	ERR_FAIL_NULL(server);
+
+	server->joint_make_generic_6dof(
+		rid,
+		p_body_a->get_rid(),
+		_get_body_local_transform(*p_body_a),
+		p_body_b != nullptr ? p_body_b->get_rid() : RID(),
+		p_body_b != nullptr ? _get_body_local_transform(*p_body_b)
+							: get_global_transform().orthonormalized()
+	);
+
+	for (int32_t i = 0; i < AXIS_COUNT; ++i) {
+		const auto axis = (Axis)i;
+
+		_update_param(axis, PARAM_LINEAR_LIMIT_UPPER);
+		_update_param(axis, PARAM_LINEAR_LIMIT_LOWER);
+		_update_param(axis, PARAM_LINEAR_MOTOR_TARGET_VELOCITY);
+		_update_param(axis, PARAM_LINEAR_MOTOR_MAX_FORCE);
+		_update_param(axis, PARAM_LINEAR_SPRING_DAMPING);
+		_update_param(axis, PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT);
+		_update_param(axis, PARAM_ANGULAR_LIMIT_UPPER);
+		_update_param(axis, PARAM_ANGULAR_LIMIT_LOWER);
+		_update_param(axis, PARAM_ANGULAR_MOTOR_TARGET_VELOCITY);
+		_update_param(axis, PARAM_ANGULAR_MOTOR_MAX_TORQUE);
+		_update_param(axis, PARAM_ANGULAR_SPRING_DAMPING);
+		_update_param(axis, PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+
+		_update_jolt_param(axis, PARAM_LINEAR_LIMIT_SPRING_FREQUENCY);
+		_update_jolt_param(axis, PARAM_LINEAR_LIMIT_SPRING_DAMPING);
+		_update_jolt_param(axis, PARAM_LINEAR_SPRING_FREQUENCY);
+		_update_jolt_param(axis, PARAM_ANGULAR_SPRING_FREQUENCY);
+
+		_update_flag(axis, FLAG_ENABLE_LINEAR_LIMIT);
+		_update_flag(axis, FLAG_ENABLE_LINEAR_MOTOR);
+		_update_flag(axis, FLAG_ENABLE_LINEAR_SPRING);
+		_update_flag(axis, FLAG_ENABLE_ANGULAR_LIMIT);
+		_update_flag(axis, FLAG_ENABLE_ANGULAR_MOTOR);
+		_update_flag(axis, FLAG_ENABLE_ANGULAR_SPRING);
+
+		_update_jolt_flag(axis, FLAG_ENABLE_LINEAR_LIMIT_SPRING);
+		_update_jolt_flag(axis, FLAG_ENABLE_LINEAR_SPRING_FREQUENCY, true);
+		_update_jolt_flag(axis, FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY, true);
+	}
+}
+
+const double* JoltGeneric6DOFJoint3D::_get_param_ptr(Axis p_axis, Param p_param) const {
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+	return const_cast<JoltGeneric6DOFJoint3D*>(this)->_get_param_ptr(p_axis, p_param);
+}
+
+double* JoltGeneric6DOFJoint3D::_get_param_ptr(Axis p_axis, Param p_param) {
+	switch (p_param) {
+		case PARAM_LINEAR_LIMIT_UPPER: {
+			return &linear_limit_upper[p_axis];
+		}
+		case PARAM_LINEAR_LIMIT_LOWER: {
+			return &linear_limit_lower[p_axis];
+		}
+		case PARAM_LINEAR_LIMIT_SPRING_FREQUENCY: {
+			return &linear_limit_spring_frequency[p_axis];
+		}
+		case PARAM_LINEAR_LIMIT_SPRING_DAMPING: {
+			return &linear_limit_spring_damping[p_axis];
+		}
+		case PARAM_LINEAR_MOTOR_TARGET_VELOCITY: {
+			return &linear_motor_target_velocity[p_axis];
+		}
+		case PARAM_LINEAR_MOTOR_MAX_FORCE: {
+			return &linear_motor_max_force[p_axis];
+		}
+		case PARAM_LINEAR_SPRING_FREQUENCY: {
+			return &linear_spring_frequency[p_axis];
+		}
+		case PARAM_LINEAR_SPRING_DAMPING: {
+			return &linear_spring_damping[p_axis];
+		}
+		case PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT: {
+			return &linear_spring_equilibrium_point[p_axis];
+		}
+		case PARAM_ANGULAR_LIMIT_UPPER: {
+			return &angular_limit_upper[p_axis];
+		}
+		case PARAM_ANGULAR_LIMIT_LOWER: {
+			return &angular_limit_lower[p_axis];
+		}
+		case PARAM_ANGULAR_MOTOR_TARGET_VELOCITY: {
+			return &angular_motor_target_velocity[p_axis];
+		}
+		case PARAM_ANGULAR_MOTOR_MAX_TORQUE: {
+			return &angular_motor_max_torque[p_axis];
+		}
+		case PARAM_ANGULAR_SPRING_FREQUENCY: {
+			return &angular_spring_frequency[p_axis];
+		}
+		case PARAM_ANGULAR_SPRING_DAMPING: {
+			return &angular_spring_damping[p_axis];
+		}
+		case PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT: {
+			return &angular_spring_equilibrium_point[p_axis];
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		}
+	}
+}
+
+const bool* JoltGeneric6DOFJoint3D::_get_flag_ptr(Axis p_axis, Flag p_flag) const {
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+	return const_cast<JoltGeneric6DOFJoint3D*>(this)->_get_flag_ptr(p_axis, p_flag);
+}
+
+bool* JoltGeneric6DOFJoint3D::_get_flag_ptr(Axis p_axis, Flag p_flag) {
+	switch (p_flag) {
+		case FLAG_ENABLE_LINEAR_LIMIT: {
+			return &linear_limit_enabled[p_axis];
+		}
+		case FLAG_ENABLE_LINEAR_LIMIT_SPRING: {
+			return &linear_limit_spring_enabled[p_axis];
+		}
+		case FLAG_ENABLE_LINEAR_MOTOR: {
+			return &linear_motor_enabled[p_axis];
+		}
+		case FLAG_ENABLE_LINEAR_SPRING: {
+			return &linear_spring_enabled[p_axis];
+		}
+		case FLAG_ENABLE_ANGULAR_LIMIT: {
+			return &angular_limit_enabled[p_axis];
+		}
+		case FLAG_ENABLE_ANGULAR_MOTOR: {
+			return &angular_motor_enabled[p_axis];
+		}
+		case FLAG_ENABLE_ANGULAR_SPRING: {
+			return &angular_spring_enabled[p_axis];
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		}
+	}
+}
+
+void JoltGeneric6DOFJoint3D::_update_param(Axis p_axis, Param p_param, double p_value) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	PhysicsServer3D* server = _get_physics_server();
+	ERR_FAIL_NULL(server);
+
+	server->generic_6dof_joint_set_param(rid, p_axis, (ServerParam)p_param, p_value);
+}
+
+void JoltGeneric6DOFJoint3D::_update_param(Axis p_axis, Param p_param) {
+	const double* value = _get_param_ptr(p_axis, p_param);
+	ERR_FAIL_NULL(value);
+
+	_update_param(p_axis, p_param, *value);
+}
+
+void JoltGeneric6DOFJoint3D::_update_jolt_param(Axis p_axis, Param p_param, double p_value) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(server);
+
+	server->generic_6dof_joint_set_jolt_param(rid, p_axis, (ServerParamJolt)p_param, p_value);
+}
+
+void JoltGeneric6DOFJoint3D::_update_jolt_param(Axis p_axis, Param p_param) {
+	const double* value = _get_param_ptr(p_axis, p_param);
+	ERR_FAIL_NULL(value);
+
+	_update_jolt_param(p_axis, p_param, *value);
+}
+
+void JoltGeneric6DOFJoint3D::_update_flag(Axis p_axis, Flag p_flag, bool p_enabled) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	PhysicsServer3D* server = _get_physics_server();
+	ERR_FAIL_NULL(server);
+
+	server->generic_6dof_joint_set_flag(rid, p_axis, (ServerFlag)p_flag, p_enabled);
+}
+
+void JoltGeneric6DOFJoint3D::_update_flag(Axis p_axis, Flag p_flag) {
+	const bool* value = _get_flag_ptr(p_axis, p_flag);
+	QUIET_FAIL_NULL(value);
+
+	_update_flag(p_axis, p_flag, *value);
+}
+
+void JoltGeneric6DOFJoint3D::_update_jolt_flag(Axis p_axis, Flag p_flag, bool p_enabled) {
+	QUIET_FAIL_COND(_is_invalid());
+
+	JoltPhysicsServer3D* server = _get_jolt_physics_server();
+	QUIET_FAIL_NULL(server);
+
+	server->generic_6dof_joint_set_jolt_flag(rid, p_axis, (ServerFlagJolt)p_flag, p_enabled);
+}
+
+void JoltGeneric6DOFJoint3D::_update_jolt_flag(Axis p_axis, Flag p_flag) {
+	const bool* value = _get_flag_ptr(p_axis, p_flag);
+	QUIET_FAIL_NULL(value);
+
+	_update_jolt_flag(p_axis, p_flag, *value);
+}
+
+void JoltGeneric6DOFJoint3D::_param_changed(Axis p_axis, Param p_param) {
+	switch (p_param) {
+		case PARAM_LINEAR_LIMIT_UPPER:
+		case PARAM_LINEAR_LIMIT_LOWER:
+		case PARAM_LINEAR_MOTOR_TARGET_VELOCITY:
+		case PARAM_LINEAR_MOTOR_MAX_FORCE:
+		case PARAM_LINEAR_SPRING_DAMPING:
+		case PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT:
+		case PARAM_ANGULAR_LIMIT_UPPER:
+		case PARAM_ANGULAR_LIMIT_LOWER:
+		case PARAM_ANGULAR_MOTOR_TARGET_VELOCITY:
+		case PARAM_ANGULAR_MOTOR_MAX_TORQUE:
+		case PARAM_ANGULAR_SPRING_DAMPING:
+		case PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT: {
+			_update_param(p_axis, p_param);
+		} break;
+
+		case PARAM_LINEAR_LIMIT_SPRING_FREQUENCY:
+		case PARAM_LINEAR_LIMIT_SPRING_DAMPING:
+		case PARAM_LINEAR_SPRING_FREQUENCY:
+		case PARAM_ANGULAR_SPRING_FREQUENCY: {
+			_update_jolt_param(p_axis, p_param);
+		} break;
+
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+}
+
+void JoltGeneric6DOFJoint3D::_flag_changed(Axis p_axis, Flag p_flag) {
+	switch (p_flag) {
+		case FLAG_ENABLE_LINEAR_LIMIT:
+		case FLAG_ENABLE_LINEAR_MOTOR:
+		case FLAG_ENABLE_LINEAR_SPRING:
+		case FLAG_ENABLE_ANGULAR_LIMIT:
+		case FLAG_ENABLE_ANGULAR_MOTOR:
+		case FLAG_ENABLE_ANGULAR_SPRING: {
+			_update_flag(p_axis, p_flag);
+		} break;
+
+		case FLAG_ENABLE_LINEAR_LIMIT_SPRING: {
+			_update_jolt_flag(p_axis, p_flag);
+		} break;
+
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+}

--- a/src/joints/jolt_generic_6dof_joint.hpp
+++ b/src/joints/jolt_generic_6dof_joint.hpp
@@ -1,0 +1,460 @@
+#pragma once
+
+#include "joints/jolt_joint_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
+
+class JoltGeneric6DOFJoint3D final : public JoltJoint3D {
+	GDCLASS_NO_WARN(JoltGeneric6DOFJoint3D, JoltJoint3D)
+
+public:
+	// clang-format off
+
+	using Axis = Vector3::Axis;
+
+	enum Param {
+		PARAM_LINEAR_LIMIT_UPPER = PhysicsServer3D::G6DOF_JOINT_LINEAR_UPPER_LIMIT,
+		PARAM_LINEAR_LIMIT_LOWER = PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT,
+		PARAM_LINEAR_LIMIT_SPRING_FREQUENCY = JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SPRING_FREQUENCY,
+		PARAM_LINEAR_LIMIT_SPRING_DAMPING = JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SPRING_DAMPING,
+		PARAM_LINEAR_MOTOR_TARGET_VELOCITY = PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_TARGET_VELOCITY,
+		PARAM_LINEAR_MOTOR_MAX_FORCE = PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_FORCE_LIMIT,
+		PARAM_LINEAR_SPRING_FREQUENCY = JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_FREQUENCY,
+		PARAM_LINEAR_SPRING_DAMPING = JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_DAMPING,
+		PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT = JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT,
+		PARAM_ANGULAR_LIMIT_UPPER = PhysicsServer3D::G6DOF_JOINT_ANGULAR_UPPER_LIMIT,
+		PARAM_ANGULAR_LIMIT_LOWER = PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT,
+		PARAM_ANGULAR_MOTOR_TARGET_VELOCITY = PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_TARGET_VELOCITY,
+		PARAM_ANGULAR_MOTOR_MAX_TORQUE = PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_FORCE_LIMIT,
+		PARAM_ANGULAR_SPRING_FREQUENCY = JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_FREQUENCY,
+		PARAM_ANGULAR_SPRING_DAMPING = JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_DAMPING,
+		PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT = JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT,
+	};
+
+	enum Flag {
+		FLAG_ENABLE_LINEAR_LIMIT = PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT,
+		FLAG_ENABLE_LINEAR_LIMIT_SPRING = JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT_SPRING,
+		FLAG_ENABLE_LINEAR_MOTOR = PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_MOTOR,
+		FLAG_ENABLE_LINEAR_SPRING = JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING,
+		FLAG_ENABLE_ANGULAR_LIMIT = PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT,
+		FLAG_ENABLE_ANGULAR_MOTOR = PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_MOTOR,
+		FLAG_ENABLE_ANGULAR_SPRING = JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING,
+
+		// HACK(mihe): These ones are left out of most places where the other flags are are used,
+		// due to not being user-facing as far as this node is concerned, and are mostly just here
+		// to simplify things a bit.
+		FLAG_ENABLE_LINEAR_SPRING_FREQUENCY = JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING_FREQUENCY,
+		FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY = JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY
+	};
+
+	// clang-format on
+
+private:
+	static constexpr Axis AXIS_X = Axis::AXIS_X;
+
+	static constexpr Axis AXIS_Y = Axis::AXIS_Y;
+
+	static constexpr Axis AXIS_Z = Axis::AXIS_Z;
+
+	static constexpr int32_t AXIS_COUNT = 3;
+
+	static void _bind_methods();
+
+public:
+	JoltGeneric6DOFJoint3D();
+
+	double get_param(Axis p_axis, Param p_param) const;
+
+	void set_param(Axis p_axis, Param p_param, double p_value);
+
+	double get_param_x(Param p_param) const { return get_param(AXIS_X, p_param); }
+
+	void set_param_x(Param p_param, double p_value) { set_param(AXIS_X, p_param, p_value); }
+
+	double get_param_y(Param p_param) const { return get_param(AXIS_Y, p_param); }
+
+	void set_param_y(Param p_param, double p_value) { set_param(AXIS_Y, p_param, p_value); }
+
+	double get_param_z(Param p_param) const { return get_param(AXIS_Z, p_param); }
+
+	void set_param_z(Param p_param, double p_value) { set_param(AXIS_Z, p_param, p_value); }
+
+	bool get_flag(Axis p_axis, Flag p_flag) const;
+
+	void set_flag(Axis p_axis, Flag p_flag, bool p_enabled);
+
+	bool get_flag_x(Flag p_flag) const { return get_flag(AXIS_X, p_flag); }
+
+	void set_flag_x(Flag p_flag, bool p_enabled) { set_flag(AXIS_X, p_flag, p_enabled); }
+
+	bool get_flag_y(Flag p_flag) const { return get_flag(AXIS_Y, p_flag); }
+
+	void set_flag_y(Flag p_flag, bool p_enabled) { set_flag(AXIS_Y, p_flag, p_enabled); }
+
+	bool get_flag_z(Flag p_flag) const { return get_flag(AXIS_Z, p_flag); }
+
+	void set_flag_z(Flag p_flag, bool p_enabled) { set_flag(AXIS_Z, p_flag, p_enabled); }
+
+	// clang-format off
+
+	double get_linear_limit_x_upper() const { return get_param_x(PARAM_LINEAR_LIMIT_UPPER); }
+
+	void set_linear_limit_x_upper(double p_value) { return set_param_x(PARAM_LINEAR_LIMIT_UPPER, p_value); }
+
+	double get_linear_limit_x_lower() const { return get_param_x(PARAM_LINEAR_LIMIT_LOWER); }
+
+	void set_linear_limit_x_lower(double p_value) { return set_param_x(PARAM_LINEAR_LIMIT_LOWER, p_value); }
+
+	double get_linear_limit_y_upper() const { return get_param_y(PARAM_LINEAR_LIMIT_UPPER); }
+
+	void set_linear_limit_y_upper(double p_value) { return set_param_y(PARAM_LINEAR_LIMIT_UPPER, p_value); }
+
+	double get_linear_limit_y_lower() const { return get_param_y(PARAM_LINEAR_LIMIT_LOWER); }
+
+	void set_linear_limit_y_lower(double p_value) { return set_param_y(PARAM_LINEAR_LIMIT_LOWER, p_value); }
+
+	double get_linear_limit_z_upper() const { return get_param_z(PARAM_LINEAR_LIMIT_UPPER); }
+
+	void set_linear_limit_z_upper(double p_value) { return set_param_z(PARAM_LINEAR_LIMIT_UPPER, p_value); }
+
+	double get_linear_limit_z_lower() const { return get_param_z(PARAM_LINEAR_LIMIT_LOWER); }
+
+	void set_linear_limit_z_lower(double p_value) { return set_param_z(PARAM_LINEAR_LIMIT_LOWER, p_value); }
+
+	double get_linear_limit_spring_x_frequency() const { return get_param_x(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY); }
+
+	void set_linear_limit_spring_x_frequency(double p_value) { return set_param_x(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY, p_value); }
+
+	double get_linear_limit_spring_x_damping() const { return get_param_x(PARAM_LINEAR_LIMIT_SPRING_DAMPING); }
+
+	void set_linear_limit_spring_x_damping(double p_value) { return set_param_x(PARAM_LINEAR_LIMIT_SPRING_DAMPING, p_value); }
+
+	double get_linear_limit_spring_y_frequency() const { return get_param_y(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY); }
+
+	void set_linear_limit_spring_y_frequency(double p_value) { return set_param_y(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY, p_value); }
+
+	double get_linear_limit_spring_y_damping() const { return get_param_y(PARAM_LINEAR_LIMIT_SPRING_DAMPING); }
+
+	void set_linear_limit_spring_y_damping(double p_value) { return set_param_y(PARAM_LINEAR_LIMIT_SPRING_DAMPING, p_value); }
+
+	double get_linear_limit_spring_z_frequency() const { return get_param_z(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY); }
+
+	void set_linear_limit_spring_z_frequency(double p_value) { return set_param_z(PARAM_LINEAR_LIMIT_SPRING_FREQUENCY, p_value); }
+
+	double get_linear_limit_spring_z_damping() const { return get_param_z(PARAM_LINEAR_LIMIT_SPRING_DAMPING); }
+
+	void set_linear_limit_spring_z_damping(double p_value) { return set_param_z(PARAM_LINEAR_LIMIT_SPRING_DAMPING, p_value); }
+
+	double get_linear_motor_x_target_velocity() const { return get_param_x(PARAM_LINEAR_MOTOR_TARGET_VELOCITY); }
+
+	void set_linear_motor_x_target_velocity(double p_value) { return set_param_x(PARAM_LINEAR_MOTOR_TARGET_VELOCITY, p_value); }
+
+	double get_linear_motor_x_max_force() const { return get_param_x(PARAM_LINEAR_MOTOR_MAX_FORCE); }
+
+	void set_linear_motor_x_max_force(double p_value) { return set_param_x(PARAM_LINEAR_MOTOR_MAX_FORCE, p_value); }
+
+	double get_linear_motor_y_target_velocity() const { return get_param_y(PARAM_LINEAR_MOTOR_TARGET_VELOCITY); }
+
+	void set_linear_motor_y_target_velocity(double p_value) { return set_param_y(PARAM_LINEAR_MOTOR_TARGET_VELOCITY, p_value); }
+
+	double get_linear_motor_y_max_force() const { return get_param_y(PARAM_LINEAR_MOTOR_MAX_FORCE); }
+
+	void set_linear_motor_y_max_force(double p_value) { return set_param_y(PARAM_LINEAR_MOTOR_MAX_FORCE, p_value); }
+
+	double get_linear_motor_z_target_velocity() const { return get_param_z(PARAM_LINEAR_MOTOR_TARGET_VELOCITY); }
+
+	void set_linear_motor_z_target_velocity(double p_value) { return set_param_z(PARAM_LINEAR_MOTOR_TARGET_VELOCITY, p_value); }
+
+	double get_linear_motor_z_max_force() const { return get_param_z(PARAM_LINEAR_MOTOR_MAX_FORCE); }
+
+	void set_linear_motor_z_max_force(double p_value) { return set_param_z(PARAM_LINEAR_MOTOR_MAX_FORCE, p_value); }
+
+	double get_linear_spring_x_frequency() const { return get_param_x(PARAM_LINEAR_SPRING_FREQUENCY); }
+
+	void set_linear_spring_x_frequency(double p_value) { return set_param_x(PARAM_LINEAR_SPRING_FREQUENCY, p_value); }
+
+	double get_linear_spring_x_damping() const { return get_param_x(PARAM_LINEAR_SPRING_DAMPING); }
+
+	void set_linear_spring_x_damping(double p_value) { return set_param_x(PARAM_LINEAR_SPRING_DAMPING, p_value); }
+
+	double get_linear_spring_x_equilibrium_point() const { return get_param_x(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT); }
+
+	void set_linear_spring_x_equilibrium_point(double p_value) { return set_param_x(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT, p_value); }
+
+	double get_linear_spring_y_frequency() const { return get_param_y(PARAM_LINEAR_SPRING_FREQUENCY); }
+
+	void set_linear_spring_y_frequency(double p_value) { return set_param_y(PARAM_LINEAR_SPRING_FREQUENCY, p_value); }
+
+	double get_linear_spring_y_damping() const { return get_param_y(PARAM_LINEAR_SPRING_DAMPING); }
+
+	void set_linear_spring_y_damping(double p_value) { return set_param_y(PARAM_LINEAR_SPRING_DAMPING, p_value); }
+
+	double get_linear_spring_y_equilibrium_point() const { return get_param_y(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT); }
+
+	void set_linear_spring_y_equilibrium_point(double p_value) { return set_param_y(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT, p_value); }
+
+	double get_linear_spring_z_frequency() const { return get_param_z(PARAM_LINEAR_SPRING_FREQUENCY); }
+
+	void set_linear_spring_z_frequency(double p_value) { return set_param_z(PARAM_LINEAR_SPRING_FREQUENCY, p_value); }
+
+	double get_linear_spring_z_damping() const { return get_param_z(PARAM_LINEAR_SPRING_DAMPING); }
+
+	void set_linear_spring_z_damping(double p_value) { return set_param_z(PARAM_LINEAR_SPRING_DAMPING, p_value); }
+
+	double get_linear_spring_z_equilibrium_point() const { return get_param_z(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT); }
+
+	void set_linear_spring_z_equilibrium_point(double p_value) { return set_param_z(PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT, p_value); }
+
+	bool get_linear_limit_x_enabled() const { return get_flag_x(FLAG_ENABLE_LINEAR_LIMIT); }
+
+	void set_linear_limit_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_LINEAR_LIMIT, p_enabled); }
+
+	bool get_linear_limit_y_enabled() const { return get_flag_y(FLAG_ENABLE_LINEAR_LIMIT); }
+
+	void set_linear_limit_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_LINEAR_LIMIT, p_enabled); }
+
+	bool get_linear_limit_z_enabled() const { return get_flag_z(FLAG_ENABLE_LINEAR_LIMIT); }
+
+	void set_linear_limit_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_LINEAR_LIMIT, p_enabled); }
+
+	bool get_linear_limit_spring_x_enabled() const { return get_flag_x(FLAG_ENABLE_LINEAR_LIMIT_SPRING); }
+
+	void set_linear_limit_spring_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_LINEAR_LIMIT_SPRING, p_enabled); }
+
+	bool get_linear_limit_spring_y_enabled() const { return get_flag_y(FLAG_ENABLE_LINEAR_LIMIT_SPRING); }
+
+	void set_linear_limit_spring_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_LINEAR_LIMIT_SPRING, p_enabled); }
+
+	bool get_linear_limit_spring_z_enabled() const { return get_flag_z(FLAG_ENABLE_LINEAR_LIMIT_SPRING); }
+
+	void set_linear_limit_spring_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_LINEAR_LIMIT_SPRING, p_enabled); }
+
+	bool get_linear_motor_x_enabled() const { return get_flag_x(FLAG_ENABLE_LINEAR_MOTOR); }
+
+	void set_linear_motor_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_LINEAR_MOTOR, p_enabled); }
+
+	bool get_linear_motor_y_enabled() const { return get_flag_y(FLAG_ENABLE_LINEAR_MOTOR); }
+
+	void set_linear_motor_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_LINEAR_MOTOR, p_enabled); }
+
+	bool get_linear_motor_z_enabled() const { return get_flag_z(FLAG_ENABLE_LINEAR_MOTOR); }
+
+	void set_linear_motor_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_LINEAR_MOTOR, p_enabled); }
+
+	bool get_linear_spring_x_enabled() const { return get_flag_x(FLAG_ENABLE_LINEAR_SPRING); }
+
+	void set_linear_spring_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_LINEAR_SPRING, p_enabled); }
+
+	bool get_linear_spring_y_enabled() const { return get_flag_y(FLAG_ENABLE_LINEAR_SPRING); }
+
+	void set_linear_spring_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_LINEAR_SPRING, p_enabled); }
+
+	bool get_linear_spring_z_enabled() const { return get_flag_z(FLAG_ENABLE_LINEAR_SPRING); }
+
+	void set_linear_spring_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_LINEAR_SPRING, p_enabled); }
+
+	double get_angular_limit_x_upper() const { return get_param_x(PARAM_ANGULAR_LIMIT_UPPER); }
+
+	void set_angular_limit_x_upper(double p_value) { return set_param_x(PARAM_ANGULAR_LIMIT_UPPER, p_value); }
+
+	double get_angular_limit_x_lower() const { return get_param_x(PARAM_ANGULAR_LIMIT_LOWER); }
+
+	void set_angular_limit_x_lower(double p_value) { return set_param_x(PARAM_ANGULAR_LIMIT_LOWER, p_value); }
+
+	double get_angular_limit_y_upper() const { return get_param_y(PARAM_ANGULAR_LIMIT_UPPER); }
+
+	void set_angular_limit_y_upper(double p_value) { return set_param_y(PARAM_ANGULAR_LIMIT_UPPER, p_value); }
+
+	double get_angular_limit_y_lower() const { return get_param_y(PARAM_ANGULAR_LIMIT_LOWER); }
+
+	void set_angular_limit_y_lower(double p_value) { return set_param_y(PARAM_ANGULAR_LIMIT_LOWER, p_value); }
+
+	double get_angular_limit_z_upper() const { return get_param_z(PARAM_ANGULAR_LIMIT_UPPER); }
+
+	void set_angular_limit_z_upper(double p_value) { return set_param_z(PARAM_ANGULAR_LIMIT_UPPER, p_value); }
+
+	double get_angular_limit_z_lower() const { return get_param_z(PARAM_ANGULAR_LIMIT_LOWER); }
+
+	void set_angular_limit_z_lower(double p_value) { return set_param_z(PARAM_ANGULAR_LIMIT_LOWER, p_value); }
+
+	double get_angular_motor_x_target_velocity() const { return get_param_x(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY); }
+
+	void set_angular_motor_x_target_velocity(double p_value) { return set_param_x(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY, p_value); }
+
+	double get_angular_motor_x_max_torque() const { return get_param_x(PARAM_ANGULAR_MOTOR_MAX_TORQUE); }
+
+	void set_angular_motor_x_max_torque(double p_value) { return set_param_x(PARAM_ANGULAR_MOTOR_MAX_TORQUE, p_value); }
+
+	double get_angular_motor_y_target_velocity() const { return get_param_y(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY); }
+
+	void set_angular_motor_y_target_velocity(double p_value) { return set_param_y(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY, p_value); }
+
+	double get_angular_motor_y_max_torque() const { return get_param_y(PARAM_ANGULAR_MOTOR_MAX_TORQUE); }
+
+	void set_angular_motor_y_max_torque(double p_value) { return set_param_y(PARAM_ANGULAR_MOTOR_MAX_TORQUE, p_value); }
+
+	double get_angular_motor_z_target_velocity() const { return get_param_z(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY); }
+
+	void set_angular_motor_z_target_velocity(double p_value) { return set_param_z(PARAM_ANGULAR_MOTOR_TARGET_VELOCITY, p_value); }
+
+	double get_angular_motor_z_max_torque() const { return get_param_z(PARAM_ANGULAR_MOTOR_MAX_TORQUE); }
+
+	void set_angular_motor_z_max_torque(double p_value) { return set_param_z(PARAM_ANGULAR_MOTOR_MAX_TORQUE, p_value); }
+
+	double get_angular_spring_x_frequency() const { return get_param_x(PARAM_ANGULAR_SPRING_FREQUENCY); }
+
+	void set_angular_spring_x_frequency(double p_value) { return set_param_x(PARAM_ANGULAR_SPRING_FREQUENCY, p_value); }
+
+	double get_angular_spring_x_damping() const { return get_param_x(PARAM_ANGULAR_SPRING_DAMPING); }
+
+	void set_angular_spring_x_damping(double p_value) { return set_param_x(PARAM_ANGULAR_SPRING_DAMPING, p_value); }
+
+	double get_angular_spring_x_equilibrium_point() const { return get_param_x(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT); }
+
+	void set_angular_spring_x_equilibrium_point(double p_value) { return set_param_x(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT, p_value); }
+
+	double get_angular_spring_y_frequency() const { return get_param_y(PARAM_ANGULAR_SPRING_FREQUENCY); }
+
+	void set_angular_spring_y_frequency(double p_value) { return set_param_y(PARAM_ANGULAR_SPRING_FREQUENCY, p_value); }
+
+	double get_angular_spring_y_damping() const { return get_param_y(PARAM_ANGULAR_SPRING_DAMPING); }
+
+	void set_angular_spring_y_damping(double p_value) { return set_param_y(PARAM_ANGULAR_SPRING_DAMPING, p_value); }
+
+	double get_angular_spring_y_equilibrium_point() const { return get_param_y(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT); }
+
+	void set_angular_spring_y_equilibrium_point(double p_value) { return set_param_y(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT, p_value); }
+
+	double get_angular_spring_z_frequency() const { return get_param_z(PARAM_ANGULAR_SPRING_FREQUENCY); }
+
+	void set_angular_spring_z_frequency(double p_value) { return set_param_z(PARAM_ANGULAR_SPRING_FREQUENCY, p_value); }
+
+	double get_angular_spring_z_damping() const { return get_param_z(PARAM_ANGULAR_SPRING_DAMPING); }
+
+	void set_angular_spring_z_damping(double p_value) { return set_param_z(PARAM_ANGULAR_SPRING_DAMPING, p_value); }
+
+	double get_angular_spring_z_equilibrium_point() const { return get_param_z(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT); }
+
+	void set_angular_spring_z_equilibrium_point(double p_value) { return set_param_z(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT, p_value); }
+
+	bool get_angular_limit_x_enabled() const { return get_flag_x(FLAG_ENABLE_ANGULAR_LIMIT); }
+
+	void set_angular_limit_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_ANGULAR_LIMIT, p_enabled); }
+
+	bool get_angular_limit_y_enabled() const { return get_flag_y(FLAG_ENABLE_ANGULAR_LIMIT); }
+
+	void set_angular_limit_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_ANGULAR_LIMIT, p_enabled); }
+
+	bool get_angular_limit_z_enabled() const { return get_flag_z(FLAG_ENABLE_ANGULAR_LIMIT); }
+
+	void set_angular_limit_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_ANGULAR_LIMIT, p_enabled); }
+
+	bool get_angular_motor_x_enabled() const { return get_flag_x(FLAG_ENABLE_ANGULAR_MOTOR); }
+
+	void set_angular_motor_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_ANGULAR_MOTOR, p_enabled); }
+
+	bool get_angular_motor_y_enabled() const { return get_flag_y(FLAG_ENABLE_ANGULAR_MOTOR); }
+
+	void set_angular_motor_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_ANGULAR_MOTOR, p_enabled); }
+
+	bool get_angular_motor_z_enabled() const { return get_flag_z(FLAG_ENABLE_ANGULAR_MOTOR); }
+
+	void set_angular_motor_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_ANGULAR_MOTOR, p_enabled); }
+
+	bool get_angular_spring_x_enabled() const { return get_flag_x(FLAG_ENABLE_ANGULAR_SPRING); }
+
+	void set_angular_spring_x_enabled(bool p_enabled) { return set_flag_x(FLAG_ENABLE_ANGULAR_SPRING, p_enabled); }
+
+	bool get_angular_spring_y_enabled() const { return get_flag_y(FLAG_ENABLE_ANGULAR_SPRING); }
+
+	void set_angular_spring_y_enabled(bool p_enabled) { return set_flag_y(FLAG_ENABLE_ANGULAR_SPRING, p_enabled); }
+
+	bool get_angular_spring_z_enabled() const { return get_flag_z(FLAG_ENABLE_ANGULAR_SPRING); }
+
+	void set_angular_spring_z_enabled(bool p_enabled) { return set_flag_z(FLAG_ENABLE_ANGULAR_SPRING, p_enabled); }
+
+	// clang-format on
+
+	float get_applied_force() const;
+
+	float get_applied_torque() const;
+
+private:
+	void _configure(PhysicsBody3D* p_body_a, PhysicsBody3D* p_body_b) override;
+
+	const double* _get_param_ptr(Axis p_axis, Param p_param) const;
+
+	double* _get_param_ptr(Axis p_axis, Param p_param);
+
+	const bool* _get_flag_ptr(Axis p_axis, Flag p_flag) const;
+
+	bool* _get_flag_ptr(Axis p_axis, Flag p_flag);
+
+	void _update_param(Axis p_axis, Param p_param, double p_value);
+
+	void _update_param(Axis p_axis, Param p_param);
+
+	void _update_jolt_param(Axis p_axis, Param p_param, double p_value);
+
+	void _update_jolt_param(Axis p_axis, Param p_param);
+
+	void _update_flag(Axis p_axis, Flag p_flag, bool p_enabled);
+
+	void _update_flag(Axis p_axis, Flag p_flag);
+
+	void _update_jolt_flag(Axis p_axis, Flag p_flag, bool p_enabled);
+
+	void _update_jolt_flag(Axis p_axis, Flag p_flag);
+
+	void _param_changed(Axis p_axis, Param p_param);
+
+	void _flag_changed(Axis p_axis, Flag p_flag);
+
+	double linear_limit_upper[AXIS_COUNT] = {};
+
+	double linear_limit_lower[AXIS_COUNT] = {};
+
+	double linear_limit_spring_frequency[AXIS_COUNT] = {};
+
+	double linear_limit_spring_damping[AXIS_COUNT] = {};
+
+	double linear_motor_target_velocity[AXIS_COUNT] = {};
+
+	double linear_motor_max_force[AXIS_COUNT] = {};
+
+	double linear_spring_frequency[AXIS_COUNT] = {};
+
+	double linear_spring_damping[AXIS_COUNT] = {};
+
+	double linear_spring_equilibrium_point[AXIS_COUNT] = {};
+
+	double angular_limit_upper[AXIS_COUNT] = {};
+
+	double angular_limit_lower[AXIS_COUNT] = {};
+
+	double angular_motor_target_velocity[AXIS_COUNT] = {};
+
+	double angular_motor_max_torque[AXIS_COUNT] = {};
+
+	double angular_spring_frequency[AXIS_COUNT] = {};
+
+	double angular_spring_damping[AXIS_COUNT] = {};
+
+	double angular_spring_equilibrium_point[AXIS_COUNT] = {};
+
+	bool linear_limit_enabled[AXIS_COUNT] = {};
+
+	bool linear_limit_spring_enabled[AXIS_COUNT] = {};
+
+	bool linear_motor_enabled[AXIS_COUNT] = {};
+
+	bool linear_spring_enabled[AXIS_COUNT] = {};
+
+	bool angular_limit_enabled[AXIS_COUNT] = {};
+
+	bool angular_motor_enabled[AXIS_COUNT] = {};
+
+	bool angular_spring_enabled[AXIS_COUNT] = {};
+};
+
+VARIANT_ENUM_CAST(JoltGeneric6DOFJoint3D::Param);
+VARIANT_ENUM_CAST(JoltGeneric6DOFJoint3D::Flag);

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -29,10 +29,7 @@ JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	rebuild(p_lock);
 }
 
-double JoltGeneric6DOFJointImpl3D::get_param(
-	Vector3::Axis p_axis,
-	PhysicsServer3D::G6DOFJointAxisParam p_param
-) const {
+double JoltGeneric6DOFJointImpl3D::get_param(Axis p_axis, Param p_param) const {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
@@ -58,13 +55,13 @@ double JoltGeneric6DOFJointImpl3D::get_param(
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_MOTOR_FORCE_LIMIT: {
 			return motor_limit[axis_lin];
 		}
-		case 7: /* G6DOF_JOINT_LINEAR_SPRING_STIFFNESS */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_STIFFNESS: {
 			return spring_stiffness[axis_lin];
 		}
-		case 8: /* G6DOF_JOINT_LINEAR_SPRING_DAMPING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_DAMPING: {
 			return spring_damping[axis_lin];
 		}
-		case 9: /* G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT: {
 			return spring_equilibrium[axis_lin];
 		}
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT: {
@@ -94,24 +91,24 @@ double JoltGeneric6DOFJointImpl3D::get_param(
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_MOTOR_FORCE_LIMIT: {
 			return motor_limit[axis_ang];
 		}
-		case 19: /* G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS: {
 			return spring_stiffness[axis_ang];
 		}
-		case 20: /* G6DOF_JOINT_ANGULAR_SPRING_DAMPING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_DAMPING: {
 			return spring_damping[axis_ang];
 		}
-		case 21: /* G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT: {
 			return spring_equilibrium[axis_ang];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled 6DOF joint parameter: '%d'", p_param));
+			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
 		}
 	}
 }
 
 void JoltGeneric6DOFJointImpl3D::set_param(
-	Vector3::Axis p_axis,
-	PhysicsServer3D::G6DOFJointAxisParam p_param,
+	Axis p_axis,
+	Param p_param,
 	double p_value,
 	bool p_lock
 ) {
@@ -165,15 +162,15 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 			motor_limit[axis_lin] = p_value;
 			_motor_limit_changed(axis_lin);
 		} break;
-		case 7: /* G6DOF_JOINT_LINEAR_SPRING_STIFFNESS */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_STIFFNESS: {
 			spring_stiffness[axis_lin] = p_value;
-			_spring_stiffness_changed(axis_lin);
+			_spring_parameters_changed(axis_lin);
 		} break;
-		case 8: /* G6DOF_JOINT_LINEAR_SPRING_DAMPING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_DAMPING: {
 			spring_damping[axis_lin] = p_value;
-			_spring_damping_changed(axis_lin);
+			_spring_parameters_changed(axis_lin);
 		} break;
-		case 9: /* G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT: {
 			spring_equilibrium[axis_lin] = p_value;
 			_spring_equilibrium_changed(axis_lin);
 		} break;
@@ -243,42 +240,39 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 			motor_limit[axis_ang] = p_value;
 			_motor_limit_changed(axis_ang);
 		} break;
-		case 19: /* G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS: {
 			spring_stiffness[axis_ang] = p_value;
-			_spring_stiffness_changed(axis_ang);
+			_spring_parameters_changed(axis_ang);
 		} break;
-		case 20: /* G6DOF_JOINT_ANGULAR_SPRING_DAMPING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_DAMPING: {
 			spring_damping[axis_ang] = p_value;
-			_spring_damping_changed(axis_ang);
+			_spring_parameters_changed(axis_ang);
 		} break;
-		case 21: /* G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT: {
 			spring_equilibrium[axis_ang] = p_value;
 			_spring_equilibrium_changed(axis_ang);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled 6DOF joint parameter: '%d'", p_param));
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
 		} break;
 	}
 }
 
-bool JoltGeneric6DOFJointImpl3D::get_flag(
-	Vector3::Axis p_axis,
-	PhysicsServer3D::G6DOFJointAxisFlag p_flag
-) const {
+bool JoltGeneric6DOFJointImpl3D::get_flag(Axis p_axis, Flag p_flag) const {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
 	switch ((int32_t)p_flag) {
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT: {
-			return use_limits[axis_lin];
+			return limit_enabled[axis_lin];
 		}
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT: {
-			return use_limits[axis_ang];
+			return limit_enabled[axis_ang];
 		}
-		case 2: /* G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING: {
 			return spring_enabled[axis_ang];
 		}
-		case 3: /* G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING: {
 			return spring_enabled[axis_lin];
 		}
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_MOTOR: {
@@ -288,34 +282,29 @@ bool JoltGeneric6DOFJointImpl3D::get_flag(
 			return motor_enabled[axis_lin];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled 6DOF joint flag: '%d'", p_flag));
+			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
 		}
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::set_flag(
-	Vector3::Axis p_axis,
-	PhysicsServer3D::G6DOFJointAxisFlag p_flag,
-	bool p_enabled,
-	bool p_lock
-) {
+void JoltGeneric6DOFJointImpl3D::set_flag(Axis p_axis, Flag p_flag, bool p_enabled, bool p_lock) {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
 	switch ((int32_t)p_flag) {
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT: {
-			use_limits[axis_lin] = p_enabled;
+			limit_enabled[axis_lin] = p_enabled;
 			_limits_changed(p_lock);
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT: {
-			use_limits[axis_ang] = p_enabled;
+			limit_enabled[axis_ang] = p_enabled;
 			_limits_changed(p_lock);
 		} break;
-		case 2: /* G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING: {
 			spring_enabled[axis_ang] = p_enabled;
 			_spring_state_changed(axis_ang);
 		} break;
-		case 3: /* G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING */ {
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING: {
 			spring_enabled[axis_lin] = p_enabled;
 			_spring_state_changed(axis_lin);
 		} break;
@@ -328,9 +317,138 @@ void JoltGeneric6DOFJointImpl3D::set_flag(
 			_motor_state_changed(axis_lin);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled 6DOF joint flag: '%d'", p_flag));
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
 		} break;
 	}
+}
+
+double JoltGeneric6DOFJointImpl3D::get_jolt_param(Axis p_axis, JoltParam p_param) const {
+	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
+	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
+
+	switch ((int32_t)p_param) {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_FREQUENCY: {
+			return spring_frequency[axis_lin];
+		}
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SPRING_FREQUENCY: {
+			return limit_spring_frequency[axis_lin];
+		}
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SPRING_DAMPING: {
+			return limit_spring_damping[axis_lin];
+		}
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_FREQUENCY: {
+			return spring_frequency[axis_ang];
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		}
+	}
+}
+
+void JoltGeneric6DOFJointImpl3D::set_jolt_param(
+	Axis p_axis,
+	JoltParam p_param,
+	double p_value,
+	[[maybe_unused]] bool p_lock
+) {
+	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
+	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
+
+	switch ((int32_t)p_param) {
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_FREQUENCY: {
+			spring_frequency[axis_lin] = p_value;
+			_spring_parameters_changed(axis_lin);
+		} break;
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SPRING_FREQUENCY: {
+			limit_spring_frequency[axis_lin] = p_value;
+			_limit_spring_parameters_changed(axis_lin);
+		} break;
+		case JoltPhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SPRING_DAMPING: {
+			limit_spring_damping[axis_lin] = p_value;
+			_limit_spring_parameters_changed(axis_lin);
+		} break;
+		case JoltPhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_FREQUENCY: {
+			spring_frequency[axis_ang] = p_value;
+			_spring_parameters_changed(axis_ang);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+		} break;
+	}
+}
+
+bool JoltGeneric6DOFJointImpl3D::get_jolt_flag(Axis p_axis, JoltFlag p_flag) const {
+	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
+	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
+
+	switch ((int32_t)p_flag) {
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT_SPRING: {
+			return limit_spring_enabled[axis_lin];
+		}
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING_FREQUENCY: {
+			return spring_use_frequency[axis_lin];
+		}
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY: {
+			return spring_use_frequency[axis_ang];
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		}
+	}
+}
+
+void JoltGeneric6DOFJointImpl3D::set_jolt_flag(
+	Axis p_axis,
+	JoltFlag p_flag,
+	bool p_enabled,
+	[[maybe_unused]] bool p_lock
+) {
+	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
+	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
+
+	switch ((int32_t)p_flag) {
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT_SPRING: {
+			limit_spring_enabled[axis_lin] = p_enabled;
+			_limit_spring_parameters_changed(axis_lin);
+		} break;
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING_FREQUENCY: {
+			spring_use_frequency[axis_lin] = p_enabled;
+			_spring_parameters_changed(axis_lin);
+		} break;
+		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY: {
+			spring_use_frequency[axis_ang] = p_enabled;
+			_spring_parameters_changed(axis_ang);
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+		} break;
+	}
+}
+
+float JoltGeneric6DOFJointImpl3D::get_applied_force() const {
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_D(constraint);
+
+	JoltSpace3D* space = get_space();
+	ERR_FAIL_NULL_D(space);
+
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
+	return constraint->GetTotalLambdaPosition().Length() / last_step;
+}
+
+float JoltGeneric6DOFJointImpl3D::get_applied_torque() const {
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	ERR_FAIL_NULL_D(constraint);
+
+	JoltSpace3D* space = get_space();
+	ERR_FAIL_NULL_D(space);
+
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND_D(last_step == 0.0f);
+
+	return constraint->GetTotalLambdaRotation().Length() / last_step;
 }
 
 void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
@@ -357,7 +475,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	float ref_shift[AXIS_COUNT] = {};
 
 	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
-		if (!use_limits[axis]) {
+		if (!limit_enabled[axis]) {
 			constraint_settings.MakeFreeAxis((JoltAxis)axis);
 			continue;
 		}
@@ -406,10 +524,6 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	constraint_settings.mAxisX2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
 
-	for (JPH::MotorSettings& motor_settings : constraint_settings.mMotorSettings) {
-		motor_settings.mSpringSettings.mMode = JPH::ESpringMode::StiffnessAndDamping;
-	}
-
 	if (body_b != nullptr) {
 		const JoltWritableBody3D jolt_body_a = bodies[0];
 		ERR_FAIL_COND(jolt_body_a.is_invalid());
@@ -430,14 +544,36 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 	_update_enabled();
 	_update_iterations();
 
+	_update_limit_spring_parameters(AXIS_LINEAR_X);
+	_update_limit_spring_parameters(AXIS_LINEAR_Y);
+	_update_limit_spring_parameters(AXIS_LINEAR_Z);
+
 	for (int32_t axis = 0; axis < AXIS_COUNT; ++axis) {
 		_update_motor_state(axis);
 		_update_motor_velocity(axis);
 		_update_motor_limit(axis);
-		_update_spring_stiffness(axis);
-		_update_spring_damping(axis);
+		_update_spring_parameters(axis);
 		_update_spring_equilibrium(axis);
 	}
+}
+
+void JoltGeneric6DOFJointImpl3D::_update_limit_spring_parameters(int32_t p_axis) {
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	QUIET_FAIL_NULL(constraint);
+
+	JPH::SpringSettings settings = constraint->GetLimitsSpringSettings((JoltAxis)p_axis);
+
+	settings.mMode = JPH::ESpringMode::FrequencyAndDamping;
+
+	if (limit_spring_enabled[p_axis]) {
+		settings.mFrequency = (float)limit_spring_frequency[p_axis];
+		settings.mDamping = (float)limit_spring_damping[p_axis];
+	} else {
+		settings.mFrequency = 0.0f;
+		settings.mDamping = 0.0f;
+	}
+
+	constraint->SetLimitsSpringSettings((JoltAxis)p_axis, settings);
 }
 
 void JoltGeneric6DOFJointImpl3D::_update_motor_state(int32_t p_axis) {
@@ -453,84 +589,94 @@ void JoltGeneric6DOFJointImpl3D::_update_motor_state(int32_t p_axis) {
 }
 
 void JoltGeneric6DOFJointImpl3D::_update_motor_velocity(int32_t p_axis) {
-	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
-		if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
-			constraint->SetTargetVelocityCS(
-				{(float)motor_speed[AXIS_LINEAR_X],
-				 (float)motor_speed[AXIS_LINEAR_Y],
-				 (float)motor_speed[AXIS_LINEAR_Z]}
-			);
-		} else {
-			// HACK(mihe): We're forced to flip the direction of these to match Godot Physics. This
-			// means that the velocity direction is inconsistent with the velocity direction for
-			// things like hinge joints.
-			constraint->SetTargetAngularVelocityCS(
-				{(float)-motor_speed[AXIS_ANGULAR_X],
-				 (float)-motor_speed[AXIS_ANGULAR_Y],
-				 (float)-motor_speed[AXIS_ANGULAR_Z]}
-			);
-		}
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	QUIET_FAIL_NULL(constraint);
+
+	if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
+		constraint->SetTargetVelocityCS(
+			{(float)motor_speed[AXIS_LINEAR_X],
+			 (float)motor_speed[AXIS_LINEAR_Y],
+			 (float)motor_speed[AXIS_LINEAR_Z]}
+		);
+	} else {
+		// HACK(mihe): We're forced to flip the direction of these to match Godot Physics. This
+		// means that the velocity direction is inconsistent with the velocity direction for
+		// things like hinge joints.
+		constraint->SetTargetAngularVelocityCS(
+			{(float)-motor_speed[AXIS_ANGULAR_X],
+			 (float)-motor_speed[AXIS_ANGULAR_Y],
+			 (float)-motor_speed[AXIS_ANGULAR_Z]}
+		);
 	}
 }
 
 void JoltGeneric6DOFJointImpl3D::_update_motor_limit(int32_t p_axis) {
-	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
-		JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	QUIET_FAIL_NULL(constraint);
 
-		// HACK(mihe): We only apply the motor limit if we're actually using a velocity motor, since
-		// it would otherwise affect a position motor as well, which doesn't seem to be how this is
-		// applied in the Bullet implementation in Godot 3.
-		const auto limit = motor_enabled[p_axis] ? (float)motor_limit[p_axis] : FLT_MAX;
+	JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
 
-		if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
-			motor_settings.SetForceLimit(limit);
-		} else {
-			motor_settings.SetTorqueLimit(limit);
-		}
+	// HACK(mihe): We only apply the motor limit if we're actually using a velocity motor, since
+	// it would otherwise affect a position motor as well, which doesn't seem to be how this is
+	// applied in the Bullet implementation in Godot 3.
+	const auto limit = motor_enabled[p_axis] ? (float)motor_limit[p_axis] : FLT_MAX;
+
+	if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
+		motor_settings.SetForceLimit(limit);
+	} else {
+		motor_settings.SetTorqueLimit(limit);
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::_update_spring_stiffness(int32_t p_axis) {
-	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
-		JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
+void JoltGeneric6DOFJointImpl3D::_update_spring_parameters(int32_t p_axis) {
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	QUIET_FAIL_NULL(constraint);
+
+	JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
+
+	if (spring_use_frequency[p_axis]) {
+		motor_settings.mSpringSettings.mMode = JPH::ESpringMode::FrequencyAndDamping;
+		motor_settings.mSpringSettings.mFrequency = (float)spring_frequency[p_axis];
+	} else {
+		motor_settings.mSpringSettings.mMode = JPH::ESpringMode::StiffnessAndDamping;
 		motor_settings.mSpringSettings.mStiffness = (float)spring_stiffness[p_axis];
 	}
-}
 
-void JoltGeneric6DOFJointImpl3D::_update_spring_damping(int32_t p_axis) {
-	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
-		JPH::MotorSettings& motor_settings = constraint->GetMotorSettings((JoltAxis)p_axis);
-		motor_settings.mSpringSettings.mDamping = (float)spring_damping[p_axis];
-	}
+	motor_settings.mSpringSettings.mDamping = (float)spring_damping[p_axis];
 }
 
 void JoltGeneric6DOFJointImpl3D::_update_spring_equilibrium(int32_t p_axis) {
-	if (auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr())) {
-		if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
-			const Vector3 target_position = Vector3(
-				(float)-spring_equilibrium[AXIS_LINEAR_X],
-				(float)-spring_equilibrium[AXIS_LINEAR_Y],
-				(float)-spring_equilibrium[AXIS_LINEAR_Z]
-			);
+	auto* constraint = static_cast<JPH::SixDOFConstraint*>(jolt_ref.GetPtr());
+	QUIET_FAIL_NULL(constraint);
 
-			constraint->SetTargetPositionCS(to_jolt(target_position));
-		} else {
-			// HACK(mihe): These are flipped to match Bullet in Godot 3, presumably for the same
-			// reason that the angular motor velocity needs to be flipped. Godot 4 does not
-			// currently have springs implemented, so can't be used as a reference.
-			const Basis target_orientation = Basis::from_euler(
-				{(float)spring_equilibrium[AXIS_ANGULAR_X],
-				 (float)spring_equilibrium[AXIS_ANGULAR_Y],
-				 (float)spring_equilibrium[AXIS_ANGULAR_Z]}
-			);
+	if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
+		const Vector3 target_position = Vector3(
+			(float)-spring_equilibrium[AXIS_LINEAR_X],
+			(float)-spring_equilibrium[AXIS_LINEAR_Y],
+			(float)-spring_equilibrium[AXIS_LINEAR_Z]
+		);
 
-			constraint->SetTargetOrientationCS(to_jolt(target_orientation));
-		}
+		constraint->SetTargetPositionCS(to_jolt(target_position));
+	} else {
+		// HACK(mihe): These are flipped to match Bullet in Godot 3, presumably for the same
+		// reason that the angular motor velocity needs to be flipped. Godot 4 does not
+		// currently have springs implemented, so can't be used as a reference.
+		const Basis target_orientation = Basis::from_euler(
+			{(float)spring_equilibrium[AXIS_ANGULAR_X],
+			 (float)spring_equilibrium[AXIS_ANGULAR_Y],
+			 (float)spring_equilibrium[AXIS_ANGULAR_Z]}
+		);
+
+		constraint->SetTargetOrientationCS(to_jolt(target_orientation));
 	}
 }
 
 void JoltGeneric6DOFJointImpl3D::_limits_changed(bool p_lock) {
 	rebuild(p_lock);
+}
+
+void JoltGeneric6DOFJointImpl3D::_limit_spring_parameters_changed(int32_t p_axis) {
+	_update_limit_spring_parameters(p_axis);
 }
 
 void JoltGeneric6DOFJointImpl3D::_motor_state_changed(int32_t p_axis) {
@@ -550,12 +696,8 @@ void JoltGeneric6DOFJointImpl3D::_spring_state_changed(int32_t p_axis) {
 	_update_motor_state(p_axis);
 }
 
-void JoltGeneric6DOFJointImpl3D::_spring_stiffness_changed(int32_t p_axis) {
-	_update_spring_stiffness(p_axis);
-}
-
-void JoltGeneric6DOFJointImpl3D::_spring_damping_changed(int32_t p_axis) {
-	_update_spring_damping(p_axis);
+void JoltGeneric6DOFJointImpl3D::_spring_parameters_changed(int32_t p_axis) {
+	_update_spring_parameters(p_axis);
 }
 
 void JoltGeneric6DOFJointImpl3D::_spring_equilibrium_changed(int32_t p_axis) {

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -1,11 +1,22 @@
 #pragma once
 
 #include "joints/jolt_joint_impl_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
 
 class JoltGeneric6DOFJointImpl3D final : public JoltJointImpl3D {
+	using Axis = Vector3::Axis;
+
 	using JoltAxis = JPH::SixDOFConstraintSettings::EAxis;
 
-	enum Axis {
+	using Param = PhysicsServer3D::G6DOFJointAxisParam;
+
+	using JoltParam = JoltPhysicsServer3D::G6DOFJointAxisParamJolt;
+
+	using Flag = PhysicsServer3D::G6DOFJointAxisFlag;
+
+	using JoltFlag = JoltPhysicsServer3D::G6DOFJointAxisFlagJolt;
+
+	enum {
 		AXIS_LINEAR_X = JoltAxis::TranslationX,
 		AXIS_LINEAR_Y = JoltAxis::TranslationY,
 		AXIS_LINEAR_Z = JoltAxis::TranslationZ,
@@ -31,40 +42,44 @@ public:
 		return PhysicsServer3D::JOINT_TYPE_6DOF;
 	}
 
-	double get_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param) const;
+	double get_param(Axis p_axis, Param p_param) const;
 
-	void set_param(
-		Vector3::Axis p_axis,
-		PhysicsServer3D::G6DOFJointAxisParam p_param,
-		double p_value,
-		bool p_lock = true
-	);
+	void set_param(Axis p_axis, Param p_param, double p_value, bool p_lock = true);
 
-	bool get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const;
+	bool get_flag(Axis p_axis, Flag p_flag) const;
 
-	void set_flag(
-		Vector3::Axis p_axis,
-		PhysicsServer3D::G6DOFJointAxisFlag p_flag,
-		bool p_enabled,
-		bool p_lock = true
-	);
+	void set_flag(Axis p_axis, Flag p_flag, bool p_enabled, bool p_lock = true);
+
+	double get_jolt_param(Axis p_axis, JoltParam p_param) const;
+
+	void set_jolt_param(Axis p_axis, JoltParam p_param, double p_value, bool p_lock = true);
+
+	bool get_jolt_flag(Axis p_axis, JoltFlag p_flag) const;
+
+	void set_jolt_flag(Axis p_axis, JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+
+	float get_applied_force() const;
+
+	float get_applied_torque() const;
 
 	void rebuild(bool p_lock = true) override;
 
 private:
+	void _update_limit_spring_parameters(int32_t p_axis);
+
 	void _update_motor_state(int32_t p_axis);
 
 	void _update_motor_velocity(int32_t p_axis);
 
 	void _update_motor_limit(int32_t p_axis);
 
-	void _update_spring_stiffness(int32_t p_axis);
-
-	void _update_spring_damping(int32_t p_axis);
+	void _update_spring_parameters(int32_t p_axis);
 
 	void _update_spring_equilibrium(int32_t p_axis);
 
 	void _limits_changed(bool p_lock = true);
+
+	void _limit_spring_parameters_changed(int32_t p_axis);
 
 	void _motor_state_changed(int32_t p_axis);
 
@@ -74,9 +89,7 @@ private:
 
 	void _spring_state_changed(int32_t p_axis);
 
-	void _spring_stiffness_changed(int32_t p_axis);
-
-	void _spring_damping_changed(int32_t p_axis);
+	void _spring_parameters_changed(int32_t p_axis);
 
 	void _spring_equilibrium_changed(int32_t p_axis);
 
@@ -84,19 +97,29 @@ private:
 
 	double limit_upper[AXIS_COUNT] = {};
 
+	double limit_spring_frequency[AXIS_COUNT] = {};
+
+	double limit_spring_damping[AXIS_COUNT] = {};
+
 	double motor_speed[AXIS_COUNT] = {};
 
 	double motor_limit[AXIS_COUNT] = {};
 
 	double spring_stiffness[AXIS_COUNT] = {};
 
+	double spring_frequency[AXIS_COUNT] = {};
+
 	double spring_damping[AXIS_COUNT] = {};
 
 	double spring_equilibrium[AXIS_COUNT] = {};
 
-	bool use_limits[AXIS_COUNT] = {};
+	bool limit_enabled[AXIS_COUNT] = {};
+
+	bool limit_spring_enabled[AXIS_COUNT] = {};
 
 	bool motor_enabled[AXIS_COUNT] = {};
 
 	bool spring_enabled[AXIS_COUNT] = {};
+
+	bool spring_use_frequency[AXIS_COUNT] = {};
 };

--- a/src/misc/bind_macros.hpp
+++ b/src/misc/bind_macros.hpp
@@ -45,3 +45,32 @@
 
 #define BIND_PROPERTY(...) \
 	BIND_PROPERTY_SELECT(__VA_ARGS__, BIND_PROPERTY_1, BIND_PROPERTY_0)(__VA_ARGS__)
+
+// HACK(mihe): Ideally we would use `ADD_SUBGROUP` instead of this `BIND_SUBPROPERTY` stuff, but
+// there's a bug in `DocTools::generate` where you'll sometimes get errors about some empty class
+// name when you have multiple sub-groups of the same name.
+
+#define BIND_SUBPROPERTY_HINTED(m_prefix, m_name, m_type, m_hint, m_hint_str) \
+	ClassDB::add_property(                                                    \
+		get_class_static(),                                                   \
+		PropertyInfo(m_type, m_prefix "/" m_name, m_hint, m_hint_str),        \
+		"set_" m_prefix "_" m_name,                                           \
+		"get_" m_prefix "_" m_name                                            \
+	)
+
+#define BIND_SUBPROPERTY_RANGED(m_prefix, m_name, m_type, m_hint_str) \
+	BIND_SUBPROPERTY_HINTED(m_prefix, m_name, m_type, PROPERTY_HINT_RANGE, m_hint_str)
+
+#define BIND_SUBPROPERTY_ENUM(m_prefix, m_name, m_hint_str) \
+	BIND_SUBPROPERTY_HINTED(m_prefix, m_name, Variant::INT, PROPERTY_HINT_ENUM, m_hint_str)
+
+#define BIND_SUBPROPERTY_0(m_prefix, m_name, m_type) \
+	BIND_SUBPROPERTY_HINTED(m_prefix, m_name, m_type, PROPERTY_HINT_NONE, "")
+
+#define BIND_SUBPROPERTY_1(m_prefix, m_name, m_type, m_hint_str) \
+	BIND_SUBPROPERTY_HINTED(m_prefix, m_name, m_type, PROPERTY_HINT_NONE, m_hint_str)
+
+#define BIND_SUBPROPERTY_SELECT(_1, _2, _3, _4, m_macro, ...) m_macro
+
+#define BIND_SUBPROPERTY(...) \
+	BIND_SUBPROPERTY_SELECT(__VA_ARGS__, BIND_SUBPROPERTY_1, BIND_SUBPROPERTY_0)(__VA_ARGS__)

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,4 +1,5 @@
 #include "joints/jolt_cone_twist_joint_3d.hpp"
+#include "joints/jolt_generic_6dof_joint.hpp"
 #include "joints/jolt_hinge_joint_3d.hpp"
 #include "joints/jolt_joint_gizmo_plugin_3d.hpp"
 #include "joints/jolt_pin_joint_3d.hpp"
@@ -46,6 +47,7 @@ void on_initialize(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<JoltHingeJoint3D>();
 			ClassDB::register_class<JoltSliderJoint3D>();
 			ClassDB::register_class<JoltConeTwistJoint3D>();
+			ClassDB::register_class<JoltGeneric6DOFJoint3D>();
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 #ifdef GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -61,6 +61,15 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_METHOD(JoltPhysicsServer3D, cone_twist_joint_get_applied_force, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, cone_twist_joint_get_applied_torque, "joint");
 
+	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_jolt_param, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_set_jolt_param, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_jolt_flag, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_set_jolt_flag, "joint", "value");
+
+	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_applied_force, "joint");
+	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_applied_torque, "joint");
+
 	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_FREQUENCY);
 	BIND_ENUM_CONSTANT(HINGE_JOINT_LIMIT_SPRING_DAMPING);
 	BIND_ENUM_CONSTANT(HINGE_JOINT_MOTOR_MAX_TORQUE);
@@ -86,6 +95,25 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONE_TWIST_JOINT_FLAG_USE_TWIST_LIMIT);
 	BIND_ENUM_CONSTANT(CONE_TWIST_JOINT_FLAG_ENABLE_SWING_MOTOR);
 	BIND_ENUM_CONSTANT(CONE_TWIST_JOINT_FLAG_ENABLE_TWIST_MOTOR);
+
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_LINEAR_SPRING_STIFFNESS);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_LINEAR_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_ANGULAR_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT);
+
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_LINEAR_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_LINEAR_LIMIT_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_LINEAR_LIMIT_SPRING_DAMPING);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_ANGULAR_SPRING_FREQUENCY);
+
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING);
+
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT_SPRING);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING_FREQUENCY);
+	BIND_ENUM_CONSTANT(G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY);
 }
 
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
@@ -2099,4 +2127,82 @@ float JoltPhysicsServer3D::cone_twist_joint_get_applied_torque(const RID& p_join
 	auto* cone_twist_joint = static_cast<JoltConeTwistJointImpl3D*>(joint);
 
 	return cone_twist_joint->get_applied_torque();
+}
+
+double JoltPhysicsServer3D::generic_6dof_joint_get_jolt_param(
+	const RID& p_joint,
+	Vector3::Axis p_axis,
+	G6DOFJointAxisParamJolt p_param
+) const {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
+
+	return g6dof_joint->get_jolt_param(p_axis, p_param);
+}
+
+void JoltPhysicsServer3D::generic_6dof_joint_set_jolt_param(
+	const RID& p_joint,
+	Vector3::Axis p_axis,
+	G6DOFJointAxisParamJolt p_param,
+	double p_value
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
+
+	return g6dof_joint->set_jolt_param(p_axis, p_param, p_value);
+}
+
+bool JoltPhysicsServer3D::generic_6dof_joint_get_jolt_flag(
+	const RID& p_joint,
+	Vector3::Axis p_axis,
+	G6DOFJointAxisFlagJolt p_flag
+) const {
+	const JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
+	const auto* g6dof_joint = static_cast<const JoltGeneric6DOFJointImpl3D*>(joint);
+
+	return g6dof_joint->get_jolt_flag(p_axis, p_flag);
+}
+
+void JoltPhysicsServer3D::generic_6dof_joint_set_jolt_flag(
+	const RID& p_joint,
+	Vector3::Axis p_axis,
+	G6DOFJointAxisFlagJolt p_flag,
+	bool p_enabled
+) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
+
+	return g6dof_joint->set_jolt_flag(p_axis, p_flag, p_enabled);
+}
+
+float JoltPhysicsServer3D::generic_6dof_joint_get_applied_force(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
+
+	return g6dof_joint->get_applied_force();
+}
+
+float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(const RID& p_joint) {
+	JoltJointImpl3D* joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_D(joint);
+
+	ERR_FAIL_COND_D(joint->get_type() != JOINT_TYPE_6DOF);
+	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
+
+	return g6dof_joint->get_applied_torque();
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -49,6 +49,33 @@ public:
 		CONE_TWIST_JOINT_FLAG_ENABLE_TWIST_MOTOR
 	};
 
+	enum G6DOFJointAxisParamJolt {
+		G6DOF_JOINT_LINEAR_SPRING_STIFFNESS = 7,
+		G6DOF_JOINT_LINEAR_SPRING_DAMPING = 8,
+		G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT = 9,
+		G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS = 19,
+		G6DOF_JOINT_ANGULAR_SPRING_DAMPING = 20,
+		G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT = 21,
+
+		// HACK(mihe): Any parameters before this point are ones that were missing from the bindings
+
+		G6DOF_JOINT_LINEAR_SPRING_FREQUENCY = 100,
+		G6DOF_JOINT_LINEAR_LIMIT_SPRING_FREQUENCY,
+		G6DOF_JOINT_LINEAR_LIMIT_SPRING_DAMPING,
+		G6DOF_JOINT_ANGULAR_SPRING_FREQUENCY
+	};
+
+	enum G6DOFJointAxisFlagJolt {
+		G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING = 2,
+		G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING = 3,
+
+		// HACK(mihe): Any flags before this point are ones that were missing from the bindings
+
+		G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT_SPRING = 100,
+		G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING_FREQUENCY,
+		G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY,
+	};
+
 private:
 	static void _bind_methods();
 
@@ -673,6 +700,36 @@ public:
 
 	float cone_twist_joint_get_applied_torque(const RID& p_joint);
 
+	double generic_6dof_joint_get_jolt_param(
+		const RID& p_joint,
+		Vector3::Axis p_axis,
+		G6DOFJointAxisParamJolt p_param
+	) const;
+
+	void generic_6dof_joint_set_jolt_param(
+		const RID& p_joint,
+		Vector3::Axis p_axis,
+		G6DOFJointAxisParamJolt p_param,
+		double p_value
+	);
+
+	bool generic_6dof_joint_get_jolt_flag(
+		const RID& p_joint,
+		Vector3::Axis p_axis,
+		G6DOFJointAxisFlagJolt p_flag
+	) const;
+
+	void generic_6dof_joint_set_jolt_flag(
+		const RID& p_joint,
+		Vector3::Axis p_axis,
+		G6DOFJointAxisFlagJolt p_flag,
+		bool p_enabled
+	);
+
+	float generic_6dof_joint_get_applied_force(const RID& p_joint);
+
+	float generic_6dof_joint_get_applied_torque(const RID& p_joint);
+
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 
@@ -699,3 +756,5 @@ VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointParamJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointFlagJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointParamJolt);
 VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointFlagJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::G6DOFJointAxisParamJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::G6DOFJointAxisFlagJolt);


### PR DESCRIPTION
Fixes #350.

This adds a substitute node for `Generic6DOFJoint3D`, called `JoltGeneric6DOFJoint3D`, that mostly matches the `Generic6DOFJoint3D` interface, with the following differences:

- You can enable/disable the joint, using its `enabled` property
- You can fetch its last applied force/torque, using `get_applied_force()` and `get_applied_torque()`
- You can override the solver velocity/position iterations for the joint
- You configure soft limits using a limit spring, instead of softness, restitution, damping and ERP
- You configure springs using frequency/damping instead of stiffness/damping
- The "force limits" are referred to as "max force" and "max torque", for consistency across joints

The first and second point together allow for creating breakable joints.

There are also a couple of other Jolt-specific features that can/will be added to this later, like axis friction, but I'm mostly concerned with getting feature-parity with `Generic6DOFJoint3D` right now.

Note that this PR doesn't include the proper editor gizmo for this joint, and instead it uses the same gizmo as `PinJoint3D`. I'll sort that out later.