### PR TITLE
Exposed step(), save_state(), and restore_state() to GDScript

### DIFF
--- a/examples/project.godot
+++ b/examples/project.godot
@@ -29,6 +29,29 @@ window/size/viewport_height=900
 
 import/blender/enabled=false
 
+[input]
+
+rewind={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+forward={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+step={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+flip_physics_active={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
+
 [physics]
 
 3d/physics_engine="JoltPhysics3D"

--- a/examples/scenes/shapes/step_save_restore.gd
+++ b/examples/scenes/shapes/step_save_restore.gd
@@ -1,0 +1,81 @@
+extends Node3D
+# This script is used to record and replay physics states
+
+# The number of states to save
+const NUMBER_OF_STATES_TO_SAVE: int = 250
+
+# The amount of time between each physics step
+var PHYSICS_STEP_DELTA: float = 1.0 / Engine.physics_ticks_per_second
+
+# Holds an array of states to replay
+var state_array: Array[PackedByteArray]
+
+# Keeps track of how many states have been saved
+var states_saved: int = 0
+
+# Keeps track of the current state to restore
+var state_index: int = 0
+
+# Whether or not we are recording state
+var is_recording: bool = true
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	state_array.resize(NUMBER_OF_STATES_TO_SAVE)
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	pass
+
+
+func _physics_process(_delta):
+	# When the scene starts, we want to record the initial states
+	if is_recording:
+		# Save the state
+		state_array[state_index] = JoltPhysicsServer3D.save_state()
+		state_index += 1
+		states_saved += 1
+
+		# If we have saved enough states, stop recording
+		if states_saved >= NUMBER_OF_STATES_TO_SAVE:
+			is_recording = false
+
+		print("Saved state " + str(states_saved) + " of " + str(NUMBER_OF_STATES_TO_SAVE))
+	else:
+		# If we are not recording, we want to restore states
+
+		# If the user presses the rewind (left arrow) button, we want to restore the state
+		if Input.is_action_pressed("rewind"):
+			print("Restoring state [rewind]" + str(state_index))
+			state_index -= 1
+			if state_index < 0:
+				state_index = states_saved - 1
+			
+			# Set the physics server to active so that the state can be restored
+			JoltPhysicsServer3D.set_active(true)
+			JoltPhysicsServer3D.restore_state(state_array[state_index])
+
+		# If the user presses the forward (right arrow) button, we want to restore the state
+		elif Input.is_action_pressed("forward"):
+			print("Restoring state [forward]" + str(state_index))
+			state_index += 1
+			if state_index >= states_saved:
+				state_index = 0
+			
+			# Set the physics server to active so that the state can be restored
+			JoltPhysicsServer3D.set_active(true)
+			JoltPhysicsServer3D.restore_state(state_array[state_index])
+
+		# If the user presses the step (down arrow) button, we want to step the simulation forward
+		elif Input.is_action_just_pressed("step"):
+			print("Stepping state by delta: " + str(PHYSICS_STEP_DELTA))
+			
+			JoltPhysicsServer3D.set_active(true)
+			JoltPhysicsServer3D.step(PHYSICS_STEP_DELTA)
+
+		else:
+			# If the user is not pressing any buttons, we want to pause the simulation
+			JoltPhysicsServer3D.set_active(false)
+			
+ 

--- a/examples/scenes/shapes/step_save_restore.tscn
+++ b/examples/scenes/shapes/step_save_restore.tscn
@@ -1,0 +1,66 @@
+[gd_scene load_steps=12 format=3 uid="uid://m7vair4cw4h0"]
+
+[ext_resource type="Script" path="res://scenes/shapes/step_save_restore.gd" id="1_1vw41"]
+[ext_resource type="Environment" uid="uid://cgl5t5rlv6o6v" path="res://scenes/common/environments/default.tres" id="2_ilxr6"]
+[ext_resource type="Script" path="res://scenes/common/scripts/free_look_camera.gd" id="3_xe3cx"]
+[ext_resource type="PackedScene" uid="uid://boging3dkleyk" path="res://scenes/shapes/entities/separation_rays/separation_rays.tscn" id="4_lpl74"]
+[ext_resource type="PackedScene" uid="uid://csdhohsaec6yg" path="res://scenes/shapes/entities/sphere/sphere.tscn" id="5_lk5td"]
+[ext_resource type="PackedScene" uid="uid://bwdap6iekb8rq" path="res://scenes/shapes/entities/box/box.tscn" id="6_ymhpp"]
+[ext_resource type="PackedScene" uid="uid://c466gt3ufxlxl" path="res://scenes/shapes/entities/capsule/capsule.tscn" id="7_gkyqq"]
+[ext_resource type="PackedScene" uid="uid://dc0dbimb6mrup" path="res://scenes/shapes/entities/cylinder/cylinder.tscn" id="8_rpjv4"]
+[ext_resource type="PackedScene" uid="uid://bp26fxa72vokv" path="res://scenes/shapes/entities/convex_polygon/convex_polygon.tscn" id="9_ram5d"]
+[ext_resource type="PackedScene" uid="uid://dl64ew24f7t8w" path="res://scenes/shapes/entities/height_map/height_map.tscn" id="10_w0s1l"]
+[ext_resource type="PackedScene" uid="uid://bmdy4wkvvlcws" path="res://scenes/shapes/entities/concave_polygon/concave_polygon.tscn" id="11_gttd1"]
+
+[node name="Shapes" type="Node3D"]
+script = ExtResource("1_1vw41")
+
+[node name="Environment" type="WorldEnvironment" parent="."]
+environment = ExtResource("2_ilxr6")
+
+[node name="Sun" type="DirectionalLight3D" parent="."]
+transform = Transform3D(-0.825549, -0.544985, 0.146493, 0, 0.259587, 0.965719, -0.56433, 0.797249, -0.214302, 0, 0, 0)
+light_bake_mode = 0
+shadow_enabled = true
+
+[node name="Camera" type="Camera3D" parent="."]
+transform = Transform3D(-0.707107, -0.353553, 0.612372, 0, 0.866026, 0.5, -0.707107, 0.353553, -0.612372, 8, 10, -8)
+current = true
+script = ExtResource("3_xe3cx")
+initial_speed = null
+interpolation_speed = null
+mouse_sensitivity = null
+speed_step_factor = null
+
+[node name="DebugGeometry" type="JoltDebugGeometry3D" parent="."]
+visible = false
+
+[node name="SeparationRays" parent="." instance=ExtResource("4_lpl74")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 12.5, 0)
+continuous_cd = true
+
+[node name="Sphere" parent="." instance=ExtResource("5_lk5td")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11, 0)
+continuous_cd = true
+
+[node name="Box" parent="." instance=ExtResource("6_ymhpp")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.5, 0)
+continuous_cd = true
+
+[node name="Capsule" parent="." instance=ExtResource("7_gkyqq")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 7.5, 0)
+continuous_cd = true
+
+[node name="Cylinder" parent="." instance=ExtResource("8_rpjv4")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.5, 0)
+continuous_cd = true
+
+[node name="ConvexPolygon" parent="." instance=ExtResource("9_ram5d")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0)
+continuous_cd = true
+
+[node name="HeightMap" parent="." instance=ExtResource("10_w0s1l")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+
+[node name="ConcavePolygon" parent="." instance=ExtResource("11_gttd1")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -599,9 +599,17 @@ public:
 
 	void _free_rid(const RID& p_rid) override;
 
+	void set_active(bool active);
+
 	void _set_active(bool p_active) override;
 
 	void _init() override;
+
+	godot::PackedByteArray save_state();
+
+	void restore_state(godot::PackedByteArray state_recorder_string);
+
+	void step(double delta);
 
 	void _step(double p_step) override;
 


### PR DESCRIPTION
### Description ###
The `step()`, `save_state()`, and `restore_state()` functionality of Jolt has been exposed to GDScript. Alongside those, the physic engine's `set_active()` function has been exposed to allow pausing/unpausing the simulation.

### Usecase ###
I wanted my game server to be able to step through the physics simulation as quickly as possible and have it save state every physics frame along the way in order to then send it to the game clients to have them replay, pause, fast-forward, etc. the "replay" of the physics simulation.

### Notes ###

- I do not have much experience with Jolt or godot-jolt, so I am unsure if this is the most proper way to expose this functionality. I'm happy to take feedback and tweak this pull request as needed. If you think that there is a better way to go about this and you want to be the one to make the change in this PR, please do so!
- I have included an example Godot scene to test this functionality out. Please review the `step_save_restore.gd` file for an example of how this functionality can be used.

Appreciate ya!