### PR TITLE
Fixed hinge motors rotating the wrong way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Breaking changes are denoted with ⚠️.
 
 ### Fixed
 
+- ⚠️ Fixed regression where a motored `HingeJoint3D` (or `JoltHingeJoint3D`) would rotate
+  counter-clockwise instead of clockwise.
 - Fixed issue where ray-casting a `ConcavePolygonShape3D` that had `backface_collision` enabled, you
   would sometimes end up with a flipped normal.
 - Fixed issue where a `CharacterBody3D` using `move_and_slide` could sometimes get stuck when

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -599,9 +599,7 @@ void JoltGeneric6DOFJointImpl3D::_update_motor_velocity(int32_t p_axis) {
 			 (float)motor_speed[AXIS_LINEAR_Z]}
 		);
 	} else {
-		// HACK(mihe): We're forced to flip the direction of these to match Godot Physics. This
-		// means that the velocity direction is inconsistent with the velocity direction for
-		// things like hinge joints.
+		// HACK(mihe): We're forced to flip the direction of these to match Godot Physics.
 		constraint->SetTargetAngularVelocityCS(
 			{(float)-motor_speed[AXIS_ANGULAR_X],
 			 (float)-motor_speed[AXIS_ANGULAR_Y],

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -381,7 +381,8 @@ void JoltHingeJointImpl3D::_update_motor_velocity() {
 	QUIET_FAIL_COND(_is_fixed());
 
 	if (auto* constraint = static_cast<JPH::HingeConstraint*>(jolt_ref.GetPtr())) {
-		constraint->SetTargetAngularVelocity((float)motor_target_speed);
+		// HACK(mihe): We're forced to flip the direction of these to match Godot Physics.
+		constraint->SetTargetAngularVelocity((float)-motor_target_speed);
 	}
 }
 


### PR DESCRIPTION
It appears that a not-so-innocent commit of mine (7495de47ad10f87f72b404df0018622a61ea89b5) that I thought was harmless, actually changed the direction by which motors rotated, causing a regression.

Instead of reverting it I've decided to simply flip the motor direction for hinge joints instead, which has the nice upside of now being consistent with the 6DOF joint's motor direction, which is also flipped.