### PR TITLE
Fixed crash in editor plugin when running with Godot 4.2

### DIFF
--- a/src/servers/jolt_editor_plugin.cpp
+++ b/src/servers/jolt_editor_plugin.cpp
@@ -13,23 +13,27 @@ void JoltEditorPlugin::_enter_tree() {
 	EditorInterface* editor_interface = get_editor_interface();
 	Control* base_control = editor_interface->get_base_control();
 
-	// HACK(mihe): For whatever reason the editor startup time takes a significant hit with every
-	// icon added unless we duplicate the theme first and manipulate that instead.
-	Ref<Theme> theme = base_control->get_theme()->duplicate();
+	Ref<Theme> old_theme = base_control->get_theme();
 
-	Ref<Texture2D> icon_pin = theme->get_icon("PinJoint3D", "EditorIcons");
-	Ref<Texture2D> icon_hinge = theme->get_icon("HingeJoint3D", "EditorIcons");
-	Ref<Texture2D> icon_slider = theme->get_icon("SliderJoint3D", "EditorIcons");
-	Ref<Texture2D> icon_cone_twist = theme->get_icon("ConeTwistJoint3D", "EditorIcons");
-	Ref<Texture2D> icon_6dof = theme->get_icon("Generic6DOFJoint3D", "EditorIcons");
+	if (old_theme.is_valid()) {
+		// HACK(mihe): For whatever reason the editor startup time takes a significant hit with
+		// every icon added unless we duplicate the theme first and manipulate that instead.
+		Ref<Theme> new_theme = old_theme->duplicate();
 
-	theme->set_icon("JoltPinJoint3D", "EditorIcons", icon_pin);
-	theme->set_icon("JoltHingeJoint3D", "EditorIcons", icon_hinge);
-	theme->set_icon("JoltSliderJoint3D", "EditorIcons", icon_slider);
-	theme->set_icon("JoltConeTwistJoint3D", "EditorIcons", icon_cone_twist);
-	theme->set_icon("JoltGeneric6DOFJoint3D", "EditorIcons", icon_6dof);
+		Ref<Texture2D> icon_pin = new_theme->get_icon("PinJoint3D", "EditorIcons");
+		Ref<Texture2D> icon_hinge = new_theme->get_icon("HingeJoint3D", "EditorIcons");
+		Ref<Texture2D> icon_slider = new_theme->get_icon("SliderJoint3D", "EditorIcons");
+		Ref<Texture2D> icon_cone_twist = new_theme->get_icon("ConeTwistJoint3D", "EditorIcons");
+		Ref<Texture2D> icon_6dof = new_theme->get_icon("Generic6DOFJoint3D", "EditorIcons");
 
-	base_control->set_theme(theme);
+		new_theme->set_icon("JoltPinJoint3D", "EditorIcons", icon_pin);
+		new_theme->set_icon("JoltHingeJoint3D", "EditorIcons", icon_hinge);
+		new_theme->set_icon("JoltSliderJoint3D", "EditorIcons", icon_slider);
+		new_theme->set_icon("JoltConeTwistJoint3D", "EditorIcons", icon_cone_twist);
+		new_theme->set_icon("JoltGeneric6DOFJoint3D", "EditorIcons", icon_6dof);
+
+		base_control->set_theme(new_theme);
+	}
 
 	joint_gizmo_plugin = Ref(memnew(JoltJointGizmoPlugin3D(editor_interface)));
 	add_node_3d_gizmo_plugin(joint_gizmo_plugin);


### PR DESCRIPTION
It appears that the theming API had a breaking change in 4.2 that causes `get_editor_interface()->get_base_control()->get_theme()` to return null. You're now instead meant to do `get_editor_interface()->get_editor_theme()`, but since this new API isn't available in the 4.1 bindings that we're using we're forced to instead just skip adding the icons for the substitute joint nodes.

Fixes #600.
Fixes #619.
Fixes #627.
Fixes #629.