### PR TITLE
Changed 6DOF and cone-twist joint to use pyramid limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed `Generic6DOFJoint3D` and `ConeTwistJointImpl3D`, as well as their substitute joints, to
+  use pyramid-shaped angular limits instead of cone-shaped limits, to better match Godot Physics.
+
 ### Fixed
 
 - Fixed issue where contact shape indices would sometimes always be the same index.

--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -314,6 +314,7 @@ JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(
 	constraint_settings.mPosition2 = to_jolt(p_shifted_ref_b.origin);
 	constraint_settings.mTwistAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
+	constraint_settings.mSwingType = JPH::ESwingType::Pyramid;
 
 	if (p_jolt_body_b != nullptr) {
 		return constraint_settings.Create(*p_jolt_body_a, *p_jolt_body_b);

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -507,6 +507,7 @@ void JoltGeneric6DOFJointImpl3D::rebuild() {
 	constraint_settings.mPosition2 = to_jolt(shifted_ref_b.origin);
 	constraint_settings.mAxisX2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY2 = to_jolt(shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
+	constraint_settings.mSwingType = JPH::ESwingType::Pyramid;
 
 	if (body_b != nullptr) {
 		const JoltWritableBody3D jolt_body_a = bodies[0];


### PR DESCRIPTION
Related to jrouwe/JoltPhysics#777.

This changes `Generic6DOFJoint3D` and `ConeTwistJointImpl3D` to use `JPH::ESwingType::Pyramid` for the new "swing type" that was introduced to Jolt recently. This effectively changes the shape of the angular limits to that of a pyramid, as opposed to the default cone shape.

This better matches how Godot Physics behaves, as well as how Bullet behaved in Godot 3.