### PR TITLE
Removed redundancy related to contact listener

### DIFF
--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -72,7 +72,7 @@ public:
 
 	void set_monitorable(bool p_monitorable, bool p_lock = true);
 
-	bool generates_contacts() const override { return true; }
+	bool generates_contacts() const override { return false; }
 
 	bool is_point_gravity() const { return point_gravity; }
 

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -78,39 +78,26 @@ bool JoltContactListener3D::_is_listening_for(const JPH::Body& p_body) const {
 }
 
 bool JoltContactListener3D::_try_override_collision_response(
-	const JPH::Body& p_body1,
-	const JPH::Body& p_body2,
+	const JPH::Body& p_jolt_body1,
+	const JPH::Body& p_jolt_body2,
 	JPH::ContactSettings& p_settings
 ) {
-	if (p_body1.IsSensor() || p_body2.IsSensor()) {
+	if (p_jolt_body1.IsSensor() || p_jolt_body2.IsSensor()) {
 		return false;
 	}
 
-	if (!p_body1.IsDynamic() && !p_body2.IsDynamic()) {
+	if (!p_jolt_body1.IsDynamic() && !p_jolt_body2.IsDynamic()) {
 		return false;
 	}
 
-	JPH::BroadPhaseLayer broad_phase_layer1 = {};
-	uint32_t collision_layer1 = 0;
-	uint32_t collision_mask1 = 0;
+	const auto* body1 = reinterpret_cast<JoltBodyImpl3D*>(p_jolt_body1.GetUserData());
+	const auto* body2 = reinterpret_cast<JoltBodyImpl3D*>(p_jolt_body2.GetUserData());
 
-	space->map_from_object_layer(
-		p_body1.GetObjectLayer(),
-		broad_phase_layer1,
-		collision_layer1,
-		collision_mask1
-	);
+	const uint32_t collision_layer1 = body1->get_collision_layer();
+	const uint32_t collision_layer2 = body2->get_collision_layer();
 
-	JPH::BroadPhaseLayer broad_phase_layer2 = {};
-	uint32_t collision_layer2 = 0;
-	uint32_t collision_mask2 = 0;
-
-	space->map_from_object_layer(
-		p_body2.GetObjectLayer(),
-		broad_phase_layer2,
-		collision_layer2,
-		collision_mask2
-	);
+	const uint32_t collision_mask1 = body1->get_collision_mask();
+	const uint32_t collision_mask2 = body2->get_collision_mask();
 
 	const bool first_scans_second = (collision_mask1 & collision_layer2) != 0;
 	const bool second_scans_first = (collision_mask2 & collision_layer1) != 0;
@@ -260,10 +247,6 @@ bool JoltContactListener3D::_try_add_area_overlap(
 	const JPH::ContactManifold& p_manifold
 ) {
 	if (!p_body1.IsSensor() && !p_body2.IsSensor()) {
-		return false;
-	}
-
-	if (!_is_listening_for(p_body1) && !_is_listening_for(p_body2)) {
 		return false;
 	}
 

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -94,8 +94,8 @@ private:
 	bool _is_listening_for(const JPH::Body& p_body) const;
 
 	bool _try_override_collision_response(
-		const JPH::Body& p_body1,
-		const JPH::Body& p_body2,
+		const JPH::Body& p_jolt_body1,
+		const JPH::Body& p_jolt_body2,
 		JPH::ContactSettings& p_settings
 	);
 


### PR DESCRIPTION
Related to #586.

As a result of #586 there's no longer any need to track whether areas should be listened for in the contact listener, since they always will be. This means we can remove the relevant early-out in `_try_add_area_overlap` and have `JoltAreaImpl3D::generates_contacts()` return `false` instead, saving us from having to store the areas every tick. 

I also stumbled upon a mistake in `_try_override_collision_response`, where the collision layers/masks were being looked up through the physics space, when it could just as well be retrieved from the bodies that were being passed in as parameters.