### PR TITLE
Fixed errors when duplicating instanced scene containing joints

### DIFF
--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -219,6 +219,10 @@ void JoltJoint3D::_disconnect_bodies() {
 }
 
 bool JoltJoint3D::_validate() {
+	if (!is_inside_tree()) {
+		return false;
+	}
+
 	PhysicsBody3D* body_a = get_body_a();
 	PhysicsBody3D* body_b = get_body_b();
 


### PR DESCRIPTION
When duplicating an instanced scene containing any of the new substitute joints, a ton of errors would be emitted saying stuff about `!is_inside_tree()` and how its referenced bodies were in different spaces.

This turned out to be because the joints were trying to set themselves up before actually being connected to the scene tree, which doesn't make a whole lot of sense.

This PR fixes this by incorporating `is_inside_tree()` in `JoltJoint3D::_validate`.