### PR TITLE
Fixed error when building for Android from Visual Studio prompt

### DIFF
--- a/cmake/GodotJoltSetup.cmake
+++ b/cmake/GodotJoltSetup.cmake
@@ -30,7 +30,7 @@ if(NOT DEFINED GDJ_TARGET_ARCHITECTURES)
 	endif()
 endif()
 
-if(DEFINED ENV{VSCMD_ARG_TGT_ARCH})
+if(MSVC AND DEFINED ENV{VSCMD_ARG_TGT_ARCH})
 	if(NOT $ENV{VSCMD_ARG_TGT_ARCH} STREQUAL ${GDJ_TARGET_ARCHITECTURES})
 		message(FATAL_ERROR
 			"Mismatched target architectures. The current Visual Studio environment is set up for "


### PR DESCRIPTION
When running the configure step for any of the Android configurations on Windows while in any of the Visual Studio command prompts, you would be met with an error saying "Mismatched target architectures".

This isn't meant to happen when cross-compiling for Android, since the Visual Studio toolchain isn't used at all in that case, so it shouldn't really matter which command prompt you're building from.

This PR fixes that by making the error exclusive to `MSVC` targets.