### PR TITLE
Added "Ignore Internal Edges" project setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Breaking changes are denoted with ⚠️.
   parameter is set to `false`, regardless of what the `backface_collision` property of the
   `ConcavePolygonShape3D` is set to.
 
+### Added
+
+- Added project setting "Ignore Internal Edges" to the "Kinematics" category, which when disabled
+  will make the normals reported by kinematic collisions like `move_and_collide`, `move_and_slide`
+  and `test_move` behave more like they do in Godot Physics when colliding with internal edges of a
+  `ConcavePolygonShape3D` or `HeightMapShape3D`.
+
 ### Fixed
 
 - ⚠️ Fixed regression where a motored `HingeJoint3D` (or `JoltHingeJoint3D`) would rotate

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -251,6 +251,19 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>-</td>
     </tr>
     <tr>
+      <td>Kinematics</td>
+      <td>Ignore Internal Edges</td>
+      <td>
+        Whether or not to "ignore" collisions with internal triangle edges.
+      </td>
+      <td>
+        When enabled, this will (for things like <code>move_and_slide</code>) result in contacts
+        with internal triangle edges of a <code>ConcavePolygonShape3D</code> or
+        <code>HeightMapShape3D</code> to have their normals overridden with the triangle normal,
+        allowing bodies to slide across the edge smoothly, effectively ignoring them.
+      </td>
+    </tr>
+    <tr>
       <td>Solver</td>
       <td>Velocity Iterations</td>
       <td>The number of solver velocity iterations to run during a physics tick.</td>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -14,6 +14,7 @@ constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetr
 
 constexpr char RECOVERY_ITERATIONS[] = "physics/jolt_3d/kinematics/recovery_iterations";
 constexpr char RECOVERY_AMOUNT[] = "physics/jolt_3d/kinematics/recovery_amount";
+constexpr char IGNORE_INTERNAL_EDGES[] = "physics/jolt_3d/kinematics/ignore_internal_edges";
 
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
 constexpr char VELOCITY_ITERATIONS[] = "physics/jolt_3d/solver/velocity_iterations";
@@ -125,6 +126,7 @@ void JoltProjectSettings::register_settings() {
 
 	register_setting_ranged(RECOVERY_ITERATIONS, 4, U"1,8,or_greater");
 	register_setting_ranged(RECOVERY_AMOUNT, 40.0f, U"0,100,0.1,suffix:%");
+	register_setting_plain(IGNORE_INTERNAL_EDGES, true);
 
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
@@ -183,6 +185,11 @@ int32_t JoltProjectSettings::get_kinematic_recovery_iterations() {
 
 float JoltProjectSettings::get_kinematic_recovery_amount() {
 	static const auto value = get_setting<float>(RECOVERY_AMOUNT) / 100.0f;
+	return value;
+}
+
+bool JoltProjectSettings::kinematics_ignore_internal_edges() {
+	static const auto value = get_setting<bool>(IGNORE_INTERNAL_EDGES);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -22,6 +22,8 @@ public:
 
 	static float get_kinematic_recovery_amount();
 
+	static bool kinematics_ignore_internal_edges();
+
 	static int32_t get_velocity_iterations();
 
 	static int32_t get_position_iterations();

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -730,8 +730,14 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 	Transform3D transform_com = p_transform.translated_local(com_scaled);
 
 	JPH::CollideShapeSettings settings;
-	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
-	settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
+
+	if (JoltProjectSettings::kinematics_ignore_internal_edges()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
+		settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
+	} else {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+	}
+
 	settings.mMaxSeparationDistance = p_margin;
 
 	const Vector3& base_offset = transform_com.origin;
@@ -902,9 +908,14 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 	const Transform3D transform_com = p_transform.translated_local(com_scaled);
 
 	JPH::CollideShapeSettings settings;
-	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
-	settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
 	settings.mMaxSeparationDistance = p_margin;
+
+	if (JoltProjectSettings::kinematics_ignore_internal_edges()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
+		settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
+	} else {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+	}
 
 	const Vector3& base_offset = transform_com.origin;
 


### PR DESCRIPTION
Fixes #530.

This adds a new project setting to the "Kinematics" category called "Ignore Internal Edges", which defaults to being enabled, and will allow for disabling the overriding of collision normals that happens as part of Jolt's active/inactive edge detection, resulting in edge normals that look more like what they do with Godot Physics.