### PR TITLE
Updated Jolt to 1fef923520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Breaking changes are denoted with ⚠️.
 
 - Fixed issue where an error saying `Parameter "body" is null` would be emitted after freeing
   certain bodies while they were in contact with a `CharacterBody3D`.
+- Fixed issue where a `RigidBody3D` could sometimes still be moved by another `RigidBody3D` despite
+  the first body not having the second body in its collision mask.
 
 ## [0.9.0] - 2023-10-12
 

--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT a1a68107c15c83d8e47987b680dfaba34acc4a8d
+	GIT_COMMIT 1fef92352095d501675e8514c4c7a7400c6d370c
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@a1a68107c15c83d8e47987b680dfaba34acc4a8d to godot-jolt/jolt@1fef92352095d501675e8514c4c7a7400c6d370c (see diff [here](https://github.com/godot-jolt/jolt/compare/a1a68107c15c83d8e47987b680dfaba34acc4a8d...1fef92352095d501675e8514c4c7a7400c6d370c)).

This brings in the following relevant changes:

- Fixed mass scaling not applied for CCD objects & during solve position constraints