### PR TITLE
Updated Jolt to 5d382fc0f7

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 12adfda9621f3f568b7c68a665d718fffa1d701c
+	GIT_COMMIT 5d382fc0f71411dacf0c1f6f93fe0d2612fed45e
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@12adfda9621f3f568b7c68a665d718fffa1d701c to godot-jolt/jolt@5d382fc0f71411dacf0c1f6f93fe0d2612fed45e (see diff [here](https://github.com/godot-jolt/jolt/compare/12adfda9621f3f568b7c68a665d718fffa1d701c...5d382fc0f71411dacf0c1f6f93fe0d2612fed45e)).

This brings in the following relevant changes:

- Bugfix in contact normal calculation in EPA algorithm

Fixes #536.