### PR TITLE
Updated Jolt to 912bdbafb9

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -27,7 +27,7 @@ set(dev_definitions
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 7df682edda5dee5f0445ceba27513f9e623dd758
+	GIT_COMMIT 912bdbafb9fa8b155c99a510a270a18e9bb7d494
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
Related to #353 and #354.

This bumps Jolt from godot-jolt/jolt@7df682edda5dee5f0445ceba27513f9e623dd758 to godot-jolt/jolt@912bdbafb9fa8b155c99a510a270a18e9bb7d494 (see diff [here](https://github.com/godot-jolt/jolt/compare/7df682edda5dee5f0445ceba27513f9e623dd758...912bdbafb9fa8b155c99a510a270a18e9bb7d494)).

This brings in the following relevant changes:

- Added support for Android ARM32/x86 architectures
- Added support for iOS versions older than iOS 13
- Added support for macOS versions older than macOS 10.15 (Catalina)
- Fixed warnings produced with Android NDK 26.1.10909125