### PR TITLE
Removed iOS code-signing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -179,7 +179,7 @@ jobs:
           APPLE_DEV_ID: ${{ secrets.APPLE_DEV_ID }}
           APPLE_DEV_TEAM_ID: ${{ secrets.APPLE_DEV_TEAM_ID }}
           APPLE_DEV_PASSWORD: ${{ secrets.APPLE_DEV_PASSWORD }}
-        run: gci -R ./dist/*.framework | ./scripts/ci_sign_macos.ps1 -Notarize
+        run: gci -R ./dist/*.framework | ./scripts/ci_sign_macos.ps1
 
       - name: Upload builds
         uses: actions/upload-artifact@v3
@@ -224,13 +224,6 @@ jobs:
           platform: macos-ios
           editor: true
           config: distribution
-
-      - name: Sign frameworks
-        shell: pwsh
-        env:
-          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
-          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
-        run: gci -R ./dist/*.framework | ./scripts/ci_sign_macos.ps1
 
       - name: Upload builds
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This reverts #665.

I realized that the certificate used to sign macOS builds are specifically meant for macOS binaries distributed outside of the App Store, and as such is likely just nonsense in the context of an iOS framework. With that in mind, I decided to just remove the signing for iOS altogether.

While I might be able to sign with an "Apple Distribution" certificate, there's really no point in going through the hassle of managing a separate certificate for something that will be overwritten as soon as the consumer of the framework deploys their app.