### PR TITLE
Fixed custom integration callback being called while sleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where the callback passed to `body_set_force_integration_callback` could be called
+  even when the body is sleeping.
+
 ## [0.10.0] - 2023-11-12
 
 ### Changed

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -696,9 +696,9 @@ void JoltBodyImpl3D::call_queries([[maybe_unused]] JPH::Body& p_jolt_body) {
 		arguments[0] = get_direct_state();
 
 		body_state_callback.callv(arguments);
-
-		sync_state = false;
 	}
+
+	sync_state = false;
 }
 
 void JoltBodyImpl3D::pre_step(float p_step, JPH::Body& p_jolt_body) {


### PR DESCRIPTION
This fixes an issue where if you provided a callback to the `body_set_force_integration_callback` method of `PhysicsServer3D` for a body that was explicitly created through the physics server then it could still sometimes get called while the body is sleeping.