### PR TITLE
Fixed kinematic collisions potentially reporting no collision

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -601,7 +601,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 
 	const float motion_length = p_motion.length();
 
-	if (motion_length == 0.0f) {
+	if (p_ignore_overlaps && motion_length == 0.0f) {
 		return false;
 	}
 


### PR DESCRIPTION
This is more of a theoretical problem than an actual one, but while rifling through `test_body_motion` I realized that we're actually skipping the cast phase entirely when using a zero motion vector. This makes sense for `cast_motion`, since it ignores any initial overlaps anyway, but it doesn't make as much sense for `test_body_motion` which doesn't ignore initial overlaps.

Granted, the recovery phase should almost always push you away far enough that you never get a collision in the cast phase with a zero motion vector, but since this is technically a discrepancy with how Godot Physics works I figured it's best to rectify that and plug any potential edge-cases that might be lurking here.

Note that this only applies when passing `false` to `recovery_as_collision`.