### PR TITLE
Changed the minimum contact depth for kinematic collisions

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -931,13 +931,13 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 		return collided;
 	}
 
-	// HACK(mihe): Without this contact depth threshold we can sometimes end up with very shallow
-	// contacts that seem to affect the outcome of things like `floor_block_on_wall`, where after
+	// HACK(mihe): Without this minimum contact depth we can sometimes end up with very shallow
+	// contacts that end up affecting the outcome of things like `floor_block_on_wall`, where after
 	// one of the recovery iterations (in Godot, not here) we can still find ourselves penetrating a
 	// wall ever so slightly, which `move_and_slide` will interpret as being trapped in a corner and
-	// stop the character altogether. We still need to movements smaller than this to actually emit
-	// contacts though, so we clamp it by the distance moved.
-	const float min_contact_depth = min(p_margin * 0.05f, p_distance);
+	// stop the character altogether. We still need distances smaller than this (like none at all)
+	// to actually emit contacts though, so we clamp it by the distance moved.
+	const float min_contact_depth = min(0.0001f, p_distance);
 
 	int32_t count = 0;
 


### PR DESCRIPTION
I wasn't too happy with the value for the minimum contact depth introduced in #559.

While `margin * 0.05` is how this is implemented in Godot Physics, I struggled to see the point in involving the margin in this calculation at all, so I decided to change it to instead be hardcoded to 0.0001, or 0.1 mm.