### PR TITLE
Updated Jolt to 8f5df4d52c

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT ea83565e6121a9d268932e403c0bf8ae5b688b90
+	GIT_COMMIT 8f5df4d52cf224f2c2fc99a5130625d9d250ec52
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/spaces/jolt_debug_renderer_3d.cpp
+++ b/src/spaces/jolt_debug_renderer_3d.cpp
@@ -164,7 +164,8 @@ void JoltDebugRenderer3D::DrawTriangle(
 	JPH::Vec3 p_vertex1,
 	JPH::Vec3 p_vertex2,
 	JPH::Vec3 p_vertex3,
-	JPH::Color p_color
+	JPH::Color p_color,
+	[[maybe_unused]] ECastShadow p_cast_shadow
 ) {
 	_reserve_triangles(1);
 

--- a/src/spaces/jolt_debug_renderer_3d.hpp
+++ b/src/spaces/jolt_debug_renderer_3d.hpp
@@ -47,7 +47,8 @@ private:
 		JPH::Vec3 p_vertex1,
 		JPH::Vec3 p_vertex2,
 		JPH::Vec3 p_vertex3,
-		JPH::Color p_color
+		JPH::Color p_color,
+		ECastShadow p_cast_shadow
 	) override;
 
 	JPH::DebugRenderer::Batch CreateTriangleBatch(


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@ea83565e6121a9d268932e403c0bf8ae5b688b90 to godot-jolt/jolt@8f5df4d52cf224f2c2fc99a5130625d9d250ec52 (see diff [here](https://github.com/godot-jolt/jolt/compare/ea83565e6121a9d268932e403c0bf8ae5b688b90...8f5df4d52cf224f2c2fc99a5130625d9d250ec52)).

This brings in the following relevant changes:

- The ability to specify solver priority for constraints
- Optimizations
- Bug fixes