### PR TITLE
Improved error messages for methods requiring a physics space

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -250,7 +250,15 @@ void JoltBodyImpl3D::set_can_sleep(bool p_enabled, bool p_lock) {
 }
 
 Basis JoltBodyImpl3D::get_principal_inertia_axes(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve principal inertia axes of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
 
 	if (is_static() || is_kinematic()) {
 		return {};
@@ -269,7 +277,15 @@ Basis JoltBodyImpl3D::get_principal_inertia_axes(bool p_lock) const {
 }
 
 Vector3 JoltBodyImpl3D::get_inverse_inertia(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve inverse inertia of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
 
 	if (is_static() || is_kinematic()) {
 		return {};
@@ -282,7 +298,15 @@ Vector3 JoltBodyImpl3D::get_inverse_inertia(bool p_lock) const {
 }
 
 Basis JoltBodyImpl3D::get_inverse_inertia_tensor(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve inverse inertia tensor of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
 
 	if (is_static() || is_kinematic()) {
 		return {};
@@ -434,7 +458,16 @@ void JoltBodyImpl3D::reset_mass_properties(bool p_lock) {
 }
 
 void JoltBodyImpl3D::apply_force(const Vector3& p_force, const Vector3& p_position, bool p_lock) {
-	ERR_FAIL_NULL(space);
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to apply force to '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
 	QUIET_FAIL_COND(!is_rigid());
 
 	if (custom_integrator || p_force == Vector3()) {
@@ -450,7 +483,16 @@ void JoltBodyImpl3D::apply_force(const Vector3& p_force, const Vector3& p_positi
 }
 
 void JoltBodyImpl3D::apply_central_force(const Vector3& p_force, bool p_lock) {
-	ERR_FAIL_NULL(space);
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to apply central force to '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
 	QUIET_FAIL_COND(!is_rigid());
 
 	if (custom_integrator || p_force == Vector3()) {
@@ -470,7 +512,16 @@ void JoltBodyImpl3D::apply_impulse(
 	const Vector3& p_position,
 	bool p_lock
 ) {
-	ERR_FAIL_NULL(space);
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to apply impulse to '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
 	QUIET_FAIL_COND(!is_rigid());
 
 	if (p_impulse == Vector3()) {
@@ -486,7 +537,16 @@ void JoltBodyImpl3D::apply_impulse(
 }
 
 void JoltBodyImpl3D::apply_central_impulse(const Vector3& p_impulse, bool p_lock) {
-	ERR_FAIL_NULL(space);
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to apply central impulse to '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
 	QUIET_FAIL_COND(!is_rigid());
 
 	if (p_impulse == Vector3()) {
@@ -502,7 +562,16 @@ void JoltBodyImpl3D::apply_central_impulse(const Vector3& p_impulse, bool p_lock
 }
 
 void JoltBodyImpl3D::apply_torque(const Vector3& p_torque, bool p_lock) {
-	ERR_FAIL_NULL(space);
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to apply torque to '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
 	QUIET_FAIL_COND(!is_rigid());
 
 	if (custom_integrator || p_torque == Vector3()) {
@@ -518,7 +587,16 @@ void JoltBodyImpl3D::apply_torque(const Vector3& p_torque, bool p_lock) {
 }
 
 void JoltBodyImpl3D::apply_torque_impulse(const Vector3& p_impulse, bool p_lock) {
-	ERR_FAIL_NULL(space);
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to apply torque impulse to '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
 	QUIET_FAIL_COND(!is_rigid());
 
 	if (p_impulse == Vector3()) {

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -143,7 +143,15 @@ Vector3 JoltObjectImpl3D::get_position(bool p_lock) const {
 }
 
 Vector3 JoltObjectImpl3D::get_center_of_mass(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve center-of-mass of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());
@@ -152,7 +160,15 @@ Vector3 JoltObjectImpl3D::get_center_of_mass(bool p_lock) const {
 }
 
 Vector3 JoltObjectImpl3D::get_center_of_mass_local(bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve local center-of-mass of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
 
 	return get_transform_scaled(p_lock).xform_inv(get_center_of_mass(p_lock));
 }
@@ -180,7 +196,15 @@ Vector3 JoltObjectImpl3D::get_angular_velocity(bool p_lock) const {
 }
 
 Vector3 JoltObjectImpl3D::get_velocity_at_position(const Vector3& p_position, bool p_lock) const {
-	ERR_FAIL_NULL_D(space);
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve point velocity for '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
 
 	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
 	ERR_FAIL_COND_D(body.is_invalid());


### PR DESCRIPTION
Does what it says on the tin.

Until now, when trying to do things like applying forces/impulses to a body outside of a physics space, you've been met with the somewhat cryptic error `Parameter "space" is null`.

Now instead you'll get an actual explanation of what the problem is and what object is affected.