### PR TITLE
Changed `ConvexPolygonShape3D` to allow for 0 points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `ConvexPolygonShape3D` to no longer emit errors about failing to build the shape when
+  adding one to the scene tree with 0 points.
+
 ## [0.8.0] - 2023-09-28
 
 ### Changed

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -35,6 +35,8 @@ String JoltConvexPolygonShapeImpl3D::to_string() const {
 JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::_build() const {
 	const auto vertex_count = (int32_t)vertices.size();
 
+	QUIET_FAIL_COND_D(vertex_count == 0);
+
 	ERR_FAIL_COND_D_MSG(
 		vertex_count < 3,
 		vformat(


### PR DESCRIPTION
This changes the implementation for `ConvexPolygonShape3D` to allow for 0 points without emitting any errors about failing to build the shape.

This brings `ConvexPolygonShape3D` in line with `ConcavePolygonShape3D` and `HeightMapShape3D`.