### PR TITLE
Fixed surface velocities not being added to point velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Breaking changes are denoted with ⚠️.
 ### Fixed
 
 - Fixed issue with project eventually freezing up when having many active physics spaces.
+- Fixed issue with static and kinematic bodies not correctly incorporating surface velocities, also
+  known as "constant velocities", as part of their reported velocities. This also makes it so
+  `move_and_slide` will respect such velocities.
 - Fixed issue with global transform not being preserved when reparenting a `RigidBody3D`.
 - Fixed issue where the callback passed to `body_set_force_integration_callback` could be called
   even when the body is sleeping.

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -193,6 +193,13 @@ bool JoltAreaImpl3D::can_interact_with(const JoltAreaImpl3D& p_other) const {
 	return can_monitor(p_other) || p_other.can_monitor(*this);
 }
 
+Vector3 JoltAreaImpl3D::get_velocity_at_position(
+	[[maybe_unused]] const Vector3& p_position,
+	[[maybe_unused]] bool p_lock
+) const {
+	return {0.0f, 0.0f, 0.0f};
+}
+
 Vector3 JoltAreaImpl3D::compute_gravity(const Vector3& p_position, bool p_lock) const {
 	if (!point_gravity) {
 		return gravity_vector * gravity;

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -80,6 +80,8 @@ public:
 
 	bool can_interact_with(const JoltAreaImpl3D& p_other) const;
 
+	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const override;
+
 	bool generates_contacts() const override { return false; }
 
 	bool is_point_gravity() const { return point_gravity; }

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -85,6 +85,8 @@ public:
 
 	void set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock = true);
 
+	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const override;
+
 	bool has_custom_center_of_mass() const override { return custom_center_of_mass; }
 
 	Vector3 get_center_of_mass_custom() const override { return center_of_mass_custom; }

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -195,23 +195,6 @@ Vector3 JoltObjectImpl3D::get_angular_velocity(bool p_lock) const {
 	return to_godot(body->GetAngularVelocity());
 }
 
-Vector3 JoltObjectImpl3D::get_velocity_at_position(const Vector3& p_position, bool p_lock) const {
-	ERR_FAIL_NULL_D_MSG(
-		space,
-		vformat(
-			"Failed to retrieve point velocity for '%s'. "
-			"Doing so without a physics space is not supported by Godot Jolt. "
-			"If this relates to a node, try adding the node to a scene tree first.",
-			to_string()
-		)
-	);
-
-	const JoltReadableBody3D body = space->read_body(jolt_id, p_lock);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetPointVelocity(to_jolt(p_position)));
-}
-
 JPH::ShapeRefC JoltObjectImpl3D::try_build_shape() {
 	int32_t built_shape_count = 0;
 	const JoltShapeInstance3D* last_built_shape = nullptr;

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -87,7 +87,8 @@ public:
 
 	Vector3 get_angular_velocity(bool p_lock = true) const;
 
-	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const;
+	virtual Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true)
+		const = 0;
 
 	virtual bool has_custom_center_of_mass() const = 0;
 


### PR DESCRIPTION
Fixes #491.

This changes methods like `get_velocity_at_local_position`, `get_rest_info`, `body_test_motion`, `move_and_collide` and `move_and_slide` to correctly incorporate surface velocities in their reported velocities for bodies that use surface velocities.