### PR TITLE
Fixed global transform not being preserved when reparenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Breaking changes are denoted with ⚠️.
 ### Fixed
 
 - Fixed issue with project eventually freezing up when having many active physics spaces.
+- Fixed issue with global transform not being preserved when reparenting a `RigidBody3D`.
 - Fixed issue where the callback passed to `body_set_force_integration_callback` could be called
   even when the body is sleeping.
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1458,6 +1458,8 @@ void JoltBodyImpl3D::_space_changed(bool p_lock) {
 	_update_group_filter(p_lock);
 	_update_joint_constraints(p_lock);
 	_areas_changed(p_lock);
+
+	sync_state = false;
 }
 
 void JoltBodyImpl3D::_areas_changed(bool p_lock) {


### PR DESCRIPTION
Fixes #693.

This fixes a discrepancy with Godot Physics where after a body has moved between physics spaces (like when reparenting) it would until now not clear its `sync_state` flag and thereby invoke the state synchronization callback, which would lead to the physics server effectively overwriting any pending `NOTIFICATION_TRANSFORM_CHANGED`, like the one pending as a result of the local transform having been set by its new parent.