### PR TITLE
Fixed joints not updating on center-of-mass changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where collision with `ConvexPolygonShape3D` could yield a flipped contact normal.
 - Fixed issue where an `Area3D` with `monitoring` disabled wouldn't emit any entered events for
   already overlapping bodies once `monitoring` was enabled.
+- Fixed issue where changing the center-of-mass of a `RigidBody3D` attached to a joint would shift
+  its transform relative to the joint.
 
 ## [0.7.0] - 2023-08-29
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1371,6 +1371,7 @@ void JoltBodyImpl3D::_mode_changed(bool p_lock) {
 
 void JoltBodyImpl3D::_shapes_built(bool p_lock) {
 	_update_mass_properties(p_lock);
+	_update_joint_constraints(p_lock);
 	wake_up(p_lock);
 }
 


### PR DESCRIPTION
Fixes #594.

This fixes an issue where if you changed the center-of-mass in any way (either explicitly or by adding another shape) while the body was attached to a joint, the joint wouldn't have its reference frames updated and would effectively shift the body relative to the joint.