### PR TITLE
Updated Jolt to godot-jolt/jolt@15e41af136

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT dd1d4a670c1dd73f7ec8dbaa0cabf9162a31e159
+	GIT_COMMIT 15e41af13629b6b471d62ae11921c1a4f4aeeb03
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/shapes/jolt_custom_decorated_shape.hpp
+++ b/src/shapes/jolt_custom_decorated_shape.hpp
@@ -155,7 +155,8 @@ public:
 	void CollideSoftBodyVertices(
 		JPH::Mat44Arg p_center_of_mass_transform,
 		JPH::Vec3Arg p_scale,
-		JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		JPH::SoftBodyVertex* p_vertices,
+		JPH::uint p_num_vertices,
 		float p_delta_time,
 		JPH::Vec3Arg p_displacement_due_to_gravity,
 		int p_colliding_shape_index
@@ -164,6 +165,7 @@ public:
 			p_center_of_mass_transform,
 			p_scale,
 			p_vertices,
+			p_num_vertices,
 			p_delta_time,
 			p_displacement_due_to_gravity,
 			p_colliding_shape_index

--- a/src/shapes/jolt_custom_empty_shape.hpp
+++ b/src/shapes/jolt_custom_empty_shape.hpp
@@ -106,7 +106,8 @@ public:
 	void CollideSoftBodyVertices(
 		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
 		[[maybe_unused]] JPH::Vec3Arg p_scale,
-		[[maybe_unused]] JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		[[maybe_unused]] JPH::SoftBodyVertex* p_vertices,
+		[[maybe_unused]] JPH::uint p_num_vertices,
 		[[maybe_unused]] float p_delta_time,
 		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
 		[[maybe_unused]] int p_colliding_shape_index

--- a/src/shapes/jolt_custom_motion_shape.hpp
+++ b/src/shapes/jolt_custom_motion_shape.hpp
@@ -150,7 +150,8 @@ public:
 	void CollideSoftBodyVertices(
 		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
 		[[maybe_unused]] JPH::Vec3Arg p_scale,
-		[[maybe_unused]] JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		[[maybe_unused]] JPH::SoftBodyVertex* p_vertices,
+		[[maybe_unused]] JPH::uint p_num_vertices,
 		[[maybe_unused]] float p_delta_time,
 		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
 		[[maybe_unused]] int p_colliding_shape_index

--- a/src/shapes/jolt_custom_ray_shape.hpp
+++ b/src/shapes/jolt_custom_ray_shape.hpp
@@ -126,7 +126,8 @@ public:
 	void CollideSoftBodyVertices(
 		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
 		[[maybe_unused]] JPH::Vec3Arg p_scale,
-		[[maybe_unused]] JPH::Array<JPH::SoftBodyVertex>& p_vertices,
+		[[maybe_unused]] JPH::SoftBodyVertex* p_vertices,
+		[[maybe_unused]] JPH::uint p_num_vertices,
 		[[maybe_unused]] float p_delta_time,
 		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
 		[[maybe_unused]] int p_colliding_shape_index


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@dd1d4a670c1dd73f7ec8dbaa0cabf9162a31e159 to godot-jolt/jolt@15e41af13629b6b471d62ae11921c1a4f4aeeb03 (see diff [here](https://github.com/godot-jolt/jolt/compare/dd1d4a670c1dd73f7ec8dbaa0cabf9162a31e159...15e41af13629b6b471d62ae11921c1a4f4aeeb03)).

This brings in the following relevant changes:

- Multi-threaded soft bodies
- Minor optimization to `JPH::Body::GetInverseInertia`