### PR TITLE
Fixed issue with contact shape indices being wrong sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where contact shape indices would sometimes always be the same index.
+- Fixed runtime crash when setting the `max_contacts_reported` property to a lower value.
+
 ## [0.11.0] - 2023-12-01
 
 ### Changed

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -82,7 +82,7 @@ public:
 
 	Vector3 get_velocity_at_position(const Vector3& p_position) const override;
 
-	bool generates_contacts() const override { return false; }
+	bool reports_contacts() const override { return false; }
 
 	bool is_point_gravity() const { return point_gravity; }
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -95,13 +95,13 @@ public:
 
 	int32_t get_max_contacts_reported() const { return contacts.size(); }
 
-	void set_max_contacts_reported(int32_t p_count) { contacts.resize(p_count); }
+	void set_max_contacts_reported(int32_t p_count);
 
 	int32_t get_contact_count() const { return contact_count; }
 
 	const Contact& get_contact(int32_t p_index) { return contacts[p_index]; }
 
-	bool generates_contacts() const override { return !contacts.is_empty(); }
+	bool reports_contacts() const override { return !contacts.is_empty(); }
 
 	void add_contact(
 		const JoltBodyImpl3D* p_collider,
@@ -304,6 +304,8 @@ private:
 	void _exceptions_changed();
 
 	void _axis_lock_changed();
+
+	void _contact_reporting_changed();
 
 	LocalVector<RID> exceptions;
 

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -97,7 +97,7 @@ public:
 
 	void set_pickable(bool p_enabled) { pickable = p_enabled; }
 
-	virtual bool generates_contacts() const = 0;
+	virtual bool reports_contacts() const = 0;
 
 	JPH::ShapeRefC try_build_shape();
 

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -446,7 +446,7 @@ void JoltSpace3D::_pre_step(float p_step) {
 
 			object->pre_step(p_step, *jolt_body);
 
-			if (object->generates_contacts()) {
+			if (object->reports_contacts()) {
 				contact_listener->listen_for(object);
 			}
 		}


### PR DESCRIPTION
Fixes #703.

This changes bodies with a `max_contacts_reported` greater than 0 to disable Jolt's manifold reduction, which would otherwise reduce the number of manifolds in multi-shape collisions to the point where they used just one (or more?) manifolds, resulting in every contact incorrectly having the same shape index associated with it.