### PR TITLE
Moved version info to a CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(templates_dir ${cmake_dir}/templates)
 list(APPEND CMAKE_MODULE_PATH ${cmake_dir})
 
 include(GodotJoltPrelude)
+include(GodotJoltVersionInfo)
 
 project(godot-jolt VERSION ${GDJ_VERSION} LANGUAGES CXX)
 

--- a/cmake/GodotJoltPrelude.cmake
+++ b/cmake/GodotJoltPrelude.cmake
@@ -31,5 +31,3 @@ endif()
 if(NOT DEFINED MSVC)
 	set(MSVC FALSE)
 endif()
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/Version.cmake)

--- a/cmake/GodotJoltVersionInfo.cmake
+++ b/cmake/GodotJoltVersionInfo.cmake
@@ -1,3 +1,5 @@
+include_guard()
+
 set(GDJ_PROJECT_TITLE "Godot Jolt")
 set(GDJ_PROJECT_DESCRIPTION "Godot extension that integrates the Jolt physics engine.")
 set(GDJ_PROJECT_COPYRIGHT "Copyright (c) Mikael Hermansson and Godot Jolt contributors.")


### PR DESCRIPTION
This moves the `/Version.cmake` file introduced in #699 to `/cmake/GodotJoltVersionInfo.cmake`.