### PR TITLE
Updated Jolt to 7df682edda

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 9d63f5a2d1b9e426a54dce6c8979e22ff6004eba
+	GIT_COMMIT 7df682edda5dee5f0445ceba27513f9e623dd758
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@9d63f5a2d1b9e426a54dce6c8979e22ff6004eba to godot-jolt/jolt@7df682edda5dee5f0445ceba27513f9e623dd758 (see diff [here](https://github.com/godot-jolt/jolt/compare/9d63f5a2d1b9e426a54dce6c8979e22ff6004eba...7df682edda5dee5f0445ceba27513f9e623dd758)).

This brings in the following relevant changes:

- Setting frequency/stiffness to 0 for springs will now effectively disable them rather than lock them up.