### PR TITLE
Add minimum iOS version to Info.plist template

### DIFF
--- a/cmake/templates/info.plist.in
+++ b/cmake/templates/info.plist.in
@@ -24,5 +24,7 @@
 	<string>FMWK</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+	<key>MinimumOSVersion</key>
+	<string>15.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
When creating a release build of an iOS app containing this extension, I got errors stating that the `MinimumOSVersion` key was missing in `Info.plist`.

This PR adds that key and sets its value to iOS 15.0. The version could potentially be lower but I haven't tested it and most people are on 16 or 17 anyway.