### PR TITLE
Removed direction from edge detection during kinematic collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where under certain conditions `move_and_slide` could get stuck on internal edges of a
   `ConcavePolygonShape3D` if the floor was within 5-ish degrees of `floor_max_angle`.
 - Fixed issue where collision with `ConvexPolygonShape3D` could yield a flipped contact normal.
+- Fixed issue with `move_and_slide` when using a `BoxShape3D` or `CylinderShape3D` shape, where
+  under certain conditions you could get stuck on internal edges of a `ConcavePolygonShape3D`.
 
 ## [0.7.0] - 2023-08-29
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -512,17 +512,8 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	Vector3 scale;
 	Transform3D transform = Math::decomposed(p_transform, scale);
 
-	const float distance_sq = p_motion.length_squared();
-	float distance = 0.0f;
-	Vector3 direction = {};
-
-	if (distance_sq > 0.0f) {
-		distance = Math::sqrt(distance_sq);
-		direction = p_motion / distance;
-	}
-
 	Vector3 recovery;
-	const bool recovered = _body_motion_recover(p_body, transform, direction, p_margin, recovery);
+	const bool recovered = _body_motion_recover(p_body, transform, p_margin, recovery);
 
 	transform.origin += recovery;
 
@@ -545,8 +536,7 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 		collided = _body_motion_collide(
 			p_body,
 			transform.translated(p_motion * unsafe_fraction),
-			direction,
-			distance,
+			p_motion.length(),
 			p_margin,
 			p_max_collisions,
 			p_result
@@ -717,7 +707,6 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
-	const Vector3& p_direction,
 	float p_margin,
 	Vector3& p_recovery
 ) const {
@@ -731,7 +720,6 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 
 	JPH::CollideShapeSettings settings;
 	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
-	settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
 	settings.mMaxSeparationDistance = p_margin;
 
 	const Vector3& base_offset = transform_com.origin;
@@ -890,7 +878,6 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 	const JoltBodyImpl3D& p_body,
 	const Transform3D& p_transform,
-	const Vector3& p_direction,
 	float p_distance,
 	float p_margin,
 	int32_t p_max_collisions,
@@ -903,7 +890,6 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 
 	JPH::CollideShapeSettings settings;
 	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
-	settings.mActiveEdgeMovementDirection = to_jolt(p_direction);
 	settings.mMaxSeparationDistance = p_margin;
 
 	const Vector3& base_offset = transform_com.origin;

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -120,7 +120,6 @@ private:
 	bool _body_motion_recover(
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
-		const Vector3& p_direction,
 		float p_margin,
 		Vector3& p_recovery
 	) const;
@@ -138,7 +137,6 @@ private:
 	bool _body_motion_collide(
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
-		const Vector3& p_direction,
 		float p_distance,
 		float p_margin,
 		int32_t p_max_collisions,


### PR DESCRIPTION
Related to #530.

This omits the usage of `mActiveEdgeMovementDirection` from the collision check in `body_test_motion` (a.k.a. `move_and_collide`).

I've yet to see any clear benefit from using this, and a couple of edge-cases seem to indicate that it has more of a negative rather than positive impact on `move_and_collide`, so I'm removing it for the time being.