### PR TITLE
Fixed broken asymmetric collisions between areas

### DIFF
--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -174,6 +174,22 @@ void JoltAreaImpl3D::set_monitorable(bool p_monitorable, bool p_lock) {
 	_monitorable_changed(p_lock);
 }
 
+bool JoltAreaImpl3D::can_monitor(const JoltBodyImpl3D& p_other) const {
+	return (collision_mask & p_other.get_collision_layer()) != 0;
+}
+
+bool JoltAreaImpl3D::can_monitor(const JoltAreaImpl3D& p_other) const {
+	return p_other.is_monitorable() && (collision_mask & p_other.get_collision_layer()) != 0;
+}
+
+bool JoltAreaImpl3D::can_interact_with(const JoltBodyImpl3D& p_other) const {
+	return can_monitor(p_other);
+}
+
+bool JoltAreaImpl3D::can_interact_with(const JoltAreaImpl3D& p_other) const {
+	return can_monitor(p_other) || p_other.can_monitor(*this);
+}
+
 Vector3 JoltAreaImpl3D::compute_gravity(const Vector3& p_position, bool p_lock) const {
 	if (!point_gravity) {
 		return gravity_vector * gravity;

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -2,6 +2,8 @@
 
 #include "objects/jolt_object_impl_3d.hpp"
 
+class JoltBodyImpl3D;
+
 class JoltAreaImpl3D final : public JoltObjectImpl3D {
 	struct BodyIDHasher {
 		static uint32_t hash(const JPH::BodyID& p_id) {
@@ -71,6 +73,14 @@ public:
 	bool is_monitorable() const { return monitorable; }
 
 	void set_monitorable(bool p_monitorable, bool p_lock = true);
+
+	bool can_monitor(const JoltBodyImpl3D& p_other) const;
+
+	bool can_monitor(const JoltAreaImpl3D& p_other) const;
+
+	bool can_interact_with(const JoltBodyImpl3D& p_other) const;
+
+	bool can_interact_with(const JoltAreaImpl3D& p_other) const;
 
 	bool generates_contacts() const override { return false; }
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -958,6 +958,15 @@ void JoltBodyImpl3D::set_axis_lock(
 	}
 }
 
+bool JoltBodyImpl3D::can_collide_with(const JoltBodyImpl3D& p_other) const {
+	return (collision_mask & p_other.get_collision_layer()) != 0;
+}
+
+bool JoltBodyImpl3D::can_interact_with(const JoltBodyImpl3D& p_other) const {
+	return (can_collide_with(p_other) || p_other.can_collide_with(*this)) &&
+		!has_collision_exception(p_other.get_rid()) && !p_other.has_collision_exception(rid);
+}
+
 JPH::BroadPhaseLayer JoltBodyImpl3D::_get_broad_phase_layer() const {
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -242,6 +242,10 @@ public:
 
 	bool are_axes_locked() const { return locked_axes != 0; }
 
+	bool can_collide_with(const JoltBodyImpl3D& p_other) const;
+
+	bool can_interact_with(const JoltBodyImpl3D& p_other) const;
+
 private:
 	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 

--- a/src/objects/jolt_group_filter.cpp
+++ b/src/objects/jolt_group_filter.cpp
@@ -59,25 +59,15 @@ bool JoltGroupFilter::CanCollide(
 		: nullptr;
 
 	if (body1 != nullptr && body2 != nullptr) {
-		return !body1->has_collision_exception(body2->get_rid()) &&
-			!body2->has_collision_exception(body1->get_rid());
+		return body1->can_interact_with(*body2);
 	}
 
-	const uint32_t collision_layer1 = object1->get_collision_layer();
-	const uint32_t collision_layer2 = object2->get_collision_layer();
-
-	const uint32_t collision_mask1 = object1->get_collision_mask();
-	const uint32_t collision_mask2 = object2->get_collision_mask();
-
-	const bool first_scans_second = (collision_mask1 & collision_layer2) != 0;
-	const bool second_scans_first = (collision_mask2 & collision_layer1) != 0;
-
 	if (area1 != nullptr && area2 != nullptr) {
-		return first_scans_second || second_scans_first;
+		return area1->can_interact_with(*area2);
 	} else if (area1 != nullptr && body2 != nullptr) {
-		return first_scans_second;
-	} else if (body1 != nullptr && area2 != nullptr) {
-		return second_scans_first;
+		return area1->can_interact_with(*body2);
+	} else if (area2 != nullptr && body1 != nullptr) {
+		return area2->can_interact_with(*body1);
 	} else {
 		return false;
 	}

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -93,19 +93,13 @@ bool JoltContactListener3D::_try_override_collision_response(
 	const auto* body1 = reinterpret_cast<JoltBodyImpl3D*>(p_jolt_body1.GetUserData());
 	const auto* body2 = reinterpret_cast<JoltBodyImpl3D*>(p_jolt_body2.GetUserData());
 
-	const uint32_t collision_layer1 = body1->get_collision_layer();
-	const uint32_t collision_layer2 = body2->get_collision_layer();
+	const bool can_collide1 = body1->can_collide_with(*body2);
+	const bool can_collide2 = body2->can_collide_with(*body1);
 
-	const uint32_t collision_mask1 = body1->get_collision_mask();
-	const uint32_t collision_mask2 = body2->get_collision_mask();
-
-	const bool first_scans_second = (collision_mask1 & collision_layer2) != 0;
-	const bool second_scans_first = (collision_mask2 & collision_layer1) != 0;
-
-	if (first_scans_second && !second_scans_first) {
+	if (can_collide1 && !can_collide2) {
 		p_settings.mInvMassScale2 = 0.0f;
 		p_settings.mInvInertiaScale2 = 0.0f;
-	} else if (second_scans_first && !first_scans_second) {
+	} else if (can_collide2 && !can_collide1) {
 		p_settings.mInvMassScale1 = 0.0f;
 		p_settings.mInvInertiaScale1 = 0.0f;
 	}
@@ -399,11 +393,11 @@ void JoltContactListener3D::_flush_area_enters() {
 		JoltAreaImpl3D* area2 = jolt_body2.as_area();
 
 		if (area1 != nullptr && area2 != nullptr) {
-			if (area2->is_monitorable()) {
+			if (area1->can_monitor(*area2)) {
 				area1->area_shape_entered(body_id2, sub_shape_id2, sub_shape_id1);
 			}
 
-			if (area1->is_monitorable()) {
+			if (area2->can_monitor(*area1)) {
 				area2->area_shape_entered(body_id1, sub_shape_id1, sub_shape_id2);
 			}
 		} else if (area1 != nullptr && area2 == nullptr) {


### PR DESCRIPTION
It seems that #605 largely (and mistakenly) undid the parts of #595 that were relevant (at the time) for #582, by regressing the behavior of collision/layers masks for `Area3D` in a way where they once again would report overlaps if another `Area3D` had the first area's layer in its mask.

This PR addresses that by to some degree undoing #605 by re-introducing filtering into `_flush_area_enters`.

Re-introducing filtering into `_flush_area_enters` means that #604 will also regress with regards to `Area3D` versus `Area3D`, so some other solution needs to be thought of there.