### PR TITLE
Fixed potentially stale kinematic transform when changing spaces

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1454,6 +1454,7 @@ void JoltBodyImpl3D::_space_changing([[maybe_unused]] bool p_lock) {
 }
 
 void JoltBodyImpl3D::_space_changed(bool p_lock) {
+	_update_kinematic_transform(p_lock);
 	_update_mass_properties(p_lock);
 	_update_group_filter(p_lock);
 	_update_joint_constraints(p_lock);


### PR DESCRIPTION
This isn't an actual problem that I've run into yet, but it struck me as potentially problematic.

When changing spaces of a kinematic body the kinematic transform wouldn't be updated, so if the body ended up having a different global transform in its new space then that would likely be interpreted as a movement and thus (erroneously) change the body's velocity for that tick.

This adds a reset of the kinematic transform when entering a new space.