### PR TITLE
Changed `HeightMapShape3D` to be double-sided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed `HeightMapShape3D` to always use back-face collision, to match Godot Physics.
+
 ### Fixed
 
 - Fixed issue with project eventually freezing up when having many active physics spaces.

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -1,6 +1,7 @@
 #include "jolt_height_map_shape_impl_3d.hpp"
 
 #include "servers/jolt_project_settings.hpp"
+#include "shapes/jolt_custom_double_sided_shape.hpp"
 
 Variant JoltHeightMapShapeImpl3D::get_data() const {
 	Dictionary data;
@@ -73,11 +74,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build() const {
 	const int32_t block_size = 2; // Default of JPH::HeightFieldShapeSettings::mBlockSize
 	const int32_t block_count = width / block_size;
 
-	if (block_count < 2) {
-		return _build_mesh();
-	}
-
-	return _build_height_field();
+	return _build_double_sided(block_count >= 2 ? _build_height_field() : _build_mesh());
 }
 
 JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_height_field() const {
@@ -191,6 +188,24 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_mesh() const {
 			to_string(),
 			to_godot(shape_result.GetError()),
 			_owners_to_string()
+		)
+	);
+
+	return shape_result.Get();
+}
+
+JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_double_sided(const JPH::Shape* p_shape) const {
+	ERR_FAIL_NULL_D(p_shape);
+
+	const JoltCustomDoubleSidedShapeSettings shape_settings(p_shape);
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+
+	ERR_FAIL_COND_D_MSG(
+		shape_result.HasError(),
+		vformat(
+			"Failed to make shape double-sided. "
+			"It returned the following error: '%s'.",
+			to_godot(shape_result.GetError())
 		)
 	);
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.hpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.hpp
@@ -25,6 +25,8 @@ private:
 
 	JPH::ShapeRefC _build_mesh() const;
 
+	JPH::ShapeRefC _build_double_sided(const JPH::Shape* p_shape) const;
+
 	PackedFloat32Array heights;
 
 	int32_t width = 0;


### PR DESCRIPTION
As discussed in #688.

This changes `HeightMapShape3D` to unconditionally use the same double-sided decorator shape that `ConcavePolygonShape3D` uses when its `backface_collision` property is set, which lines up with how Godot Physics behaves.