### PR TITLE
Fixed issue with point gravity being zero when distance is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes are denoted with ⚠️.
 
 ### Changed
 
+- ⚠️ Changed `gravity_point_unit_distance` for `Area3D` to result in a constant gravity when set to
+  zero, rather than resulting in a zero gravity, to match Godot Physics.
 - ⚠️ Changed so that ray-casts using the `hit_from_inside` parameter report a zero normal when
   hitting a convex shape from inside, to match Godot Physics.
 - Changed the `space_get_contacts` method of `PhysicsServer3D` (and thus also the "Visible Collision

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -203,6 +203,10 @@ Vector3 JoltAreaImpl3D::compute_gravity(const Vector3& p_position, bool p_lock) 
 	const float to_point_dist_sq = max(to_point.length_squared(), CMP_EPSILON);
 	const Vector3 to_point_dir = to_point / Math::sqrt(to_point_dist_sq);
 
+	if (point_gravity_distance == 0.0f) {
+		return to_point_dir * gravity;
+	}
+
 	const float gravity_dist_sq = point_gravity_distance * point_gravity_distance;
 
 	return to_point_dir * (gravity * gravity_dist_sq / to_point_dist_sq);


### PR DESCRIPTION
This fixes an issue where if you'd set the `gravity_point_unit_distance` of an `Area3D` to zero, it would always result in that `Area3D` contributing a zero gravity vector. Now instead it will result in a constant gravity (as specified by the `gravity` property) pointing towards the center of the area, which is how Godot Physics behaves as well.