### PR TITLE
Fixed issue with `move_and_slide` getting stuck while sliding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Breaking changes are denoted with ⚠️.
 
 - Fixed issue where ray-casting a `ConcavePolygonShape3D` that had `backface_collision` enabled, you
   would sometimes end up with a flipped normal.
+- Fixed issue where a `CharacterBody3D` using `move_and_slide` could sometimes get stuck when
+  sliding along a wall.
 
 ## [0.6.0] - 2023-08-17
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -139,6 +139,7 @@ private:
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
 		const Vector3& p_direction,
+		float p_distance,
 		float p_margin,
 		int32_t p_max_collisions,
 		PhysicsServer3DExtensionMotionResult* p_result


### PR DESCRIPTION
Fixes #529.

This introduces a minimum penetration depth for the contacts reported by `test_body_motion`, similar to how Godot Physics does it, which alleviates problems with `move_and_slide` where even after recovery you could end up still overlapping with the wall you're sliding against ever so slightly, which `floor_block_on_wall` would interpret as being trapped in a corner and would subsequently stop the character.