### PR TITLE
Added registering of `JoltPhysicsServer3D` as a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Breaking changes are denoted with ⚠️.
 ### Added
 
 - Added timings of Jolt's various jobs to the "Physics 3D" profiler category.
+- Added registering of `JoltPhysicsServer3D` as an actual singleton, which makes Jolt-specific
+  server methods (like `pin_joint_get_applied_force`) easier to deal with from dynamic scripting
+  languages like GDScript.
 
 ### Fixed
 

--- a/src/misc/utility_macros.hpp
+++ b/src/misc/utility_macros.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#define NAMEOF(x) #x

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -157,5 +157,6 @@ using namespace godot;
 #include "misc/scope_guard.hpp"
 #include "misc/type_conversions.hpp"
 #include "misc/utility_functions.hpp"
+#include "misc/utility_macros.hpp"
 
 // NOLINTEND(readability-duplicate-include)

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -116,6 +116,22 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY);
 }
 
+JoltPhysicsServer3D::JoltPhysicsServer3D() {
+	const StringName server_name = NAMEOF(JoltPhysicsServer3D);
+
+	Engine* engine = Engine::get_singleton();
+
+	if (engine->has_singleton(server_name)) {
+		engine->unregister_singleton(server_name);
+	}
+
+	engine->register_singleton(server_name, this);
+}
+
+JoltPhysicsServer3D::~JoltPhysicsServer3D() {
+	Engine::get_singleton()->unregister_singleton(NAMEOF(JoltPhysicsServer3D));
+}
+
 RID JoltPhysicsServer3D::_world_boundary_shape_create() {
 	JoltShapeImpl3D* shape = memnew(JoltWorldBoundaryShapeImpl3D);
 	RID rid = shape_owner.make_rid(shape);

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -80,6 +80,10 @@ private:
 	static void _bind_methods();
 
 public:
+	JoltPhysicsServer3D();
+
+	~JoltPhysicsServer3D() override;
+
 	RID _world_boundary_shape_create() override;
 
 	RID _separation_ray_shape_create() override;


### PR DESCRIPTION
This registers `JoltPhysicsServer3D` as an actual engine singleton, which allows for things like `JoltPhysicsServer3D.pin_joint_get_applied_force(my_joint)`, as opposed to having to do some kind of casting of the regular `PhysicsServer3D` (if that's even possible?) or using the even more questionable option of `PhysicsServer3D.call("pin_joint_get_applied_force", my_joint)`