### PR TITLE
Fixed null error after freeing a `move_and_slide` platform

### DIFF
--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1111,7 +1111,11 @@ bool JoltPhysicsServer3D::_body_test_motion(
 
 PhysicsDirectBodyState3D* JoltPhysicsServer3D::_body_get_direct_state(const RID& p_body) {
 	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
-	ERR_FAIL_NULL_D(body);
+
+	// Unlike most other server methods this one is meant to quietly return null if the body has
+	// since been freed, which is used in places like `move_and_slide` to determine whether a
+	// previously used platform has been freed or not.
+	QUIET_FAIL_NULL_D(body);
 
 	return body->get_direct_state();
 }


### PR DESCRIPTION
Fixes #645.

This changes `JoltPhysicsServer3D::_body_get_direct_state` to no longer emit an error if you pass it an invalid RID, as `move_and_slide` expects this method to be able to return null without error in such cases, as seen [here](https://github.com/godotengine/godot/blob/a574c0296b38d5f786f249b12e6251e562c528cc/scene/3d/physics_body_3d.cpp#L1191-L1199).