### PR TITLE
Fixed joints emitting warnings when restructuring its bodies

### DIFF
--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -61,9 +61,8 @@ JoltJoint3D::~JoltJoint3D() {
 }
 
 void JoltJoint3D::set_node_a(const NodePath& p_path) {
-	if (node_a == p_path) {
-		return;
-	}
+	// NOTE(mihe): We can't do a dirty check on the node path here, because when renaming nodes it
+	// ends up calling the setter twice, and the node path won't be valid the first time around.
 
 	_nodes_changing();
 	node_a = p_path;
@@ -71,9 +70,8 @@ void JoltJoint3D::set_node_a(const NodePath& p_path) {
 }
 
 void JoltJoint3D::set_node_b(const NodePath& p_path) {
-	if (node_b == p_path) {
-		return;
-	}
+	// NOTE(mihe): We can't do a dirty check on the node path here, because when renaming nodes it
+	// ends up calling the setter twice, and the node path won't be valid the first time around.
 
 	_nodes_changing();
 	node_b = p_path;


### PR DESCRIPTION
When using one of the new substitute joints and altering the node structure of either of the two bodies it refers to, either by renaming or reparenting the bodies, you would sometimes end up with a warning on the joint node along the lines of "Node A must be of type PhysicsBody3D".

This turned out to be a result of the dirty check that was performed in `JoltJoint3D::set_node_a` and `JoltJoint3D::set_node_b`. For whatever reason these setters end up being called twice with the same node path when doing stuff like renaming a body, and only on the second call is the change actually committed and the node path valid.

This PR fixes this problem by simply removing the dirty check in `set_node_a` and `set_node_b`, allowing the joint to be rebuilt even if the node path is the same.