### PR TITLE
Updated godot-cpp to 4.1.2

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT a69c980bfbb4dcd851eb2cf29080a62c8428c735
+	GIT_COMMIT de9291384f6885eea67ef640864edf07b06f0ffe
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES

--- a/src/joints/jolt_generic_6dof_joint.hpp
+++ b/src/joints/jolt_generic_6dof_joint.hpp
@@ -456,5 +456,5 @@ private:
 	bool angular_spring_enabled[AXIS_COUNT] = {};
 };
 
-VARIANT_ENUM_CAST(JoltGeneric6DOFJoint3D::Param);
-VARIANT_ENUM_CAST(JoltGeneric6DOFJoint3D::Flag);
+VARIANT_ENUM_CAST(JoltGeneric6DOFJoint3D::Param)
+VARIANT_ENUM_CAST(JoltGeneric6DOFJoint3D::Flag)

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -760,11 +760,11 @@ private:
 	bool flushing_queries = false;
 };
 
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointFlagJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointParamJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointFlagJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointParamJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointFlagJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::G6DOFJointAxisParamJolt);
-VARIANT_ENUM_CAST(JoltPhysicsServer3D::G6DOFJointAxisFlagJolt);
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointParamJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::HingeJointFlagJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointParamJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::SliderJointFlagJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointParamJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::ConeTwistJointFlagJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::G6DOFJointAxisParamJolt)
+VARIANT_ENUM_CAST(JoltPhysicsServer3D::G6DOFJointAxisFlagJolt)

--- a/src/spaces/jolt_debug_geometry_3d.hpp
+++ b/src/spaces/jolt_debug_geometry_3d.hpp
@@ -88,4 +88,4 @@ private:
 #endif // JPH_DEBUG_RENDERER
 };
 
-VARIANT_ENUM_CAST(JoltDebugGeometry3D::ColorScheme);
+VARIANT_ENUM_CAST(JoltDebugGeometry3D::ColorScheme)


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@a69c980bfbb4dcd851eb2cf29080a62c8428c735 aka 4.1.1-stable to godot-jolt/godot-cpp@de9291384f6885eea67ef640864edf07b06f0ffe aka 4.1.2-stable (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/a69c980bfbb4dcd851eb2cf29080a62c8428c735...de9291384f6885eea67ef640864edf07b06f0ffe)).