### PR TITLE
Removed the 32-bit clang-tidy step from CI

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -46,13 +46,8 @@ jobs:
         run: ./scripts/run_clang_format.ps1 -SourcePath ./src
 
   clang-tidy:
-    name: Linting (${{ matrix.arch }})
+    name: Linting
     runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x64, x86]
 
     steps:
       - name: Checkout code
@@ -67,14 +62,14 @@ jobs:
         uses: ./.github/actions/cmake-configure
         with:
           platform: linux-clang
-          arch: ${{ matrix.arch }}
+          arch: x64
           args: -DGDJ_PRECOMPILE_HEADERS=FALSE
 
       - name: Build
         uses: ./.github/actions/cmake-build
         with:
           platform: linux-clang
-          arch: ${{ matrix.arch }}
+          arch: x64
           editor: false
           config: debug
 
@@ -87,4 +82,4 @@ jobs:
         run: >
           ./scripts/run_clang_tidy.ps1
           -SourcePath ./src
-          -BuildPath ./build/linux-clang-${{ matrix.arch }}
+          -BuildPath ./build/linux-clang-x64


### PR DESCRIPTION
In the interest of shaving down the CI time I'm removing the x86 clang-tidy step.

Seeing as how I've yet to see a single discrepancy between the x86 and x64 clang-tidy runs in the 1000+ CI runs that have completed so far, I think it's safe to rely on just the x64 one going forward.