### PR TITLE
Fixed deadlock when having multiple active physics spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes are denoted with ⚠️.
 
 ### Fixed
 
+- Fixed issue with project eventually freezing up when having many active physics spaces.
 - Fixed issue where the callback passed to `body_set_force_integration_callback` could be called
   even when the body is sleeping.
 

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -1796,13 +1796,13 @@ void JoltPhysicsServer3D::_step(double p_step) {
 		return;
 	}
 
-	job_system->pre_step();
-
 	for (JoltSpace3D* active_space : active_spaces) {
-		active_space->step((float)p_step);
-	}
+		job_system->pre_step();
 
-	job_system->post_step();
+		active_space->step((float)p_step);
+
+		job_system->post_step();
+	}
 }
 
 void JoltPhysicsServer3D::_flush_queries() {

--- a/src/spaces/jolt_job_system.cpp
+++ b/src/spaces/jolt_job_system.cpp
@@ -19,9 +19,7 @@ void JoltJobSystem::pre_step() {
 }
 
 void JoltJobSystem::post_step() {
-	while (Job* job = Job::pop_completed()) {
-		jobs.destruct(job);
-	}
+	_reclaim_jobs();
 }
 
 #ifdef GDJ_CONFIG_EDITOR
@@ -151,6 +149,8 @@ JPH::JobHandle JoltJobSystem::CreateJob(
 		);
 
 		OS::get_singleton()->delay_usec(100);
+
+		_reclaim_jobs();
 	}
 
 	// This will increment the job's reference count, so must happen before we queue the job
@@ -175,4 +175,10 @@ void JoltJobSystem::QueueJobs(JPH::JobSystem::Job** p_jobs, JPH::uint p_job_coun
 
 void JoltJobSystem::FreeJob(JPH::JobSystem::Job* p_job) {
 	Job::push_completed(static_cast<Job*>(p_job));
+}
+
+void JoltJobSystem::_reclaim_jobs() {
+	while (Job* job = Job::pop_completed()) {
+		jobs.destruct(job);
+	}
 }

--- a/src/spaces/jolt_job_system.hpp
+++ b/src/spaces/jolt_job_system.hpp
@@ -66,6 +66,8 @@ private:
 
 	void FreeJob(JPH::JobSystem::Job* p_job) override;
 
+	void _reclaim_jobs();
+
 #ifdef GDJ_CONFIG_EDITOR
 	// HACK(mihe): We use `const void*` here to avoid the cost of hashing the actual string, since
 	// the job names are always literals and as such will point to the same address every time.


### PR DESCRIPTION
Fixes #554.
Fixes #684.

This fixes an issue where if you had many active physics spaces you would eventually end up in a deadlock/freeze, due to the job system running out of available jobs.

The solution was simply to reclaim any pending jobs after stepping every physics space, rather than after having stepped all of them.