### PR TITLE
Updated Jolt to 4ff703d115

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 1fef92352095d501675e8514c4c7a7400c6d370c
+	GIT_COMMIT 4ff703d11506290383fc82e926f1eaad728f0e01
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@1fef92352095d501675e8514c4c7a7400c6d370c to godot-jolt/jolt@4ff703d11506290383fc82e926f1eaad728f0e01 (see diff [here](https://github.com/godot-jolt/jolt/compare/1fef92352095d501675e8514c4c7a7400c6d370c...4ff703d11506290383fc82e926f1eaad728f0e01)).

This brings in the following relevant changes:

- Reduced memory usage for contact points