### PR TITLE
Updated Jolt to a1a68107c1

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -25,9 +25,15 @@ set(dev_definitions
 	JPH_DEBUG_RENDERER
 )
 
+if(ANDROID)
+	set(override_cxx_flags_arg -DOVERRIDE_CXX_FLAGS=FALSE)
+else()
+	set(override_cxx_flags_arg "")
+endif()
+
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT d8e0fec253f3e3f32c1accbe58427cd47a93cd40
+	GIT_COMMIT a1a68107c15c83d8e47987b680dfaba34acc4a8d
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt
@@ -65,6 +71,7 @@ gdj_add_external_library(jolt "${configurations}"
 		-DUSE_SSE4_2=${GDJ_USE_SSE4_2}
 		-DUSE_SSE4_1=${GDJ_USE_SSE4_2}
 		-DUSE_STATIC_MSVC_RUNTIME_LIBRARY=${GDJ_STATIC_RUNTIME_LIBRARY}
+		${override_cxx_flags_arg}
 	LIBRARY_CONFIG_DEBUG Debug
 	LIBRARY_CONFIG_DEVELOPMENT Release
 	LIBRARY_CONFIG_DISTRIBUTION Distribution


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@d8e0fec253f3e3f32c1accbe58427cd47a93cd40 to godot-jolt/jolt@a1a68107c15c83d8e47987b680dfaba34acc4a8d (see diff [here](https://github.com/godot-jolt/jolt/compare/d8e0fec253f3e3f32c1accbe58427cd47a93cd40...a1a68107c15c83d8e47987b680dfaba34acc4a8d)).

This brings in the following relevant changes:

- Adds the `OVERRIDE_CXX_FLAGS` CMake option to allow Android to use largely the same CMake code path as other Unix-based platforms