### PR TITLE
Removed adding of debug contacts for area/sensor overlaps

### DIFF
--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -36,7 +36,7 @@ void JoltContactListener3D::OnContactAdded(
 	_try_evaluate_area_overlap(p_body1, p_body2, p_manifold);
 
 #ifdef GDJ_CONFIG_EDITOR
-	_try_add_debug_contacts(p_manifold);
+	_try_add_debug_contacts(p_body1, p_body2, p_manifold);
 #endif // GDJ_CONFIG_EDITOR
 }
 
@@ -52,7 +52,7 @@ void JoltContactListener3D::OnContactPersisted(
 	_try_evaluate_area_overlap(p_body1, p_body2, p_manifold);
 
 #ifdef GDJ_CONFIG_EDITOR
-	_try_add_debug_contacts(p_manifold);
+	_try_add_debug_contacts(p_body1, p_body2, p_manifold);
 #endif // GDJ_CONFIG_EDITOR
 }
 
@@ -323,7 +323,15 @@ bool JoltContactListener3D::_try_remove_area_overlap(const JPH::SubShapeIDPair& 
 
 #ifdef GDJ_CONFIG_EDITOR
 
-bool JoltContactListener3D::_try_add_debug_contacts(const JPH::ContactManifold& p_manifold) {
+bool JoltContactListener3D::_try_add_debug_contacts(
+	const JPH::Body& p_body1,
+	const JPH::Body& p_body2,
+	const JPH::ContactManifold& p_manifold
+) {
+	if (p_body1.IsSensor() || p_body2.IsSensor()) {
+		return false;
+	}
+
 	const int64_t max_count = debug_contacts.size();
 
 	if (max_count == 0) {

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -123,7 +123,11 @@ private:
 	bool _try_remove_area_overlap(const JPH::SubShapeIDPair& p_shape_pair);
 
 #ifdef GDJ_CONFIG_EDITOR
-	bool _try_add_debug_contacts(const JPH::ContactManifold& p_manifold);
+	bool _try_add_debug_contacts(
+		const JPH::Body& p_body1,
+		const JPH::Body& p_body2,
+		const JPH::ContactManifold& p_manifold
+	);
 #endif // GDJ_CONFIG_EDITOR
 
 	void _flush_contacts();


### PR DESCRIPTION
Fixes #649.

This changes how the "Visible Collision Shapes" debug rendering behaves when you have overlaps between an `Area3D` and a `RigidBody3D`, `CharacterBody3D` or `StaticBody3D`.

Previously it would add any and all contact points as generated by Jolt as a debug contact, including those generated by `Area3D`, but now instead it will omit all contacts whenever either of the two bodies is an `Area3D`, to better match how the debug rendering behaves in Godot Physics.