### PR TITLE
Added separate `Info.plist` for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Breaking changes are denoted with ⚠️.
   frozen `RigidBody3D` using `FREEZE_MODE_STATIC`) would result in NaNs.
 - Fixed issue where `HingeJoint3D` and `JoltHingeJoint3D` would sometimes dull forces applied to
   either of its bodies when at either of its limits.
+- Fixed issue with iOS `Info.plist` missing the `MinimumOSVersion` key.
 
 ## [0.11.0] - 2023-12-01
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,12 @@ endif()
 set(suffix_editor $<${is_editor_config}:_editor>)
 set(suffix ${suffix_platform}${suffix_arch}${suffix_editor})
 
+if(IOS)
+	set(info_plist ${templates_dir}/info_ios.plist.in)
+else()
+	set(info_plist ${templates_dir}/info_macos.plist.in)
+endif()
+
 set(use_static_crt $<BOOL:${GDJ_STATIC_RUNTIME_LIBRARY}>)
 set(msvcrt_debug $<$<CONFIG:Debug,EditorDebug>:Debug>)
 set(msvcrt_dll $<$<NOT:${use_static_crt}>:DLL>)
@@ -139,7 +145,7 @@ set_target_properties(godot-jolt PROPERTIES
 	FRAMEWORK TRUE
 	MACOSX_RPATH FALSE
 	INSTALL_NAME_DIR @rpath
-	MACOSX_FRAMEWORK_INFO_PLIST ${templates_dir}/info.plist.in
+	MACOSX_FRAMEWORK_INFO_PLIST ${info_plist}
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${PROJECT_BUNDLE_IDENTIFIER}
 )
 

--- a/cmake/templates/info_ios.plist.in
+++ b/cmake/templates/info_ios.plist.in
@@ -24,5 +24,9 @@
 	<string>FMWK</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+	<key>DTPlatformName</key>
+	<string>iphoneos</string>
+	<key>MinimumOSVersion</key>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
 </dict>
 </plist>

--- a/cmake/templates/info_macos.plist.in
+++ b/cmake/templates/info_macos.plist.in
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_FRAMEWORK_NAME}</string>
+	<key>CFBundleName</key>
+	<string>${PROJECT_TITLE}</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PROJECT_TITLE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PROJECT_BUNDLE_IDENTIFIER}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>${PROJECT_COPYRIGHT}</string>
+	<key>CFBundleVersion</key>
+	<string>${PROJECT_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${PROJECT_VERSION}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
+</dict>
+</plist>


### PR DESCRIPTION
Supersedes #710.

This adds a new `Info.plist` template specific to iOS, which adds the missing `MinimumOSVersion` key, allowing one to actually create release builds when this extension is bundled.

I also threw in the `DTPlatformName` key on both macOS and iOS, which seems to be something that Godot adds for its [automatically generated](https://github.com/godotengine/godot/blob/d5ad37afcd44f4ba953e3473b5ab3afb18068134/platform/ios/export/export_plugin.cpp#L1180-L1203) `Info.plist` in the case where an extension only provides a `.dylib` file.