### PR TITLE
Updated Jolt to 1939b95491

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 4ff703d11506290383fc82e926f1eaad728f0e01
+	GIT_COMMIT 1939b954913ba77a61cb1c651cb0028456d748f6
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@4ff703d11506290383fc82e926f1eaad728f0e01 to godot-jolt/jolt@1939b954913ba77a61cb1c651cb0028456d748f6 (see diff [here](https://github.com/godot-jolt/jolt/compare/4ff703d11506290383fc82e926f1eaad728f0e01...1939b954913ba77a61cb1c651cb0028456d748f6)).

This brings in the following relevant changes:

- Added `JPH::BodyInterface::SetUseManifoldReduction`