### PR TITLE
Fixed `Area3D` not catching enters when not monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue with `move_and_slide`, where under certain conditions, while using a `BoxShape3D` or
   `CylinderShape3D` shape, you could get stuck on internal edges of a `ConcavePolygonShape3D`.
 - Fixed issue where collision with `ConvexPolygonShape3D` could yield a flipped contact normal.
+- Fixed issue where an `Area3D` with `monitoring` disabled wouldn't emit any entered events for
+  already overlapping bodies once `monitoring` was enabled.
 
 ## [0.7.0] - 2023-08-29
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -64,15 +64,11 @@ public:
 
 	void set_area_monitor_callback(const Callable& p_callback);
 
-	bool is_monitoring() const {
-		return has_body_monitor_callback() || has_area_monitor_callback();
-	}
-
 	bool is_monitorable() const { return monitorable; }
 
 	void set_monitorable(bool p_monitorable, bool p_lock = true);
 
-	bool generates_contacts() const override { return is_monitoring(); }
+	bool generates_contacts() const override { return true; }
 
 	bool is_point_gravity() const { return point_gravity; }
 


### PR DESCRIPTION
Fixes #584.

This fixes an issue with `Area3D`, where if you had `monitoring` disabled and bodies already overlapping, it wouldn't report any enter events once `monitoring` was enabled.