### PR TITLE
Changed custom integration to only be called on state sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Breaking changes are denoted with ⚠️.
   layer of the overlapping object.
 - ⚠️ Changed the `body_set_force_integration_callback` method of `PhysicsServer3D` to behave like it
   does with Godot Physics, where omitting the binding of `userdata` requires that the callback also
-  doesn't take any `userdata`.
+  doesn't take any `userdata`. It also will no longer be called when the body is sleeping.
 
 ### Added
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -671,7 +671,11 @@ void JoltBodyImpl3D::remove_joint(JoltJointImpl3D* p_joint, bool p_lock) {
 }
 
 void JoltBodyImpl3D::call_queries([[maybe_unused]] JPH::Body& p_jolt_body) {
-	if (is_rigid() && custom_integration_callback.is_valid()) {
+	if (!sync_state) {
+		return;
+	}
+
+	if (custom_integration_callback.is_valid()) {
 		if (custom_integration_userdata.get_type() != Variant::NIL) {
 			static thread_local Array arguments = []() {
 				Array array;
@@ -696,7 +700,7 @@ void JoltBodyImpl3D::call_queries([[maybe_unused]] JPH::Body& p_jolt_body) {
 		}
 	}
 
-	if (sync_state && body_state_callback.is_valid()) {
+	if (body_state_callback.is_valid()) {
 		static thread_local Array arguments = []() {
 			Array array;
 			array.resize(1);


### PR DESCRIPTION
This changes the behavior of any callback that's passed to the `body_set_force_integration_callback` method of `PhysicsServer3D`, where previously it would always be invoked every physics tick, whereas now it behaves like `_integrate_forces` does, where it's only invoked when synchronizing state, i.e. when the body has moved in some way.