### PR TITLE
Removed everything related to locking of Jolt bodies

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -16,11 +16,10 @@ JoltConeTwistJointImpl3D::JoltConeTwistJointImpl3D(
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
-	const Transform3D& p_local_ref_b,
-	bool p_lock
+	const Transform3D& p_local_ref_b
 )
 	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
-	rebuild(p_lock);
+	rebuild();
 }
 
 double JoltConeTwistJointImpl3D::get_param(PhysicsServer3D::ConeTwistJointParam p_param) const {
@@ -48,17 +47,16 @@ double JoltConeTwistJointImpl3D::get_param(PhysicsServer3D::ConeTwistJointParam 
 
 void JoltConeTwistJointImpl3D::set_param(
 	PhysicsServer3D::ConeTwistJointParam p_param,
-	double p_value,
-	bool p_lock
+	double p_value
 ) {
 	switch (p_param) {
 		case PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN: {
 			swing_limit_span = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN: {
 			twist_limit_span = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::CONE_TWIST_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
@@ -119,11 +117,7 @@ double JoltConeTwistJointImpl3D::get_jolt_param(JoltParameter p_param) const {
 	}
 }
 
-void JoltConeTwistJointImpl3D::set_jolt_param(
-	JoltParameter p_param,
-	double p_value,
-	[[maybe_unused]] bool p_lock
-) {
+void JoltConeTwistJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value) {
 	switch (p_param) {
 		case JoltPhysicsServer3D::CONE_TWIST_JOINT_SWING_MOTOR_TARGET_VELOCITY_Y: {
 			swing_motor_target_speed_y = p_value;
@@ -171,15 +165,15 @@ bool JoltConeTwistJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
 	}
 }
 
-void JoltConeTwistJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock) {
+void JoltConeTwistJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled) {
 	switch (p_flag) {
 		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_SWING_LIMIT: {
 			swing_limit_enabled = p_enabled;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_USE_TWIST_LIMIT: {
 			twist_limit_enabled = p_enabled;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case JoltPhysicsServer3D::CONE_TWIST_JOINT_FLAG_ENABLE_SWING_MOTOR: {
 			swing_motor_enabled = p_enabled;
@@ -227,7 +221,7 @@ float JoltConeTwistJointImpl3D::get_applied_torque() const {
 	return rotation_lambda.length() / last_step;
 }
 
-void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
+void JoltConeTwistJointImpl3D::rebuild() {
 	destroy();
 
 	JoltSpace3D* space = get_space();
@@ -244,7 +238,7 @@ void JoltConeTwistJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count);
 
 	auto* jolt_body_a = static_cast<JPH::Body*>(jolt_bodies[0]);
 	ERR_FAIL_COND(jolt_body_a == nullptr);
@@ -372,8 +366,8 @@ void JoltConeTwistJointImpl3D::_update_twist_motor_limit() {
 	}
 }
 
-void JoltConeTwistJointImpl3D::_limits_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltConeTwistJointImpl3D::_limits_changed() {
+	rebuild();
 }
 
 void JoltConeTwistJointImpl3D::_swing_motor_state_changed() {

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -16,8 +16,7 @@ public:
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
+		const Transform3D& p_local_ref_b
 	);
 
 	PhysicsServer3D::JointType get_type() const override {
@@ -26,25 +25,21 @@ public:
 
 	double get_param(PhysicsServer3D::ConeTwistJointParam p_param) const;
 
-	void set_param(
-		PhysicsServer3D::ConeTwistJointParam p_param,
-		double p_value,
-		bool p_lock = true
-	);
+	void set_param(PhysicsServer3D::ConeTwistJointParam p_param, double p_value);
 
 	double get_jolt_param(JoltParameter p_param) const;
 
-	void set_jolt_param(JoltParameter p_param, double p_value, bool p_lock = true);
+	void set_jolt_param(JoltParameter p_param, double p_value);
 
 	bool get_jolt_flag(JoltFlag p_flag) const;
 
-	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+	void set_jolt_flag(JoltFlag p_flag, bool p_enabled);
 
 	float get_applied_force() const;
 
 	float get_applied_torque() const;
 
-	void rebuild(bool p_lock = true) override;
+	void rebuild() override;
 
 private:
 	JPH::Constraint* _build_swing_twist(
@@ -66,7 +61,7 @@ private:
 
 	void _update_twist_motor_limit();
 
-	void _limits_changed(bool p_lock = true);
+	void _limits_changed();
 
 	void _swing_motor_state_changed();
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -22,11 +22,10 @@ JoltGeneric6DOFJointImpl3D::JoltGeneric6DOFJointImpl3D(
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
-	const Transform3D& p_local_ref_b,
-	bool p_lock
+	const Transform3D& p_local_ref_b
 )
 	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
-	rebuild(p_lock);
+	rebuild();
 }
 
 double JoltGeneric6DOFJointImpl3D::get_param(Axis p_axis, Param p_param) const {
@@ -106,23 +105,18 @@ double JoltGeneric6DOFJointImpl3D::get_param(Axis p_axis, Param p_param) const {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::set_param(
-	Axis p_axis,
-	Param p_param,
-	double p_value,
-	bool p_lock
-) {
+void JoltGeneric6DOFJointImpl3D::set_param(Axis p_axis, Param p_param, double p_value) {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
 	switch ((int32_t)p_param) {
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT: {
 			limit_lower[axis_lin] = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_UPPER_LIMIT: {
 			limit_upper[axis_lin] = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
@@ -176,11 +170,11 @@ void JoltGeneric6DOFJointImpl3D::set_param(
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT: {
 			limit_lower[axis_ang] = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_UPPER_LIMIT: {
 			limit_upper[axis_ang] = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_ANGULAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_ANGULAR_LIMIT_SOFTNESS)) {
@@ -287,18 +281,18 @@ bool JoltGeneric6DOFJointImpl3D::get_flag(Axis p_axis, Flag p_flag) const {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::set_flag(Axis p_axis, Flag p_flag, bool p_enabled, bool p_lock) {
+void JoltGeneric6DOFJointImpl3D::set_flag(Axis p_axis, Flag p_flag, bool p_enabled) {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
 	switch ((int32_t)p_flag) {
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT: {
 			limit_enabled[axis_lin] = p_enabled;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT: {
 			limit_enabled[axis_ang] = p_enabled;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case JoltPhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING: {
 			spring_enabled[axis_ang] = p_enabled;
@@ -345,12 +339,7 @@ double JoltGeneric6DOFJointImpl3D::get_jolt_param(Axis p_axis, JoltParam p_param
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::set_jolt_param(
-	Axis p_axis,
-	JoltParam p_param,
-	double p_value,
-	[[maybe_unused]] bool p_lock
-) {
+void JoltGeneric6DOFJointImpl3D::set_jolt_param(Axis p_axis, JoltParam p_param, double p_value) {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
@@ -397,12 +386,7 @@ bool JoltGeneric6DOFJointImpl3D::get_jolt_flag(Axis p_axis, JoltFlag p_flag) con
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::set_jolt_flag(
-	Axis p_axis,
-	JoltFlag p_flag,
-	bool p_enabled,
-	[[maybe_unused]] bool p_lock
-) {
+void JoltGeneric6DOFJointImpl3D::set_jolt_flag(Axis p_axis, JoltFlag p_flag, bool p_enabled) {
 	const int32_t axis_lin = AXES_LINEAR + (int32_t)p_axis;
 	const int32_t axis_ang = AXES_ANGULAR + (int32_t)p_axis;
 
@@ -451,7 +435,7 @@ float JoltGeneric6DOFJointImpl3D::get_applied_torque() const {
 	return constraint->GetTotalLambdaRotation().Length() / last_step;
 }
 
-void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
+void JoltGeneric6DOFJointImpl3D::rebuild() {
 	destroy();
 
 	JoltSpace3D* space = get_space();
@@ -468,7 +452,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D bodies = space->write_bodies(body_ids, body_count);
 
 	JPH::SixDOFConstraintSettings constraint_settings;
 
@@ -669,8 +653,8 @@ void JoltGeneric6DOFJointImpl3D::_update_spring_equilibrium(int32_t p_axis) {
 	}
 }
 
-void JoltGeneric6DOFJointImpl3D::_limits_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltGeneric6DOFJointImpl3D::_limits_changed() {
+	rebuild();
 }
 
 void JoltGeneric6DOFJointImpl3D::_limit_spring_parameters_changed(int32_t p_axis) {

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -34,8 +34,7 @@ public:
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
+		const Transform3D& p_local_ref_b
 	);
 
 	PhysicsServer3D::JointType get_type() const override {
@@ -44,25 +43,25 @@ public:
 
 	double get_param(Axis p_axis, Param p_param) const;
 
-	void set_param(Axis p_axis, Param p_param, double p_value, bool p_lock = true);
+	void set_param(Axis p_axis, Param p_param, double p_value);
 
 	bool get_flag(Axis p_axis, Flag p_flag) const;
 
-	void set_flag(Axis p_axis, Flag p_flag, bool p_enabled, bool p_lock = true);
+	void set_flag(Axis p_axis, Flag p_flag, bool p_enabled);
 
 	double get_jolt_param(Axis p_axis, JoltParam p_param) const;
 
-	void set_jolt_param(Axis p_axis, JoltParam p_param, double p_value, bool p_lock = true);
+	void set_jolt_param(Axis p_axis, JoltParam p_param, double p_value);
 
 	bool get_jolt_flag(Axis p_axis, JoltFlag p_flag) const;
 
-	void set_jolt_flag(Axis p_axis, JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+	void set_jolt_flag(Axis p_axis, JoltFlag p_flag, bool p_enabled);
 
 	float get_applied_force() const;
 
 	float get_applied_torque() const;
 
-	void rebuild(bool p_lock = true) override;
+	void rebuild() override;
 
 private:
 	void _update_limit_spring_parameters(int32_t p_axis);
@@ -77,7 +76,7 @@ private:
 
 	void _update_spring_equilibrium(int32_t p_axis);
 
-	void _limits_changed(bool p_lock = true);
+	void _limits_changed();
 
 	void _limit_spring_parameters_changed(int32_t p_axis);
 

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -17,11 +17,10 @@ JoltHingeJointImpl3D::JoltHingeJointImpl3D(
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
-	const Transform3D& p_local_ref_b,
-	bool p_lock
+	const Transform3D& p_local_ref_b
 )
 	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
-	rebuild(p_lock);
+	rebuild();
 }
 
 double JoltHingeJointImpl3D::get_param(Parameter p_param) const {
@@ -58,7 +57,7 @@ double JoltHingeJointImpl3D::get_param(Parameter p_param) const {
 	}
 }
 
-void JoltHingeJointImpl3D::set_param(Parameter p_param, double p_value, bool p_lock) {
+void JoltHingeJointImpl3D::set_param(Parameter p_param, double p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::HINGE_JOINT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_BIAS)) {
@@ -72,11 +71,11 @@ void JoltHingeJointImpl3D::set_param(Parameter p_param, double p_value, bool p_l
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER: {
 			limit_upper = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_LOWER: {
 			limit_lower = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_LIMIT_BIAS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LIMIT_BIAS)) {
@@ -141,15 +140,15 @@ double JoltHingeJointImpl3D::get_jolt_param(JoltParameter p_param) const {
 	}
 }
 
-void JoltHingeJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value, bool p_lock) {
+void JoltHingeJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value) {
 	switch (p_param) {
 		case JoltPhysicsServer3D::HINGE_JOINT_LIMIT_SPRING_FREQUENCY: {
 			limit_spring_frequency = p_value;
-			_limit_spring_changed(p_lock);
+			_limit_spring_changed();
 		} break;
 		case JoltPhysicsServer3D::HINGE_JOINT_LIMIT_SPRING_DAMPING: {
 			limit_spring_damping = p_value;
-			_limit_spring_changed(p_lock);
+			_limit_spring_changed();
 		} break;
 		case JoltPhysicsServer3D::HINGE_JOINT_MOTOR_MAX_TORQUE: {
 			motor_max_torque = p_value;
@@ -175,11 +174,11 @@ bool JoltHingeJointImpl3D::get_flag(Flag p_flag) const {
 	}
 }
 
-void JoltHingeJointImpl3D::set_flag(Flag p_flag, bool p_enabled, bool p_lock) {
+void JoltHingeJointImpl3D::set_flag(Flag p_flag, bool p_enabled) {
 	switch (p_flag) {
 		case PhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT: {
 			limits_enabled = p_enabled;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::HINGE_JOINT_FLAG_ENABLE_MOTOR: {
 			motor_enabled = p_enabled;
@@ -203,12 +202,12 @@ bool JoltHingeJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
 	}
 }
 
-void JoltHingeJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock) {
+void JoltHingeJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled) {
 	// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 	switch (p_flag) {
 		case JoltPhysicsServer3D::HINGE_JOINT_FLAG_USE_LIMIT_SPRING: {
 			limit_spring_enabled = p_enabled;
-			_limit_spring_changed(p_lock);
+			_limit_spring_changed();
 		} break;
 		default: {
 			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
@@ -252,7 +251,7 @@ float JoltHingeJointImpl3D::get_applied_torque() const {
 	}
 }
 
-void JoltHingeJointImpl3D::rebuild(bool p_lock) {
+void JoltHingeJointImpl3D::rebuild() {
 	destroy();
 
 	JoltSpace3D* space = get_space();
@@ -269,7 +268,7 @@ void JoltHingeJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count);
 
 	auto* jolt_body_a = static_cast<JPH::Body*>(jolt_bodies[0]);
 	ERR_FAIL_COND(jolt_body_a == nullptr);
@@ -396,12 +395,12 @@ void JoltHingeJointImpl3D::_update_motor_limit() {
 	}
 }
 
-void JoltHingeJointImpl3D::_limits_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltHingeJointImpl3D::_limits_changed() {
+	rebuild();
 }
 
-void JoltHingeJointImpl3D::_limit_spring_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltHingeJointImpl3D::_limit_spring_changed() {
+	rebuild();
 }
 
 void JoltHingeJointImpl3D::_motor_state_changed() {

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -18,8 +18,7 @@ public:
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
+		const Transform3D& p_local_ref_b
 	);
 
 	PhysicsServer3D::JointType get_type() const override {
@@ -28,25 +27,25 @@ public:
 
 	double get_param(Parameter p_param) const;
 
-	void set_param(Parameter p_param, double p_value, bool p_lock = true);
+	void set_param(Parameter p_param, double p_value);
 
 	double get_jolt_param(JoltParameter p_param) const;
 
-	void set_jolt_param(JoltParameter p_param, double p_value, bool p_lock = true);
+	void set_jolt_param(JoltParameter p_param, double p_value);
 
 	bool get_flag(Flag p_flag) const;
 
-	void set_flag(Flag p_flag, bool p_enabled, bool p_lock = true);
+	void set_flag(Flag p_flag, bool p_enabled);
 
 	bool get_jolt_flag(JoltFlag p_flag) const;
 
-	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+	void set_jolt_flag(JoltFlag p_flag, bool p_enabled);
 
 	float get_applied_force() const;
 
 	float get_applied_torque() const;
 
-	void rebuild(bool p_lock = true) override;
+	void rebuild() override;
 
 private:
 	JPH::Constraint* _build_hinge(
@@ -74,9 +73,9 @@ private:
 
 	void _update_motor_limit();
 
-	void _limits_changed(bool p_lock = true);
+	void _limits_changed();
 
-	void _limit_spring_changed(bool p_lock = true);
+	void _limit_spring_changed();
 
 	void _motor_state_changed();
 

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -49,7 +49,7 @@ public:
 
 	void destroy();
 
-	virtual void rebuild([[maybe_unused]] bool p_lock = true) { }
+	virtual void rebuild() { }
 
 protected:
 	void _shift_reference_frames(

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -16,8 +16,7 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Vector3& p_local_a,
-	const Vector3& p_local_b,
-	bool p_lock
+	const Vector3& p_local_b
 )
 	: JoltJointImpl3D(
 		  p_old_joint,
@@ -26,17 +25,17 @@ JoltPinJointImpl3D::JoltPinJointImpl3D(
 		  Transform3D({}, p_local_a),
 		  Transform3D({}, p_local_b)
 	  ) {
-	rebuild(p_lock);
+	rebuild();
 }
 
-void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a, bool p_lock) {
+void JoltPinJointImpl3D::set_local_a(const Vector3& p_local_a) {
 	local_ref_a = Transform3D({}, p_local_a);
-	_points_changed(p_lock);
+	_points_changed();
 }
 
-void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b, bool p_lock) {
+void JoltPinJointImpl3D::set_local_b(const Vector3& p_local_b) {
 	local_ref_b = Transform3D({}, p_local_b);
-	_points_changed(p_lock);
+	_points_changed();
 }
 
 double JoltPinJointImpl3D::get_param(PhysicsServer3D::PinJointParam p_param) const {
@@ -107,7 +106,7 @@ float JoltPinJointImpl3D::get_applied_force() const {
 	return constraint->GetTotalLambdaPosition().Length() / last_step;
 }
 
-void JoltPinJointImpl3D::rebuild(bool p_lock) {
+void JoltPinJointImpl3D::rebuild() {
 	destroy();
 
 	JoltSpace3D* space = get_space();
@@ -124,7 +123,7 @@ void JoltPinJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count);
 
 	auto* jolt_body_a = static_cast<JPH::Body*>(jolt_bodies[0]);
 	ERR_FAIL_COND(jolt_body_a == nullptr);
@@ -163,6 +162,6 @@ JPH::Constraint* JoltPinJointImpl3D::_build_pin(
 	}
 }
 
-void JoltPinJointImpl3D::_points_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltPinJointImpl3D::_points_changed() {
+	rebuild();
 }

--- a/src/joints/jolt_pin_joint_impl_3d.hpp
+++ b/src/joints/jolt_pin_joint_impl_3d.hpp
@@ -12,19 +12,18 @@ public:
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Vector3& p_local_a,
-		const Vector3& p_local_b,
-		bool p_lock = true
+		const Vector3& p_local_b
 	);
 
 	PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_PIN; }
 
 	Vector3 get_local_a() const { return local_ref_a.origin; }
 
-	void set_local_a(const Vector3& p_local_a, bool p_lock = true);
+	void set_local_a(const Vector3& p_local_a);
 
 	Vector3 get_local_b() const { return local_ref_b.origin; }
 
-	void set_local_b(const Vector3& p_local_b, bool p_lock = true);
+	void set_local_b(const Vector3& p_local_b);
 
 	double get_param(PhysicsServer3D::PinJointParam p_param) const;
 
@@ -32,7 +31,7 @@ public:
 
 	float get_applied_force() const;
 
-	void rebuild(bool p_lock = true) override;
+	void rebuild() override;
 
 private:
 	static JPH::Constraint* _build_pin(
@@ -42,5 +41,5 @@ private:
 		const Transform3D& p_shifted_ref_b
 	);
 
-	void _points_changed(bool p_lock = true);
+	void _points_changed();
 };

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -38,11 +38,10 @@ JoltSliderJointImpl3D::JoltSliderJointImpl3D(
 	JoltBodyImpl3D* p_body_a,
 	JoltBodyImpl3D* p_body_b,
 	const Transform3D& p_local_ref_a,
-	const Transform3D& p_local_ref_b,
-	bool p_lock
+	const Transform3D& p_local_ref_b
 )
 	: JoltJointImpl3D(p_old_joint, p_body_a, p_body_b, p_local_ref_a, p_local_ref_b) {
-	rebuild(p_lock);
+	rebuild();
 }
 
 double JoltSliderJointImpl3D::get_param(PhysicsServer3D::SliderJointParam p_param) const {
@@ -119,19 +118,15 @@ double JoltSliderJointImpl3D::get_param(PhysicsServer3D::SliderJointParam p_para
 	}
 }
 
-void JoltSliderJointImpl3D::set_param(
-	PhysicsServer3D::SliderJointParam p_param,
-	double p_value,
-	bool p_lock
-) {
+void JoltSliderJointImpl3D::set_param(PhysicsServer3D::SliderJointParam p_param, double p_value) {
 	switch (p_param) {
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_UPPER: {
 			limit_upper = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_LOWER: {
 			limit_lower = p_value;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case PhysicsServer3D::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS: {
 			if (!Math::is_equal_approx(p_value, DEFAULT_LINEAR_LIMIT_SOFTNESS)) {
@@ -361,15 +356,15 @@ double JoltSliderJointImpl3D::get_jolt_param(JoltParameter p_param) const {
 	}
 }
 
-void JoltSliderJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value, bool p_lock) {
+void JoltSliderJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value) {
 	switch (p_param) {
 		case JoltPhysicsServer3D::SLIDER_JOINT_LIMIT_SPRING_FREQUENCY: {
 			limit_spring_frequency = p_value;
-			_limit_spring_changed(p_lock);
+			_limit_spring_changed();
 		} break;
 		case JoltPhysicsServer3D::SLIDER_JOINT_LIMIT_SPRING_DAMPING: {
 			limit_spring_damping = p_value;
-			_limit_spring_changed(p_lock);
+			_limit_spring_changed();
 		} break;
 		case JoltPhysicsServer3D::SLIDER_JOINT_MOTOR_TARGET_VELOCITY: {
 			motor_target_speed = p_value;
@@ -402,15 +397,15 @@ bool JoltSliderJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
 	}
 }
 
-void JoltSliderJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock) {
+void JoltSliderJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled) {
 	switch (p_flag) {
 		case JoltPhysicsServer3D::SLIDER_JOINT_FLAG_USE_LIMIT: {
 			limits_enabled = p_enabled;
-			_limits_changed(p_lock);
+			_limits_changed();
 		} break;
 		case JoltPhysicsServer3D::SLIDER_JOINT_FLAG_USE_LIMIT_SPRING: {
 			limit_spring_enabled = p_enabled;
-			_limit_spring_changed(p_lock);
+			_limit_spring_changed();
 		} break;
 		case JoltPhysicsServer3D::SLIDER_JOINT_FLAG_ENABLE_MOTOR: {
 			motor_enabled = p_enabled;
@@ -458,7 +453,7 @@ float JoltSliderJointImpl3D::get_applied_torque() const {
 	}
 }
 
-void JoltSliderJointImpl3D::rebuild(bool p_lock) {
+void JoltSliderJointImpl3D::rebuild() {
 	destroy();
 
 	JoltSpace3D* space = get_space();
@@ -475,7 +470,7 @@ void JoltSliderJointImpl3D::rebuild(bool p_lock) {
 		body_count = 2;
 	}
 
-	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count, p_lock);
+	const JoltWritableBodies3D jolt_bodies = space->write_bodies(body_ids, body_count);
 
 	auto* jolt_body_a = static_cast<JPH::Body*>(jolt_bodies[0]);
 	ERR_FAIL_COND(jolt_body_a == nullptr);
@@ -602,12 +597,12 @@ void JoltSliderJointImpl3D::_update_motor_limit() {
 	}
 }
 
-void JoltSliderJointImpl3D::_limits_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltSliderJointImpl3D::_limits_changed() {
+	rebuild();
 }
 
-void JoltSliderJointImpl3D::_limit_spring_changed(bool p_lock) {
-	rebuild(p_lock);
+void JoltSliderJointImpl3D::_limit_spring_changed() {
+	rebuild();
 }
 
 void JoltSliderJointImpl3D::_motor_state_changed() {

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -16,8 +16,7 @@ public:
 		JoltBodyImpl3D* p_body_a,
 		JoltBodyImpl3D* p_body_b,
 		const Transform3D& p_local_ref_a,
-		const Transform3D& p_local_ref_b,
-		bool p_lock = true
+		const Transform3D& p_local_ref_b
 	);
 
 	PhysicsServer3D::JointType get_type() const override {
@@ -26,21 +25,21 @@ public:
 
 	double get_param(PhysicsServer3D::SliderJointParam p_param) const;
 
-	void set_param(PhysicsServer3D::SliderJointParam p_param, double p_value, bool p_lock = true);
+	void set_param(PhysicsServer3D::SliderJointParam p_param, double p_value);
 
 	double get_jolt_param(JoltParameter p_param) const;
 
-	void set_jolt_param(JoltParameter p_param, double p_value, bool p_lock = true);
+	void set_jolt_param(JoltParameter p_param, double p_value);
 
 	bool get_jolt_flag(JoltFlag p_flag) const;
 
-	void set_jolt_flag(JoltFlag p_flag, bool p_enabled, bool p_lock = true);
+	void set_jolt_flag(JoltFlag p_flag, bool p_enabled);
 
 	float get_applied_force() const;
 
 	float get_applied_torque() const;
 
-	void rebuild(bool p_lock = true) override;
+	void rebuild() override;
 
 private:
 	JPH::Constraint* _build_slider(
@@ -68,9 +67,9 @@ private:
 
 	void _update_motor_limit();
 
-	void _limits_changed(bool p_lock = true);
+	void _limits_changed();
 
-	void _limit_spring_changed(bool p_lock = true);
+	void _limit_spring_changed();
 
 	void _motor_state_changed();
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -70,7 +70,7 @@ public:
 
 	bool is_monitorable() const { return monitorable; }
 
-	void set_monitorable(bool p_monitorable, bool p_lock = true);
+	void set_monitorable(bool p_monitorable);
 
 	bool can_monitor(const JoltBodyImpl3D& p_other) const;
 
@@ -80,7 +80,7 @@ public:
 
 	bool can_interact_with(const JoltAreaImpl3D& p_other) const;
 
-	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const override;
+	Vector3 get_velocity_at_position(const Vector3& p_position) const override;
 
 	bool generates_contacts() const override { return false; }
 
@@ -124,7 +124,7 @@ public:
 
 	void set_gravity_vector(const Vector3& p_vector) { gravity_vector = p_vector; }
 
-	Vector3 compute_gravity(const Vector3& p_position, bool p_lock = true) const;
+	Vector3 compute_gravity(const Vector3& p_position) const;
 
 	void body_shape_entered(
 		const JPH::BodyID& p_body_id,
@@ -193,29 +193,29 @@ private:
 		int32_t p_self_shape_index
 	) const;
 
-	void _notify_body_entered(const JPH::BodyID& p_body_id, bool p_lock = true);
+	void _notify_body_entered(const JPH::BodyID& p_body_id);
 
-	void _notify_body_exited(const JPH::BodyID& p_body_id, bool p_lock = true);
+	void _notify_body_exited(const JPH::BodyID& p_body_id);
 
 	void _force_bodies_entered();
 
-	void _force_bodies_exited(bool p_remove, bool p_lock = true);
+	void _force_bodies_exited(bool p_remove);
 
 	void _force_areas_entered();
 
-	void _force_areas_exited(bool p_remove, bool p_lock = true);
+	void _force_areas_exited(bool p_remove);
 
-	void _update_group_filter(bool p_lock = true);
+	void _update_group_filter();
 
-	void _space_changing(bool p_lock = true) override;
+	void _space_changing() override;
 
-	void _space_changed(bool p_lock = true) override;
+	void _space_changed() override;
 
 	void _body_monitoring_changed();
 
 	void _area_monitoring_changed();
 
-	void _monitorable_changed(bool p_lock = true);
+	void _monitorable_changed();
 
 	OverlapsById bodies_by_id;
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -59,39 +59,39 @@ public:
 
 	bool has_custom_integrator() const { return custom_integrator; }
 
-	void set_custom_integrator(bool p_enabled, bool p_lock = true);
+	void set_custom_integrator(bool p_enabled);
 
-	bool is_sleeping(bool p_lock = true) const;
+	bool is_sleeping() const;
 
-	void set_is_sleeping(bool p_enabled, bool p_lock = true);
+	void set_is_sleeping(bool p_enabled);
 
-	void put_to_sleep(bool p_lock = true) { set_is_sleeping(true, p_lock); }
+	void put_to_sleep() { set_is_sleeping(true); }
 
-	void wake_up(bool p_lock = true) { set_is_sleeping(false, p_lock); }
+	void wake_up() { set_is_sleeping(false); }
 
-	bool can_sleep(bool p_lock = true) const;
+	bool can_sleep() const;
 
-	void set_can_sleep(bool p_enabled, bool p_lock = true);
+	void set_can_sleep(bool p_enabled);
 
-	Basis get_principal_inertia_axes(bool p_lock = true) const;
+	Basis get_principal_inertia_axes() const;
 
-	Vector3 get_inverse_inertia(bool p_lock = true) const;
+	Vector3 get_inverse_inertia() const;
 
-	Basis get_inverse_inertia_tensor(bool p_lock = true) const;
+	Basis get_inverse_inertia_tensor() const;
 
-	void set_linear_velocity(const Vector3& p_velocity, bool p_lock = true);
+	void set_linear_velocity(const Vector3& p_velocity);
 
-	void set_angular_velocity(const Vector3& p_velocity, bool p_lock = true);
+	void set_angular_velocity(const Vector3& p_velocity);
 
-	void set_axis_velocity(const Vector3& p_axis_velocity, bool p_lock = true);
+	void set_axis_velocity(const Vector3& p_axis_velocity);
 
-	Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true) const override;
+	Vector3 get_velocity_at_position(const Vector3& p_position) const override;
 
 	bool has_custom_center_of_mass() const override { return custom_center_of_mass; }
 
 	Vector3 get_center_of_mass_custom() const override { return center_of_mass_custom; }
 
-	void set_center_of_mass_custom(const Vector3& p_center_of_mass, bool p_lock = true);
+	void set_center_of_mass_custom(const Vector3& p_center_of_mass);
 
 	int32_t get_max_contacts_reported() const { return contacts.size(); }
 
@@ -116,53 +116,53 @@ public:
 		const Vector3& p_impulse
 	);
 
-	void reset_mass_properties(bool p_lock = true);
+	void reset_mass_properties();
 
-	void apply_force(const Vector3& p_force, const Vector3& p_position, bool p_lock = true);
+	void apply_force(const Vector3& p_force, const Vector3& p_position);
 
-	void apply_central_force(const Vector3& p_force, bool p_lock = true);
+	void apply_central_force(const Vector3& p_force);
 
-	void apply_impulse(const Vector3& p_impulse, const Vector3& p_position, bool p_lock = true);
+	void apply_impulse(const Vector3& p_impulse, const Vector3& p_position);
 
-	void apply_central_impulse(const Vector3& p_impulse, bool p_lock = true);
+	void apply_central_impulse(const Vector3& p_impulse);
 
-	void apply_torque(const Vector3& p_torque, bool p_lock = true);
+	void apply_torque(const Vector3& p_torque);
 
-	void apply_torque_impulse(const Vector3& p_impulse, bool p_lock = true);
+	void apply_torque_impulse(const Vector3& p_impulse);
 
-	void add_constant_central_force(const Vector3& p_force, bool p_lock = true);
+	void add_constant_central_force(const Vector3& p_force);
 
-	void add_constant_force(const Vector3& p_force, const Vector3& p_position, bool p_lock = true);
+	void add_constant_force(const Vector3& p_force, const Vector3& p_position);
 
-	void add_constant_torque(const Vector3& p_torque, bool p_lock = true);
+	void add_constant_torque(const Vector3& p_torque);
 
 	Vector3 get_constant_force() const;
 
-	void set_constant_force(const Vector3& p_force, bool p_lock = true);
+	void set_constant_force(const Vector3& p_force);
 
 	Vector3 get_constant_torque() const;
 
-	void set_constant_torque(const Vector3& p_torque, bool p_lock = true);
+	void set_constant_torque(const Vector3& p_torque);
 
 	Vector3 get_linear_surface_velocity() const { return linear_surface_velocity; }
 
 	Vector3 get_angular_surface_velocity() const { return angular_surface_velocity; }
 
-	void add_collision_exception(const RID& p_excepted_body, bool p_lock = true);
+	void add_collision_exception(const RID& p_excepted_body);
 
-	void remove_collision_exception(const RID& p_excepted_body, bool p_lock = true);
+	void remove_collision_exception(const RID& p_excepted_body);
 
 	bool has_collision_exception(const RID& p_excepted_body) const;
 
 	TypedArray<RID> get_collision_exceptions() const;
 
-	void add_area(JoltAreaImpl3D* p_area, bool p_lock = true);
+	void add_area(JoltAreaImpl3D* p_area);
 
-	void remove_area(JoltAreaImpl3D* p_area, bool p_lock = true);
+	void remove_area(JoltAreaImpl3D* p_area);
 
-	void add_joint(JoltJointImpl3D* p_joint, bool p_lock = true);
+	void add_joint(JoltJointImpl3D* p_joint);
 
-	void remove_joint(JoltJointImpl3D* p_joint, bool p_lock = true);
+	void remove_joint(JoltJointImpl3D* p_joint);
 
 	void call_queries(JPH::Body& p_jolt_body);
 
@@ -174,7 +174,7 @@ public:
 
 	PhysicsServer3D::BodyMode get_mode() const { return mode; }
 
-	void set_mode(PhysicsServer3D::BodyMode p_mode, bool p_lock = true);
+	void set_mode(PhysicsServer3D::BodyMode p_mode);
 
 	bool is_static() const { return mode == PhysicsServer3D::BODY_MODE_STATIC; }
 
@@ -186,39 +186,39 @@ public:
 
 	bool is_rigid() const { return is_rigid_free() || is_rigid_linear(); }
 
-	bool is_ccd_enabled(bool p_lock = true) const;
+	bool is_ccd_enabled() const;
 
-	void set_ccd_enabled(bool p_enabled, bool p_lock = true);
+	void set_ccd_enabled(bool p_enabled);
 
 	float get_mass() const { return mass; }
 
-	void set_mass(float p_mass, bool p_lock = true);
+	void set_mass(float p_mass);
 
 	Vector3 get_inertia() const { return inertia; }
 
-	void set_inertia(const Vector3& p_inertia, bool p_lock = true);
+	void set_inertia(const Vector3& p_inertia);
 
-	float get_bounce(bool p_lock = true) const;
+	float get_bounce() const;
 
-	void set_bounce(float p_bounce, bool p_lock = true);
+	void set_bounce(float p_bounce);
 
-	float get_friction(bool p_lock = true) const;
+	float get_friction() const;
 
-	void set_friction(float p_friction, bool p_lock = true);
+	void set_friction(float p_friction);
 
-	float get_gravity_scale(bool p_lock = true) const;
+	float get_gravity_scale() const;
 
-	void set_gravity_scale(float p_scale, bool p_lock = true);
+	void set_gravity_scale(float p_scale);
 
 	Vector3 get_gravity() const { return gravity; }
 
 	float get_linear_damp() const { return linear_damp; }
 
-	void set_linear_damp(float p_damp, bool p_lock = true);
+	void set_linear_damp(float p_damp);
 
 	float get_angular_damp() const { return angular_damp; }
 
-	void set_angular_damp(float p_damp, bool p_lock = true);
+	void set_angular_damp(float p_damp);
 
 	float get_total_linear_damp() const { return total_linear_damp; }
 
@@ -238,7 +238,7 @@ public:
 
 	bool is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const;
 
-	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock_axis, bool p_lock = true);
+	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_enabled);
 
 	bool are_axes_locked() const { return locked_axes != 0; }
 
@@ -261,7 +261,7 @@ private:
 
 	void _pre_step_kinematic(float p_step, JPH::Body& p_jolt_body);
 
-	void _apply_transform(const Transform3D& p_transform, bool p_lock = true) override;
+	void _apply_transform(const Transform3D& p_transform) override;
 
 	JPH::EAllowedDOFs _calculate_allowed_dofs() const;
 
@@ -271,39 +271,39 @@ private:
 
 	void _stop_locked_axes(JPH::Body& p_jolt_body) const;
 
-	void _update_mass_properties(bool p_lock = true);
+	void _update_mass_properties();
 
 	void _update_gravity(JPH::Body& p_jolt_body);
 
-	void _update_damp(bool p_lock = true);
+	void _update_damp();
 
-	void _update_kinematic_transform(bool p_lock = true);
+	void _update_kinematic_transform();
 
-	void _update_group_filter(bool p_lock = true);
+	void _update_group_filter();
 
-	void _update_joint_constraints(bool p_lock = true);
+	void _update_joint_constraints();
 
 	void _destroy_joint_constraints();
 
-	void _mode_changed(bool p_lock = true);
+	void _mode_changed();
 
-	void _shapes_built(bool p_lock) override;
+	void _shapes_built() override;
 
-	void _space_changing(bool p_lock = true) override;
+	void _space_changing() override;
 
-	void _space_changed(bool p_lock = true) override;
+	void _space_changed() override;
 
-	void _areas_changed(bool p_lock = true);
+	void _areas_changed();
 
-	void _joints_changed(bool p_lock = true);
+	void _joints_changed();
 
-	void _transform_changed(bool p_lock = true) override;
+	void _transform_changed() override;
 
-	void _motion_changed(bool p_lock = true);
+	void _motion_changed();
 
-	void _exceptions_changed(bool p_lock = true);
+	void _exceptions_changed();
 
-	void _axis_lock_changed(bool p_lock = true);
+	void _axis_lock_changed();
 
 	LocalVector<RID> exceptions;
 

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -57,38 +57,37 @@ public:
 
 	JoltSpace3D* get_space() const { return space; }
 
-	void set_space(JoltSpace3D* p_space, bool p_lock = true);
+	void set_space(JoltSpace3D* p_space);
 
 	uint32_t get_collision_layer() const { return collision_layer; }
 
-	void set_collision_layer(uint32_t p_layer, bool p_lock = true);
+	void set_collision_layer(uint32_t p_layer);
 
 	uint32_t get_collision_mask() const { return collision_mask; }
 
-	void set_collision_mask(uint32_t p_mask, bool p_lock = true);
+	void set_collision_mask(uint32_t p_mask);
 
-	Transform3D get_transform_unscaled(bool p_lock = true) const;
+	Transform3D get_transform_unscaled() const;
 
-	Transform3D get_transform_scaled(bool p_lock = true) const;
+	Transform3D get_transform_scaled() const;
 
-	void set_transform(Transform3D p_transform, bool p_lock = true);
+	void set_transform(Transform3D p_transform);
 
 	Vector3 get_scale() const { return scale; }
 
-	Basis get_basis(bool p_lock = true) const;
+	Basis get_basis() const;
 
-	Vector3 get_position(bool p_lock = true) const;
+	Vector3 get_position() const;
 
-	Vector3 get_center_of_mass(bool p_lock = true) const;
+	Vector3 get_center_of_mass() const;
 
-	Vector3 get_center_of_mass_local(bool p_lock = true) const;
+	Vector3 get_center_of_mass_local() const;
 
-	Vector3 get_linear_velocity(bool p_lock = true) const;
+	Vector3 get_linear_velocity() const;
 
-	Vector3 get_angular_velocity(bool p_lock = true) const;
+	Vector3 get_angular_velocity() const;
 
-	virtual Vector3 get_velocity_at_position(const Vector3& p_position, bool p_lock = true)
-		const = 0;
+	virtual Vector3 get_velocity_at_position(const Vector3& p_position) const = 0;
 
 	virtual bool has_custom_center_of_mass() const = 0;
 
@@ -102,28 +101,23 @@ public:
 
 	JPH::ShapeRefC try_build_shape();
 
-	void build_shape(bool p_lock = true);
+	void build_shape();
 
 	const JPH::Shape* get_jolt_shape() const { return jolt_shape; }
 
 	const JPH::Shape* get_previous_jolt_shape() const { return previous_jolt_shape; }
 
-	void add_shape(
-		JoltShapeImpl3D* p_shape,
-		Transform3D p_transform,
-		bool p_disabled,
-		bool p_lock = true
-	);
+	void add_shape(JoltShapeImpl3D* p_shape, Transform3D p_transform, bool p_disabled);
 
-	void remove_shape(const JoltShapeImpl3D* p_shape, bool p_lock = true);
+	void remove_shape(const JoltShapeImpl3D* p_shape);
 
-	void remove_shape(int32_t p_index, bool p_lock = true);
+	void remove_shape(int32_t p_index);
 
 	JoltShapeImpl3D* get_shape(int32_t p_index) const;
 
-	void set_shape(int32_t p_index, JoltShapeImpl3D* p_shape, bool p_lock = true);
+	void set_shape(int32_t p_index, JoltShapeImpl3D* p_shape);
 
-	void clear_shapes(bool p_lock = true);
+	void clear_shapes();
 
 	int32_t get_shape_count() const { return shapes.size(); }
 
@@ -141,11 +135,11 @@ public:
 
 	Vector3 get_shape_scale(int32_t p_index) const;
 
-	void set_shape_transform(int32_t p_index, Transform3D p_transform, bool p_lock = true);
+	void set_shape_transform(int32_t p_index, Transform3D p_transform);
 
 	bool is_shape_disabled(int32_t p_index) const;
 
-	void set_shape_disabled(int32_t p_index, bool p_disabled, bool p_lock = true);
+	void set_shape_disabled(int32_t p_index, bool p_disabled);
 
 	virtual void pre_step(float p_step, JPH::Body& p_jolt_body);
 
@@ -164,33 +158,33 @@ protected:
 
 	virtual void _create_in_space() = 0;
 
-	virtual void _add_to_space(bool p_lock = true);
+	virtual void _add_to_space();
 
-	virtual void _remove_from_space(bool p_lock = true);
+	virtual void _remove_from_space();
 
-	virtual void _destroy_in_space(bool p_lock = true);
+	virtual void _destroy_in_space();
 
-	virtual void _apply_transform(const Transform3D& p_transform, bool p_lock = true);
+	virtual void _apply_transform(const Transform3D& p_transform);
 
 	void _create_begin();
 
 	JPH::Body* _create_end();
 
-	void _update_object_layer(bool p_lock = true);
+	void _update_object_layer();
 
-	virtual void _collision_layer_changed(bool p_lock = true);
+	virtual void _collision_layer_changed();
 
-	virtual void _collision_mask_changed(bool p_lock = true);
+	virtual void _collision_mask_changed();
 
-	virtual void _shapes_changed(bool p_lock = true);
+	virtual void _shapes_changed();
 
-	virtual void _shapes_built([[maybe_unused]] bool p_lock = true) { }
+	virtual void _shapes_built() { }
 
-	virtual void _space_changing([[maybe_unused]] bool p_lock = true) { }
+	virtual void _space_changing() { }
 
-	virtual void _space_changed([[maybe_unused]] bool p_lock = true) { }
+	virtual void _space_changed() { }
 
-	virtual void _transform_changed([[maybe_unused]] bool p_lock = true) { }
+	virtual void _transform_changed() { }
 
 	LocalVector<JoltShapeInstance3D> shapes;
 

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -21,13 +21,13 @@ void JoltShapeImpl3D::remove_owner(JoltObjectImpl3D* p_owner) {
 	}
 }
 
-void JoltShapeImpl3D::remove_self(bool p_lock) {
+void JoltShapeImpl3D::remove_self() {
 	// `remove_owner` will be called when we `remove_shape`, so we need to copy the map since the
 	// iterator would be invalidated from underneath us
 	const auto ref_counts_by_owner_copy = ref_counts_by_owner;
 
 	for (const auto& [owner, ref_count] : ref_counts_by_owner_copy) {
-		owner->remove_shape(this, p_lock);
+		owner->remove_shape(this);
 	}
 }
 
@@ -300,9 +300,9 @@ JPH::ShapeRefC JoltShapeImpl3D::without_custom_shapes(const JPH::Shape* p_shape)
 	}
 }
 
-void JoltShapeImpl3D::_invalidated(bool p_lock) {
+void JoltShapeImpl3D::_invalidated() {
 	for (const auto& [owner, ref_count] : ref_counts_by_owner) {
-		owner->_shapes_changed(p_lock);
+		owner->_shapes_changed();
 	}
 }
 

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -16,7 +16,7 @@ public:
 
 	void remove_owner(JoltObjectImpl3D* p_owner);
 
-	void remove_self(bool p_lock = true);
+	void remove_self();
 
 	virtual ShapeType get_type() const = 0;
 
@@ -74,7 +74,7 @@ public:
 protected:
 	virtual JPH::ShapeRefC _build() const = 0;
 
-	virtual void _invalidated(bool p_lock = true);
+	virtual void _invalidated();
 
 	String _owners_to_string() const;
 

--- a/src/spaces/jolt_body_accessor_3d.cpp
+++ b/src/spaces/jolt_body_accessor_3d.cpp
@@ -19,43 +19,35 @@ JoltBodyAccessor3D::JoltBodyAccessor3D(const JoltSpace3D* p_space)
 
 JoltBodyAccessor3D::~JoltBodyAccessor3D() = default;
 
-void JoltBodyAccessor3D::acquire(const JPH::BodyID* p_ids, int32_t p_id_count, bool p_lock) {
+void JoltBodyAccessor3D::acquire(const JPH::BodyID* p_ids, int32_t p_id_count) {
 	ERR_FAIL_NULL(space);
 
-	lock_iface = &space->get_lock_iface(p_lock);
+	lock_iface = &space->get_lock_iface();
 	ids = BodyIDSpan(p_ids, p_id_count);
 	_acquire_internal(p_ids, p_id_count);
 }
 
-void JoltBodyAccessor3D::acquire(const JPH::BodyID& p_id, bool p_lock) {
+void JoltBodyAccessor3D::acquire(const JPH::BodyID& p_id) {
 	ERR_FAIL_NULL(space);
 
-	lock_iface = &space->get_lock_iface(p_lock);
+	lock_iface = &space->get_lock_iface();
 	ids = p_id;
 	_acquire_internal(&p_id, 1);
 }
 
-void JoltBodyAccessor3D::acquire_active(bool p_lock) {
-	ERR_FAIL_NULL(space);
+void JoltBodyAccessor3D::acquire_active() {
+	const JPH::PhysicsSystem& physics_system = space->get_physics_system();
 
-	lock_iface = &space->get_lock_iface(p_lock);
-
-	auto* vector = std::get_if<JPH::BodyIDVector>(&ids);
-
-	if (vector == nullptr) {
-		ids = JPH::BodyIDVector();
-		vector = std::get_if<JPH::BodyIDVector>(&ids);
-	}
-
-	space->get_physics_system().GetActiveBodies(JPH::EBodyType::RigidBody, *vector);
-
-	_acquire_internal(vector->data(), (int32_t)vector->size());
+	acquire(
+		physics_system.GetActiveBodiesUnsafe(JPH::EBodyType::RigidBody),
+		(int32_t)physics_system.GetNumActiveBodies(JPH::EBodyType::RigidBody)
+	);
 }
 
-void JoltBodyAccessor3D::acquire_all(bool p_lock) {
+void JoltBodyAccessor3D::acquire_all() {
 	ERR_FAIL_NULL(space);
 
-	lock_iface = &space->get_lock_iface(p_lock);
+	lock_iface = &space->get_lock_iface();
 
 	auto* vector = std::get_if<JPH::BodyIDVector>(&ids);
 

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -21,13 +21,13 @@ public:
 
 	virtual ~JoltBodyAccessor3D() = 0;
 
-	void acquire(const JPH::BodyID* p_ids, int32_t p_id_count, bool p_lock = true);
+	void acquire(const JPH::BodyID* p_ids, int32_t p_id_count);
 
-	void acquire(const JPH::BodyID& p_id, bool p_lock = true);
+	void acquire(const JPH::BodyID& p_id);
 
-	void acquire_active(bool p_lock = true);
+	void acquire_active();
 
-	void acquire_all(bool p_lock = true);
+	void acquire_all();
 
 	void release();
 
@@ -97,20 +97,15 @@ public:
 	JoltScopedBodyAccessor3D(
 		const JoltSpace3D& p_space,
 		const JPH::BodyID* p_ids,
-		int32_t p_id_count,
-		bool p_lock = true
+		int32_t p_id_count
 	)
 		: inner(&p_space) {
-		inner.acquire(p_ids, p_id_count, p_lock);
+		inner.acquire(p_ids, p_id_count);
 	}
 
-	JoltScopedBodyAccessor3D(
-		const JoltSpace3D& p_space,
-		const JPH::BodyID& p_id,
-		bool p_lock = true
-	)
+	JoltScopedBodyAccessor3D(const JoltSpace3D& p_space, const JPH::BodyID& p_id)
 		: inner(&p_space) {
-		inner.acquire(p_id, p_lock);
+		inner.acquire(p_id);
 	}
 
 	JoltScopedBodyAccessor3D(const JoltScopedBodyAccessor3D& p_other) = delete;
@@ -142,8 +137,8 @@ private:
 template<typename TAccessor, typename TBody>
 class JoltAccessibleBody3D {
 public:
-	JoltAccessibleBody3D(const JoltSpace3D& p_space, const JPH::BodyID& p_id, bool p_lock = true)
-		: accessor(p_space, p_id, p_lock)
+	JoltAccessibleBody3D(const JoltSpace3D& p_space, const JPH::BodyID& p_id)
+		: accessor(p_space, p_id)
 		, body(accessor.try_get()) { }
 
 	bool is_valid() const { return body != nullptr; }
@@ -189,20 +184,15 @@ private:
 template<typename TAccessor, typename TBody>
 class JoltAccessibleBodies3D {
 public:
-	JoltAccessibleBodies3D(
-		const JoltSpace3D& p_space,
-		const JPH::BodyID* p_ids,
-		int32_t p_id_count,
-		bool p_lock = true
-	)
-		: accessor(p_space, p_ids, p_id_count, p_lock) { }
+	JoltAccessibleBodies3D(const JoltSpace3D& p_space, const JPH::BodyID* p_ids, int32_t p_id_count)
+		: accessor(p_space, p_ids, p_id_count) { }
 
 	JoltAccessibleBody3D<TAccessor, TBody> operator[](int32_t p_index) const {
 		const JPH::BodyID& body_id = p_index < accessor.get_count()
 			? accessor.get_at(p_index)
 			: JPH::BodyID();
 
-		return {accessor.get_space(), body_id, false};
+		return {accessor.get_space(), body_id};
 	}
 
 private:

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -373,11 +373,7 @@ void JoltContactListener3D::_flush_contacts() {
 	for (auto&& [shape_pair, manifold] : manifolds_by_shape_pair) {
 		const JPH::BodyID body_ids[] = {shape_pair.GetBody1ID(), shape_pair.GetBody2ID()};
 
-		const JoltReadableBodies3D jolt_bodies = space->read_bodies(
-			body_ids,
-			count_of(body_ids),
-			false
-		);
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(body_ids, count_of(body_ids));
 
 		JoltBodyImpl3D* body1 = jolt_bodies[0].as_body();
 		ERR_FAIL_NULL(body1);
@@ -433,11 +429,7 @@ void JoltContactListener3D::_flush_area_enters() {
 
 		const JPH::BodyID body_ids[] = {body_id1, body_id2};
 
-		const JoltReadableBodies3D jolt_bodies = space->read_bodies(
-			body_ids,
-			count_of(body_ids),
-			false
-		);
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(body_ids, count_of(body_ids));
 
 		const JoltReadableBody3D jolt_body1 = jolt_bodies[0];
 		const JoltReadableBody3D jolt_body2 = jolt_bodies[1];
@@ -464,7 +456,7 @@ void JoltContactListener3D::_flush_area_enters() {
 void JoltContactListener3D::_flush_area_shifts() {
 	for (const JPH::SubShapeIDPair& shape_pair : area_overlaps) {
 		auto is_shifted = [&](const JPH::BodyID& p_body_id, const JPH::SubShapeID& p_sub_shape_id) {
-			const JoltReadableBody3D jolt_body = space->read_body(p_body_id, false);
+			const JoltReadableBody3D jolt_body = space->read_body(p_body_id);
 			const JoltObjectImpl3D* object = jolt_body.as_object();
 			ERR_FAIL_NULL_V(object, false);
 
@@ -500,11 +492,7 @@ void JoltContactListener3D::_flush_area_exits() {
 
 		const JPH::BodyID body_ids[] = {body_id1, body_id2};
 
-		const JoltReadableBodies3D jolt_bodies = space->read_bodies(
-			body_ids,
-			count_of(body_ids),
-			false
-		);
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(body_ids, count_of(body_ids));
 
 		const JoltReadableBody3D jolt_body1 = jolt_bodies[0];
 		const JoltReadableBody3D jolt_body2 = jolt_bodies[1];

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -61,11 +61,7 @@ bool JoltMotionFilter3D::ShouldCollideLocked(const JPH::Body& p_jolt_body) const
 		return false;
 	}
 
-	// TODO(mihe): This should ideally be locked, but we've already locked the body that we're
-	// checking against, so we could deadlock if we try. Since we're not actually using the locks
-	// for anything crucial we can get away with not locking here, but a more robust solution should
-	// be implemented down the line.
-	const JoltReadableBody3D jolt_body_self = space.read_body(body_self, false);
+	const JoltReadableBody3D jolt_body_self = space.read_body(body_self);
 
 	return jolt_body_self->GetCollisionGroup().CanCollide(p_jolt_body.GetCollisionGroup());
 }

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -400,7 +400,7 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	p_info->rid = object->get_rid();
 	p_info->collider_id = object->get_instance_id();
 	p_info->shape = shape_index;
-	p_info->linear_velocity = object->get_velocity_at_position(hit_point, false);
+	p_info->linear_velocity = object->get_velocity_at_position(hit_point);
 
 	return true;
 }
@@ -956,8 +956,8 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 
 		collision.position = position;
 		collision.normal = to_godot(-hit.mPenetrationAxis.Normalized());
-		collision.collider_velocity = collider->get_velocity_at_position(position, false);
-		collision.collider_angular_velocity = collider->get_angular_velocity(false);
+		collision.collider_velocity = collider->get_velocity_at_position(position);
+		collision.collider_angular_velocity = collider->get_angular_velocity();
 		collision.depth = penetration_depth;
 		collision.local_shape = local_shape;
 		collision.collider_id = collider->get_instance_id();

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -270,33 +270,15 @@ void JoltSpace3D::set_param(
 	}
 }
 
-JPH::BodyInterface& JoltSpace3D::get_body_iface([[maybe_unused]] bool p_locked) {
-#ifndef GDJ_CONFIG_DISTRIBUTION
-	if (p_locked && body_accessor.not_acquired()) {
-		return physics_system->GetBodyInterface();
-	}
-#endif // GDJ_CONFIG_DISTRIBUTION
-
+JPH::BodyInterface& JoltSpace3D::get_body_iface() {
 	return physics_system->GetBodyInterfaceNoLock();
 }
 
-const JPH::BodyInterface& JoltSpace3D::get_body_iface([[maybe_unused]] bool p_locked) const {
-#ifndef GDJ_CONFIG_DISTRIBUTION
-	if (p_locked && body_accessor.not_acquired()) {
-		return physics_system->GetBodyInterface();
-	}
-#endif // GDJ_CONFIG_DISTRIBUTION
-
+const JPH::BodyInterface& JoltSpace3D::get_body_iface() const {
 	return physics_system->GetBodyInterfaceNoLock();
 }
 
-const JPH::BodyLockInterface& JoltSpace3D::get_lock_iface([[maybe_unused]] bool p_locked) const {
-#ifndef GDJ_CONFIG_DISTRIBUTION
-	if (p_locked && body_accessor.not_acquired()) {
-		return physics_system->GetBodyLockInterface();
-	}
-#endif // GDJ_CONFIG_DISTRIBUTION
-
+const JPH::BodyLockInterface& JoltSpace3D::get_lock_iface() const {
 	return physics_system->GetBodyLockInterfaceNoLock();
 }
 
@@ -304,14 +286,7 @@ const JPH::BroadPhaseQuery& JoltSpace3D::get_broad_phase_query() const {
 	return physics_system->GetBroadPhaseQuery();
 }
 
-const JPH::NarrowPhaseQuery& JoltSpace3D::get_narrow_phase_query([[maybe_unused]] bool p_locked
-) const {
-#ifndef GDJ_CONFIG_DISTRIBUTION
-	if (p_locked && body_accessor.not_acquired()) {
-		return physics_system->GetNarrowPhaseQuery();
-	}
-#endif // GDJ_CONFIG_DISTRIBUTION
-
+const JPH::NarrowPhaseQuery& JoltSpace3D::get_narrow_phase_query() const {
 	return physics_system->GetNarrowPhaseQueryNoLock();
 }
 
@@ -337,36 +312,30 @@ void JoltSpace3D::map_from_object_layer(
 	);
 }
 
-JoltReadableBody3D JoltSpace3D::read_body(const JPH::BodyID& p_body_id, bool p_lock) const {
-	return {*this, p_body_id, p_lock};
+JoltReadableBody3D JoltSpace3D::read_body(const JPH::BodyID& p_body_id) const {
+	return {*this, p_body_id};
 }
 
-JoltReadableBody3D JoltSpace3D::read_body(const JoltObjectImpl3D& p_object, bool p_lock) const {
-	return read_body(p_object.get_jolt_id(), p_lock);
+JoltReadableBody3D JoltSpace3D::read_body(const JoltObjectImpl3D& p_object) const {
+	return read_body(p_object.get_jolt_id());
 }
 
-JoltWritableBody3D JoltSpace3D::write_body(const JPH::BodyID& p_body_id, bool p_lock) const {
-	return {*this, p_body_id, p_lock};
+JoltWritableBody3D JoltSpace3D::write_body(const JPH::BodyID& p_body_id) const {
+	return {*this, p_body_id};
 }
 
-JoltWritableBody3D JoltSpace3D::write_body(const JoltObjectImpl3D& p_object, bool p_lock) const {
-	return write_body(p_object.get_jolt_id(), p_lock);
+JoltWritableBody3D JoltSpace3D::write_body(const JoltObjectImpl3D& p_object) const {
+	return write_body(p_object.get_jolt_id());
 }
 
-JoltReadableBodies3D JoltSpace3D::read_bodies(
-	const JPH::BodyID* p_body_ids,
-	int32_t p_body_count,
-	bool p_lock
-) const {
-	return {*this, p_body_ids, p_body_count, p_lock};
+JoltReadableBodies3D JoltSpace3D::read_bodies(const JPH::BodyID* p_body_ids, int32_t p_body_count)
+	const {
+	return {*this, p_body_ids, p_body_count};
 }
 
-JoltWritableBodies3D JoltSpace3D::write_bodies(
-	const JPH::BodyID* p_body_ids,
-	int32_t p_body_count,
-	bool p_lock
-) const {
-	return {*this, p_body_ids, p_body_count, p_lock};
+JoltWritableBodies3D JoltSpace3D::write_bodies(const JPH::BodyID* p_body_ids, int32_t p_body_count)
+	const {
+	return {*this, p_body_ids, p_body_count};
 }
 
 JoltPhysicsDirectSpaceState3D* JoltSpace3D::get_direct_state() {
@@ -465,7 +434,7 @@ void JoltSpace3D::set_max_debug_contacts(int32_t p_count) {
 #endif // GDJ_CONFIG_EDITOR
 
 void JoltSpace3D::_pre_step(float p_step) {
-	body_accessor.acquire_all(true);
+	body_accessor.acquire_all();
 
 	contact_listener->pre_step();
 
@@ -487,7 +456,7 @@ void JoltSpace3D::_pre_step(float p_step) {
 }
 
 void JoltSpace3D::_post_step(float p_step) {
-	body_accessor.acquire_all(true);
+	body_accessor.acquire_all();
 
 	contact_listener->post_step();
 

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -29,15 +29,15 @@ public:
 
 	JPH::PhysicsSystem& get_physics_system() const { return *physics_system; }
 
-	JPH::BodyInterface& get_body_iface(bool p_locked = true);
+	JPH::BodyInterface& get_body_iface();
 
-	const JPH::BodyInterface& get_body_iface(bool p_locked = true) const;
+	const JPH::BodyInterface& get_body_iface() const;
 
-	const JPH::BodyLockInterface& get_lock_iface(bool p_locked = true) const;
+	const JPH::BodyLockInterface& get_lock_iface() const;
 
 	const JPH::BroadPhaseQuery& get_broad_phase_query() const;
 
-	const JPH::NarrowPhaseQuery& get_narrow_phase_query(bool p_locked = true) const;
+	const JPH::NarrowPhaseQuery& get_narrow_phase_query() const;
 
 	JPH::ObjectLayer map_to_object_layer(
 		JPH::BroadPhaseLayer p_broad_phase_layer,
@@ -52,25 +52,17 @@ public:
 		uint32_t& p_collision_mask
 	) const;
 
-	JoltReadableBody3D read_body(const JPH::BodyID& p_body_id, bool p_lock = true) const;
+	JoltReadableBody3D read_body(const JPH::BodyID& p_body_id) const;
 
-	JoltReadableBody3D read_body(const JoltObjectImpl3D& p_object, bool p_lock = true) const;
+	JoltReadableBody3D read_body(const JoltObjectImpl3D& p_object) const;
 
-	JoltWritableBody3D write_body(const JPH::BodyID& p_body_id, bool p_lock = true) const;
+	JoltWritableBody3D write_body(const JPH::BodyID& p_body_id) const;
 
-	JoltWritableBody3D write_body(const JoltObjectImpl3D& p_object, bool p_lock = true) const;
+	JoltWritableBody3D write_body(const JoltObjectImpl3D& p_object) const;
 
-	JoltReadableBodies3D read_bodies(
-		const JPH::BodyID* p_body_ids,
-		int32_t p_body_count,
-		bool p_lock = true
-	) const;
+	JoltReadableBodies3D read_bodies(const JPH::BodyID* p_body_ids, int32_t p_body_count) const;
 
-	JoltWritableBodies3D write_bodies(
-		const JPH::BodyID* p_body_ids,
-		int32_t p_body_count,
-		bool p_lock = true
-	) const;
+	JoltWritableBodies3D write_bodies(const JPH::BodyID* p_body_ids, int32_t p_body_count) const;
 
 	JoltPhysicsDirectSpaceState3D* get_direct_state();
 


### PR DESCRIPTION
This (finally) removes all the `p_lock` parameters that's found on almost every single method in this codebase.

These parameters have never done anything in distributed builds, and only existed because I didn't know what thread-safety would look like for this extension, leading me to end up with this half-and-half weird-looking thing.

It's been pretty clear for a while now that the likelihood of this implementation using any type of fine-grained locking is pretty slim, as discussed in #356, so I've decided to remove all the `p_lock` parameters.

The next step (at some later date) will be to actually embed the `JPH::Body` pointer within `JoltObjectImpl3D`, which should help get rid of a lot of usage of `JoltReadableBody3D` and `JoltWritableBody3D` that is similarly prevalent for no good reason.