### PR TITLE
Added project setting for the active edge threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Added
+
+- Added new project setting, "Active Edge Threshold", for tuning the cut-off angle for Jolt's active
+  edge detection, which can help balance trade-offs related to triangle edge collisions.
+
 ### Changed
 
 - Changed `ConvexPolygonShape3D` to no longer emit errors about failing to build the shape when

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -272,6 +272,23 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Solver</td>
+      <td>Active Edge Threshold</td>
+      <td>
+        The cut-off angle for the active edge detection.
+      </td>
+      <td>
+        This angle determines whether or not an edge between two triangles in either a
+        <code>ConcavePolygonShape3D</code> or <code>HeightMapShape3D</code> will be considered
+        "active" or "inactive", where contact with an inactive edge will have its normal overridden
+        to instead be the surface normal of the triangle.
+        <br><br>Setting this too low can result in ghost collisions. Setting this too high can
+        result in things like <code>RigidBody3D</code> sinking into triangle edges or
+        <code>move_and_slide</code> behaving in weird ways when going over or pressing up against
+        triangle edges.
+      </td>
+    </tr>
+    <tr>
+      <td>Solver</td>
       <td>Bounce Velocity Threshold</td>
       <td>
         The minimum velocity needed before a collision can be elastic.

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -18,6 +18,7 @@ constexpr char RECOVERY_AMOUNT[] = "physics/jolt_3d/kinematics/recovery_amount";
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
 constexpr char VELOCITY_ITERATIONS[] = "physics/jolt_3d/solver/velocity_iterations";
 constexpr char POSITION_CORRECTION[] = "physics/jolt_3d/solver/position_correction";
+constexpr char ACTIVE_EDGE_THRESHOLD[] = "physics/jolt_3d/solver/active_edge_threshold";
 constexpr char BOUNCE_VELOCITY_THRESHOLD[] = "physics/jolt_3d/solver/bounce_velocity_threshold";
 constexpr char CONTACT_DISTANCE[] = "physics/jolt_3d/solver/contact_speculative_distance";
 constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_penetration";
@@ -129,6 +130,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
 	register_setting_ranged(POSITION_CORRECTION, 20.0f, U"0,100,0.1,suffix:%");
+	register_setting_ranged(ACTIVE_EDGE_THRESHOLD, Math::deg_to_rad(50.0f), U"0,90,0.01,radians");
 	register_setting_hinted(BOUNCE_VELOCITY_THRESHOLD, 1.0f, U"suffix:m/s");
 	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.001,or_greater,suffix:m");
 	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.001,or_greater,suffix:m");
@@ -198,6 +200,11 @@ int32_t JoltProjectSettings::get_position_iterations() {
 
 float JoltProjectSettings::get_position_correction() {
 	static const auto value = get_setting<float>(POSITION_CORRECTION) / 100.0f;
+	return value;
+}
+
+float JoltProjectSettings::get_active_edge_threshold() {
+	static const auto value = Math::cos(get_setting<float>(ACTIVE_EDGE_THRESHOLD));
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -28,6 +28,8 @@ public:
 
 	static float get_position_correction();
 
+	static float get_active_edge_threshold();
+
 	static float get_bounce_velocity_threshold();
 
 	static float get_contact_distance();

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -1,12 +1,7 @@
 #include "jolt_concave_polygon_shape_impl_3d.hpp"
 
+#include "servers/jolt_project_settings.hpp"
 #include "shapes/jolt_custom_double_sided_shape.hpp"
-
-namespace {
-
-const float ACTIVE_EDGE_THRESHOLD = Math::cos(Math::deg_to_rad(50.0f));
-
-} // namespace
 
 Variant JoltConcavePolygonShapeImpl3D::get_data() const {
 	Dictionary data;
@@ -88,7 +83,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 	}
 
 	JPH::MeshShapeSettings shape_settings(jolt_faces);
-	shape_settings.mActiveEdgeCosThresholdAngle = ACTIVE_EDGE_THRESHOLD;
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -1,10 +1,6 @@
 #include "jolt_height_map_shape_impl_3d.hpp"
 
-namespace {
-
-const float ACTIVE_EDGE_THRESHOLD = Math::cos(Math::deg_to_rad(50.0f));
-
-} // namespace
+#include "servers/jolt_project_settings.hpp"
 
 Variant JoltHeightMapShapeImpl3D::get_data() const {
 	Dictionary data;
@@ -118,7 +114,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_height_field() const {
 	);
 
 	shape_settings.mBitsPerSample = shape_settings.CalculateBitsPerSampleForError(0.0f);
-	shape_settings.mActiveEdgeCosThresholdAngle = ACTIVE_EDGE_THRESHOLD;
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
@@ -182,7 +178,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_mesh() const {
 	}
 
 	JPH::MeshShapeSettings shape_settings(std::move(vertices), std::move(indices));
-	shape_settings.mActiveEdgeCosThresholdAngle = ACTIVE_EDGE_THRESHOLD;
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 


### PR DESCRIPTION
Fixes #634.

This adds a new project setting called "Active Edge Threshold" that determines the cut-off angle for Jolt's active edge detection, which is what helps prevent collisions with triangle edges.

This has until now been hardcoded at 50 degrees (per #546) but with different projects having different tolerances to the trade-offs involved in changing this I will go ahead and make it configurable through a project setting instead.