### PR TITLE
Updated Jolt to d558166ebd

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 5d382fc0f71411dacf0c1f6f93fe0d2612fed45e
+	GIT_COMMIT d558166ebdfa37269670a3dd3ac804c2e04462fe
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@5d382fc0f71411dacf0c1f6f93fe0d2612fed45e to godot-jolt/jolt@d558166ebdfa37269670a3dd3ac804c2e04462fe (see diff [here](https://github.com/godot-jolt/jolt/compare/5d382fc0f71411dacf0c1f6f93fe0d2612fed45e...d558166ebdfa37269670a3dd3ac804c2e04462fe)).

This brings in the following relevant changes:

- Constraints check to see if inverse effective mass is zero to avoid producing NaNs

Fixes #558.