### PR TITLE
Renamed "Dump Snapshots" to "Dump Debug Snapshots"

### DIFF
--- a/src/servers/jolt_editor_plugin.cpp
+++ b/src/servers/jolt_editor_plugin.cpp
@@ -36,7 +36,7 @@ void JoltEditorPlugin::_enter_tree() {
 
 	PopupMenu* tool_menu = memnew(PopupMenu);
 	tool_menu->connect("id_pressed", Callable(this, NAMEOF(_tool_menu_pressed)));
-	tool_menu->add_item("Dump Snapshots", MENU_OPTION_DUMP_SNAPSHOTS);
+	tool_menu->add_item("Dump Debug Snapshots", MENU_OPTION_DUMP_DEBUG_SNAPSHOTS);
 
 	add_tool_submenu_item("Jolt Physics", tool_menu);
 }
@@ -45,38 +45,41 @@ void JoltEditorPlugin::_exit_tree() {
 	remove_node_3d_gizmo_plugin(joint_gizmo_plugin);
 	joint_gizmo_plugin.unref();
 
-	if (snapshots_dialog != nullptr) {
-		snapshots_dialog->queue_free();
-		snapshots_dialog = nullptr;
+	if (debug_snapshots_dialog != nullptr) {
+		debug_snapshots_dialog->queue_free();
+		debug_snapshots_dialog = nullptr;
 	}
 }
 
 void JoltEditorPlugin::_tool_menu_pressed(int32_t p_index) {
 	// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 	switch (p_index) {
-		case MENU_OPTION_DUMP_SNAPSHOTS: {
-			_dump_snapshots();
+		case MENU_OPTION_DUMP_DEBUG_SNAPSHOTS: {
+			_dump_debug_snapshots();
 		} break;
 	}
 }
 
 void JoltEditorPlugin::_snapshots_dir_selected(const String& p_dir) {
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
-	physics_server->dump_snapshots(p_dir);
+	physics_server->dump_debug_snapshots(p_dir);
 }
 
-void JoltEditorPlugin::_dump_snapshots() {
-	if (snapshots_dialog == nullptr) {
-		snapshots_dialog = memnew(EditorFileDialog);
-		snapshots_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
-		snapshots_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
-		snapshots_dialog->set_current_dir("res://");
-		snapshots_dialog->connect("dir_selected", Callable(this, NAMEOF(_snapshots_dir_selected)));
+void JoltEditorPlugin::_dump_debug_snapshots() {
+	if (debug_snapshots_dialog == nullptr) {
+		debug_snapshots_dialog = memnew(EditorFileDialog);
+		debug_snapshots_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+		debug_snapshots_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+		debug_snapshots_dialog->set_current_dir("res://");
+		debug_snapshots_dialog->connect(
+			"dir_selected",
+			Callable(this, NAMEOF(_snapshots_dir_selected))
+		);
 
-		get_editor_interface()->get_base_control()->add_child(snapshots_dialog);
+		get_editor_interface()->get_base_control()->add_child(debug_snapshots_dialog);
 	}
 
-	snapshots_dialog->popup_centered_ratio(0.5);
+	debug_snapshots_dialog->popup_centered_ratio(0.5);
 }
 
 #endif // GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_editor_plugin.hpp
+++ b/src/servers/jolt_editor_plugin.hpp
@@ -17,18 +17,18 @@ public:
 
 private:
 	enum MenuOption {
-		MENU_OPTION_DUMP_SNAPSHOTS
+		MENU_OPTION_DUMP_DEBUG_SNAPSHOTS
 	};
 
 	void _tool_menu_pressed(int32_t p_index);
 
 	void _snapshots_dir_selected(const String& p_dir);
 
-	void _dump_snapshots();
+	void _dump_debug_snapshots();
 
 	Ref<JoltJointGizmoPlugin3D> joint_gizmo_plugin;
 
-	EditorFileDialog* snapshots_dialog = nullptr;
+	EditorFileDialog* debug_snapshots_dialog = nullptr;
 };
 
 #endif // GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -24,9 +24,9 @@
 
 void JoltPhysicsServer3D::_bind_methods() {
 #ifdef GDJ_CONFIG_EDITOR
-	BIND_METHOD(JoltPhysicsServer3D, dump_snapshots, "dir");
+	BIND_METHOD(JoltPhysicsServer3D, dump_debug_snapshots, "dir");
 
-	BIND_METHOD(JoltPhysicsServer3D, space_dump_snapshot, "space", "dir");
+	BIND_METHOD(JoltPhysicsServer3D, space_dump_debug_snapshot, "space", "dir");
 #endif // GDJ_CONFIG_EDITOR
 
 	BIND_METHOD(JoltPhysicsServer3D, joint_get_enabled, "joint");
@@ -1881,17 +1881,17 @@ void JoltPhysicsServer3D::free_joint(JoltJointImpl3D* p_joint) {
 
 #ifdef GDJ_CONFIG_EDITOR
 
-void JoltPhysicsServer3D::dump_snapshots(const String& p_dir) {
+void JoltPhysicsServer3D::dump_debug_snapshots(const String& p_dir) {
 	for (JoltSpace3D* space : active_spaces) {
-		space->dump_snapshot(p_dir);
+		space->dump_debug_snapshot(p_dir);
 	}
 }
 
-void JoltPhysicsServer3D::space_dump_snapshot(const RID& p_space, const String& p_dir) {
+void JoltPhysicsServer3D::space_dump_debug_snapshot(const RID& p_space, const String& p_dir) {
 	JoltSpace3D* space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
-	space->dump_snapshot(p_dir);
+	space->dump_debug_snapshot(p_dir);
 }
 
 #endif // GDJ_CONFIG_EDITOR

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -638,9 +638,9 @@ public:
 	JoltJointImpl3D* get_joint(const RID& p_rid) const { return joint_owner.get_or_null(p_rid); }
 
 #ifdef GDJ_CONFIG_EDITOR
-	void dump_snapshots(const String& p_dir);
+	void dump_debug_snapshots(const String& p_dir);
 
-	void space_dump_snapshot(const RID& p_space, const String& p_dir);
+	void space_dump_debug_snapshot(const RID& p_space, const String& p_dir);
 #endif // GDJ_CONFIG_EDITOR
 
 	bool joint_get_enabled(const RID& p_joint) const;

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -380,7 +380,7 @@ void JoltSpace3D::remove_joint(JoltJointImpl3D* p_joint) {
 
 #ifdef GDJ_CONFIG_EDITOR
 
-void JoltSpace3D::dump_snapshot(const String& p_dir) {
+void JoltSpace3D::dump_debug_snapshot(const String& p_dir) {
 	const Dictionary datetime = Time::get_singleton()->get_datetime_dict_from_system();
 
 	const String datetime_str = vformat(

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -89,7 +89,7 @@ public:
 	void remove_joint(JoltJointImpl3D* p_joint);
 
 #ifdef GDJ_CONFIG_EDITOR
-	void dump_snapshot(const String& p_dir);
+	void dump_debug_snapshot(const String& p_dir);
 
 	const PackedVector3Array& get_debug_contacts() const;
 


### PR DESCRIPTION
This changes the "Dump Snapshots" menu option (as well as accompanying server methods) to be referred to as "Dump Debug Snapshots" instead.

I figured this better communicates that it's not really a useful general-purpose feature, and more of a debugging/development feature. I suppose it also opens up for some hypothetical future `space_dump_snapshot` method that doesn't filter out the custom shapes, if such a thing would happen to be useful.

CC: @jrouwe