### PR TITLE
Added support for total gravity for kinematic bodies

### DIFF
--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -269,6 +269,8 @@ private:
 
 	void _update_mass_properties(bool p_lock = true);
 
+	void _update_gravity(JPH::Body& p_jolt_body);
+
 	void _update_damp(bool p_lock = true);
 
 	void _update_kinematic_transform(bool p_lock = true);


### PR DESCRIPTION
Fixes #602.

This changes the updating of gravity (which is typically retrieved through `PhysicsDirectBodyState3D.total_gravity`) from only happening as part of `_pre_step_rigid`, which only applied to dynamic bodies, to now also happen in `_pre_step_kinematic`, which lets kinematic bodies like `CharacterBody3D` also use it.