### PR TITLE
Changed force integration callback to match Godot Physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed the `body_set_force_integration_callback` method of `PhysicsServer3D` to behave like it
+  does with Godot Physics, where omitting the binding of `userdata` requires that the callback also
+  doesn't take any `userdata`.
+
 ### Added
 
 - Added timings of Jolt's various jobs to the "Physics 3D" profiler category.

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -672,16 +672,28 @@ void JoltBodyImpl3D::remove_joint(JoltJointImpl3D* p_joint, bool p_lock) {
 
 void JoltBodyImpl3D::call_queries([[maybe_unused]] JPH::Body& p_jolt_body) {
 	if (is_rigid() && custom_integration_callback.is_valid()) {
-		static thread_local Array arguments = []() {
-			Array array;
-			array.resize(2);
-			return array;
-		}();
+		if (custom_integration_userdata.get_type() != Variant::NIL) {
+			static thread_local Array arguments = []() {
+				Array array;
+				array.resize(2);
+				return array;
+			}();
 
-		arguments[0] = get_direct_state();
-		arguments[1] = custom_integration_userdata;
+			arguments[0] = get_direct_state();
+			arguments[1] = custom_integration_userdata;
 
-		custom_integration_callback.callv(arguments);
+			custom_integration_callback.callv(arguments);
+		} else {
+			static thread_local Array arguments = []() {
+				Array array;
+				array.resize(1);
+				return array;
+			}();
+
+			arguments[0] = get_direct_state();
+
+			custom_integration_callback.callv(arguments);
+		}
 	}
 
 	if (sync_state && body_state_callback.is_valid()) {


### PR DESCRIPTION
This changes `body_set_force_integration_callback` to behave like it does with Godot Physics, where the number of parameters in the callback has to line up with the number of arguments passed to `body_set_force_integration_callback`.

Until now the `_my_integration` method in this (somewhat forced) example would not have been called:

```gdscript
extends RigidBody3D

func _my_integration(state):
    pass

func _ready():
    PhysicsServer3D.body_set_force_integration_callback(self, _my_integration)
```

... because you always had to have a `userdata` parameter in the callback. Now instead you only add the `userdata` parameter to the callback if `userdata` is also provided to `body_set_force_integration_callback`, like so:

```gdscript
extends RigidBody3D

func _my_integration(state, userdata):
    pass

func _ready():
    PhysicsServer3D.body_set_force_integration_callback(self, _my_integration, "some userdata")
```