### PR TITLE
Moved warning about separate thread not being supported

### DIFF
--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -8,7 +8,6 @@
 #include "joints/jolt_slider_joint_impl_3d.hpp"
 #include "objects/jolt_area_impl_3d.hpp"
 #include "objects/jolt_body_impl_3d.hpp"
-#include "servers/jolt_project_settings.hpp"
 #include "shapes/jolt_box_shape_impl_3d.hpp"
 #include "shapes/jolt_capsule_shape_impl_3d.hpp"
 #include "shapes/jolt_concave_polygon_shape_impl_3d.hpp"
@@ -1785,13 +1784,6 @@ void JoltPhysicsServer3D::_set_active(bool p_active) {
 }
 
 void JoltPhysicsServer3D::_init() {
-	if (JoltProjectSettings::should_run_on_separate_thread()) {
-		WARN_PRINT_ONCE(
-			"Running on a separate thread is not currently supported by Godot Jolt. "
-			"Any such value will be ignored."
-		);
-	}
-
 	job_system = new JoltJobSystem();
 }
 

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -74,6 +74,18 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 			return clamp(p_body1.GetRestitution() + p_body2.GetRestitution(), 0.0f, 1.0f);
 		}
 	);
+
+#ifdef GDJ_CONFIG_EDITOR
+	// HACK(mihe): The `EditorLog` class gets initialized fairly late in the application flow, so if
+	// we do this any earlier the warning is only ever going to be emitted to stdout and not the
+	// editor log, hence why this is here.
+	if (JoltProjectSettings::should_run_on_separate_thread()) {
+		WARN_PRINT_ONCE(
+			"Running on a separate thread is not currently supported by Godot Jolt. "
+			"Any such setting will be ignored."
+		);
+	}
+#endif // GDJ_CONFIG_EDITOR
 }
 
 JoltSpace3D::~JoltSpace3D() {


### PR DESCRIPTION
This moves where the warning about this extension's inability to run on a separate thread is emitted.

Previously this was emitted in `PhysicsServer3DExtension::_init`, but this ends up being too early in the application flow, causing the warning to only ever be emitted to stdout and not the editor log.

Now instead it's emitted in the physics space constructor, which is late enough in the application flow for `EditorLog` to be initialized and registered as an error handler, leading to the warning being more prominent.