### PR TITLE
Make cast_motion return whether or not it hit anything.

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -243,7 +243,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	_cast_motion_impl(
+	return _cast_motion_impl(
 		*jolt_shape,
 		transform_com,
 		scale,
@@ -257,8 +257,6 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 		*p_closest_safe,
 		*p_closest_unsafe
 	);
-
-	return true;
 }
 
 bool JoltPhysicsDirectSpaceState3D::_collide_shape(


### PR DESCRIPTION
Not strictly necessary since the bool isn't exposed to godot's scripting, but in my case I'm building godot-jolt as an engine module with a set of very funky workarounds. ( https://github.com/EIRTeam/godot-jolt/ ) so it would be nice if the behavior matches godotphysics