### PR TITLE
Updated Jolt to 153291b7c6

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 8f5df4d52cf224f2c2fc99a5130625d9d250ec52
+	GIT_COMMIT 153291b7c6e294d727c707fd0734c038cc2fdce0
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/shapes/jolt_custom_empty_shape.hpp
+++ b/src/shapes/jolt_custom_empty_shape.hpp
@@ -103,6 +103,15 @@ public:
 		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
 	) const override { }
 
+	void CollideSoftBodyVertices(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		[[maybe_unused]] float p_delta_time,
+		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
+		[[maybe_unused]] int p_colliding_shape_index
+	) const override { }
+
 	void GetTrianglesStart(
 		[[maybe_unused]] GetTrianglesContext& p_context,
 		[[maybe_unused]] const JPH::AABox& p_box,

--- a/src/shapes/jolt_custom_motion_shape.hpp
+++ b/src/shapes/jolt_custom_motion_shape.hpp
@@ -147,6 +147,17 @@ public:
 		ERR_FAIL_NOT_IMPL();
 	}
 
+	void CollideSoftBodyVertices(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		[[maybe_unused]] float p_delta_time,
+		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
+		[[maybe_unused]] int p_colliding_shape_index
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
 	void CollectTransformedShapes(
 		[[maybe_unused]] const JPH::AABox& p_box,
 		[[maybe_unused]] JPH::Vec3Arg p_position_com,

--- a/src/shapes/jolt_custom_ray_shape.hpp
+++ b/src/shapes/jolt_custom_ray_shape.hpp
@@ -123,6 +123,17 @@ public:
 		[[maybe_unused]] const JPH::ShapeFilter& p_shape_filter = {}
 	) const override { }
 
+	void CollideSoftBodyVertices(
+		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+		[[maybe_unused]] JPH::Vec3Arg p_scale,
+		[[maybe_unused]] JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		[[maybe_unused]] float p_delta_time,
+		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
+		[[maybe_unused]] int p_colliding_shape_index
+	) const override {
+		ERR_FAIL_NOT_IMPL();
+	}
+
 	JPH::Shape::Stats GetStats() const override { return {sizeof(*this), 0}; }
 
 	float GetVolume() const override { return 0.0f; }

--- a/src/shapes/jolt_custom_user_data_shape.hpp
+++ b/src/shapes/jolt_custom_user_data_shape.hpp
@@ -168,6 +168,24 @@ public:
 		mInnerShape->CollidePoint(p_point, p_sub_shape_id_creator, p_collector, p_shape_filter);
 	}
 
+	void CollideSoftBodyVertices(
+		JPH::Mat44Arg p_center_of_mass_transform,
+		JPH::Vec3Arg p_scale,
+		JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		float p_delta_time,
+		JPH::Vec3Arg p_displacement_due_to_gravity,
+		int p_colliding_shape_index
+	) const override {
+		mInnerShape->CollideSoftBodyVertices(
+			p_center_of_mass_transform,
+			p_scale,
+			p_vertices,
+			p_delta_time,
+			p_displacement_due_to_gravity,
+			p_colliding_shape_index
+		);
+	}
+
 	void CollectTransformedShapes(
 		const JPH::AABox& p_box,
 		JPH::Vec3Arg p_position_com,

--- a/src/spaces/jolt_body_accessor_3d.cpp
+++ b/src/spaces/jolt_body_accessor_3d.cpp
@@ -47,7 +47,7 @@ void JoltBodyAccessor3D::acquire_active(bool p_lock) {
 		vector = std::get_if<JPH::BodyIDVector>(&ids);
 	}
 
-	space->get_physics_system().GetActiveBodies(*vector);
+	space->get_physics_system().GetActiveBodies(JPH::EBodyType::RigidBody, *vector);
 
 	_acquire_internal(vector->data(), (int32_t)vector->size());
 }

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -170,7 +170,7 @@ bool JoltContactListener3D::_try_apply_surface_velocities(
 	const JPH::Vec3 angular_linear_velocity2 = rel_com2.Cross(angular_velocity2);
 	const JPH::Vec3 total_linear_velocity2 = linear_velocity2 + angular_linear_velocity2;
 
-	p_settings.mRelativeSurfaceVelocity = total_linear_velocity2 - linear_velocity1;
+	p_settings.mRelativeLinearSurfaceVelocity = total_linear_velocity2 - linear_velocity1;
 	p_settings.mRelativeAngularSurfaceVelocity = angular_velocity2 - angular_velocity1;
 
 	return true;


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@8f5df4d52cf224f2c2fc99a5130625d9d250ec52 to godot-jolt/jolt@153291b7c6e294d727c707fd0734c038cc2fdce0 (see diff [here](https://github.com/godot-jolt/jolt/compare/8f5df4d52cf224f2c2fc99a5130625d9d250ec52...153291b7c6e294d727c707fd0734c038cc2fdce0)).

This brings in the following relevant changes:

- Support for soft-body physics
- Support for non-power-of-two `JPH::HeightFieldShape`