### PR TITLE
Added profiler timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Added
+
+- Added timings of Jolt's various jobs to the "Physics 3D" profiler category.
+
 ### Fixed
 
 - Fixed issue where under certain conditions `move_and_slide` could get stuck on internal edges of a

--- a/src/misc/math.hpp
+++ b/src/misc/math.hpp
@@ -13,6 +13,8 @@
 
 // NOLINTEND(readability-identifier-naming)
 
+#define USEC_TO_SEC(m_usec) (double(m_usec) / 1000000.0)
+
 namespace godot::Math {
 
 _FORCE_INLINE_ void decompose(Basis& p_basis, Vector3& p_scale) {

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -52,9 +52,12 @@
 #include <godot_cpp/classes/editor_node3d_gizmo_plugin.hpp>
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
+#include <godot_cpp/classes/engine_debugger.hpp>
 #include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/theme.hpp>
+#include <godot_cpp/classes/time.hpp>
 #include <godot_cpp/classes/timer.hpp>
+#include <godot_cpp/templates/spin_lock.hpp>
 
 #endif // GDJ_CONFIG_EDITOR
 

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1799,6 +1799,10 @@ void JoltPhysicsServer3D::_flush_queries() {
 	}
 
 	flushing_queries = false;
+
+#ifdef GDJ_CONFIG_EDITOR
+	job_system->flush_timings();
+#endif // GDJ_CONFIG_EDITOR
 }
 
 void JoltPhysicsServer3D::_finish() {


### PR DESCRIPTION
Fixes #507.

This adds a number of timings to the "Physics 3D" category in the "Profiler" tab in Godot's debugger.

The timings reported are the time it took to execute the various jobs that Jolt schedules, which currently consist of things like:

- `DetermineActiveConstraints`
- `PostIntegrateVelocity`
- `PreIntegrateVelocity`
- `FinalizeIslands`
- `IntegrateVelocity`
- `SolveVelocityConstraints`
- `ApplyGravity`
- `BodySetIslandIndex`
- `UpdateBroadPhasePrepare`
- `UpdateBroadPhaseFinalize`
- `FindCollisions`
- `SolvePositionConstraints`
- `ContactRemovedCallbacks`
- `ResolveCCDContacts`
- `UpdateSoftBodies`
- `SetupVelocityConstraints`
- `BuildIslandsFromConstraints`
- `FindCollisions`