### PR TITLE
Updated Jolt to 8d1f587da4

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 1939b954913ba77a61cb1c651cb0028456d748f6
+	GIT_COMMIT 8d1f587da49809bafe6eba54cd89301a8a820e95
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -179,8 +179,8 @@ void JoltJointImpl3D::_update_enabled() {
 
 void JoltJointImpl3D::_update_iterations() {
 	if (jolt_ref != nullptr) {
-		jolt_ref->SetNumVelocityStepsOverride(velocity_iterations);
-		jolt_ref->SetNumPositionStepsOverride(position_iterations);
+		jolt_ref->SetNumVelocityStepsOverride((JPH::uint)velocity_iterations);
+		jolt_ref->SetNumPositionStepsOverride((JPH::uint)position_iterations);
 	}
 }
 

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -46,8 +46,8 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	settings.mPenetrationSlop = JoltProjectSettings::get_contact_penetration();
 	settings.mLinearCastThreshold = JoltProjectSettings::get_ccd_movement_threshold();
 	settings.mLinearCastMaxPenetration = JoltProjectSettings::get_ccd_max_penetration();
-	settings.mNumVelocitySteps = JoltProjectSettings::get_velocity_iterations();
-	settings.mNumPositionSteps = JoltProjectSettings::get_position_iterations();
+	settings.mNumVelocitySteps = (JPH::uint)JoltProjectSettings::get_velocity_iterations();
+	settings.mNumPositionSteps = (JPH::uint)JoltProjectSettings::get_position_iterations();
 	settings.mMinVelocityForRestitution = JoltProjectSettings::get_bounce_velocity_threshold();
 	settings.mTimeBeforeSleep = JoltProjectSettings::get_sleep_time_threshold();
 	settings.mPointVelocitySleepThreshold = JoltProjectSettings::get_sleep_velocity_threshold();


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@1939b954913ba77a61cb1c651cb0028456d748f6 to godot-jolt/jolt@8d1f587da49809bafe6eba54cd89301a8a820e95 (see diff [here](https://github.com/godot-jolt/jolt/compare/1939b954913ba77a61cb1c651cb0028456d748f6...8d1f587da49809bafe6eba54cd89301a8a820e95)).

This brings in the following relevant changes:

- Changes the solver iteration overrides for joints to allow for values lower than the default/global values.
- Allows for asymmetrical limits for `JPH::SixDOFConstraint`.
- Allows for pyramidal limits for `JPH::SixDOFConstraint` and `JPH::SwingTwistConstraint`.
- Bugfix to indexification that happens when creating `JPH::MeshShape`.