### PR TITLE
Fixed issue with `Area3D` picking up speculative contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Breaking changes are denoted with ⚠️.
   its transform relative to the joint.
 - Fixed issue where the `total_gravity` property on `PhysicsDirectBodyState3D` would always return a
   zero vector for kinematic bodies.
+- Fixed issue with `Area3D` detecting overlaps slightly outside of its collision shapes.
 
 ## [0.7.0] - 2023-08-29
 

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -238,10 +238,12 @@ bool JoltContactListener3D::_try_evaluate_area_overlap(
 		return false;
 	}
 
+	const bool is_actually_overlapping = p_manifold.mPenetrationDepth >= 0.0f;
+
 	auto evaluate = [&](auto&& p_area, auto&& p_object, const JPH::SubShapeIDPair& p_shape_pair) {
 		const MutexLock write_lock(write_mutex);
 
-		if (p_area.can_monitor(p_object)) {
+		if (is_actually_overlapping && p_area.can_monitor(p_object)) {
 			if (!area_overlaps.has(p_shape_pair)) {
 				area_overlaps.insert(p_shape_pair);
 				area_enters.insert(p_shape_pair);


### PR DESCRIPTION
Fixes #582 (for real this time).

This changes the evaluation of area overlaps that happens in the contact listener to dismiss any contacts that aren't actually the result of overlapping shapes.