### PR TITLE
Fixed `max_contacts_reported` not invalidating contacts

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -445,10 +445,9 @@ void JoltBodyImpl3D::set_max_contacts_reported(int32_t p_count) {
 		return;
 	}
 
-	const JoltWritableBody3D body = space->write_body(jolt_id);
-	ERR_FAIL_COND(body.is_invalid());
+	JPH::BodyInterface& body_iface = space->get_body_iface();
 
-	body->SetUseManifoldReduction(use_manifold_reduction);
+	body_iface.SetUseManifoldReduction(jolt_id, use_manifold_reduction);
 }
 
 void JoltBodyImpl3D::add_contact(


### PR DESCRIPTION
This fixes an issue, which is technically only relevant since #705, where if you enabled contact reporting (by changing `max_contacts_reported` to be non-zero) while you were mid-contact with some other body, you wouldn't receive reports of all the shape indices as expected.