### PR TITLE
Updated Jolt to 886e4e2b6e

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 58445d6c2633d2f25df0aa54898bc4249b37f4e8
+	GIT_COMMIT 886e4e2b6e8e375491f36e10301f9a7025ceec4d
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@58445d6c2633d2f25df0aa54898bc4249b37f4e8 to godot-jolt/jolt@886e4e2b6e8e375491f36e10301f9a7025ceec4d (see diff [here](https://github.com/godot-jolt/jolt/compare/58445d6c2633d2f25df0aa54898bc4249b37f4e8...886e4e2b6e8e375491f36e10301f9a7025ceec4d)).

This brings in the following relevant changes:

- Reduced tolerance for early out when contact normal equals surface normal in active edge detection
- Fixed flipped normals in EPA penetration depth algorithm

Fixes #536.