### PR TITLE
Changed `Area3D` layers/masks to support asymmetrical setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Breaking changes are denoted with ⚠️.
 
 ### Changed
 
+- ⚠️ Changed collision layers and masks for `Area3D` to behave as they do in Godot Physics, allowing
+  for asymmetrical setups, where overlaps are only reported if the mask of an `Area3D` contains the
+  layer of the overlapping object.
 - ⚠️ Changed the `body_set_force_integration_callback` method of `PhysicsServer3D` to behave like it
   does with Godot Physics, where omitting the binding of `userdata` requires that the callback also
   doesn't take any `userdata`.

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -412,21 +412,40 @@ void JoltContactListener3D::_flush_area_enters() {
 			continue;
 		}
 
+		const JoltObjectImpl3D* object1 = jolt_body1.as_object();
+		const JoltObjectImpl3D* object2 = jolt_body2.as_object();
+
+		const uint32_t collision_layer1 = object1->get_collision_layer();
+		const uint32_t collision_layer2 = object2->get_collision_layer();
+
+		const uint32_t collision_mask1 = object1->get_collision_mask();
+		const uint32_t collision_mask2 = object2->get_collision_mask();
+
+		const bool first_scans_second = (collision_mask1 & collision_layer2) != 0;
+		const bool second_scans_first = (collision_mask2 & collision_layer1) != 0;
+
 		JoltAreaImpl3D* area1 = jolt_body1.as_area();
 		JoltAreaImpl3D* area2 = jolt_body2.as_area();
 
+		const JoltBodyImpl3D* body1 = jolt_body1.as_body();
+		const JoltBodyImpl3D* body2 = jolt_body2.as_body();
+
 		if (area1 != nullptr && area2 != nullptr) {
-			if (area2->is_monitorable()) {
+			if (first_scans_second && area2->is_monitorable()) {
 				area1->area_shape_entered(body_id2, sub_shape_id2, sub_shape_id1);
 			}
 
-			if (area1->is_monitorable()) {
+			if (second_scans_first && area1->is_monitorable()) {
 				area2->area_shape_entered(body_id1, sub_shape_id1, sub_shape_id2);
 			}
-		} else if (area1 != nullptr && area2 == nullptr) {
-			area1->body_shape_entered(body_id2, sub_shape_id2, sub_shape_id1);
-		} else if (area1 == nullptr && area2 != nullptr) {
-			area2->body_shape_entered(body_id1, sub_shape_id1, sub_shape_id2);
+		} else if (area1 != nullptr && body2 != nullptr) {
+			if (first_scans_second) {
+				area1->body_shape_entered(body_id2, sub_shape_id2, sub_shape_id1);
+			}
+		} else if (body1 != nullptr && area2 != nullptr) {
+			if (second_scans_first) {
+				area2->body_shape_entered(body_id1, sub_shape_id1, sub_shape_id2);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #582.

This changes how collision layers/masks work with `Area3D`, and is effectively the `Area3D` equivalent of #457.

Until now `Area3D` has behaved like bodies did prior to #457, meaning overlaps were detected if `(area_mask & object_layer) || (object_mask & area_layer)`, but with this PR you will instead only get a reported overlap if `area_mask & object_layer`.

Note that this opens up for another issue, which is that changing the collision mask of an `Area3D` while an affected body is overlapping it, or changing that overlapping body's collision layer, will not correctly report an exit like it does in Godot Physics. I'll try to figure out some solution for that later.