### PR TITLE
Changed code-signing for iOS to exclude notarization

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -179,7 +179,7 @@ jobs:
           APPLE_DEV_ID: ${{ secrets.APPLE_DEV_ID }}
           APPLE_DEV_TEAM_ID: ${{ secrets.APPLE_DEV_TEAM_ID }}
           APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
-        run: gci -R ./dist/*.framework | ./scripts/ci_sign_macos.ps1
+        run: gci -R ./dist/*.framework | ./scripts/ci_sign_macos.ps1 -Notarize
 
       - name: Upload builds
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This adds an opt-in `-Notarize` switch to the `ci_sign_macos.ps1` script, which lets iOS builds exclude notarization, since it doesn't really make any sense to do for iOS, given that there's no Gatekeeper equivalent, as I understand it.

Consumers of these frameworks will also need to re-sign the actual app that bundles the frameworks anyway.