### PR TITLE
Updated Jolt to 58445d6c26

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT d558166ebdfa37269670a3dd3ac804c2e04462fe
+	GIT_COMMIT 58445d6c2633d2f25df0aa54898bc4249b37f4e8
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@d558166ebdfa37269670a3dd3ac804c2e04462fe to godot-jolt/jolt@58445d6c2633d2f25df0aa54898bc4249b37f4e8 (see diff [here](https://github.com/godot-jolt/jolt/compare/d558166ebdfa37269670a3dd3ac804c2e04462fe...58445d6c2633d2f25df0aa54898bc4249b37f4e8)).

This brings in the following relevant changes:

- Revert of jrouwe/JoltPhysics@5d382fc0f71411dacf0c1f6f93fe0d2612fed45e