### PR TITLE
Updated Jolt to 38e6435777

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 8d1f587da49809bafe6eba54cd89301a8a820e95
+	GIT_COMMIT 38e6435777e4cd81f8598b777e6c4961656cffec
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@8d1f587da49809bafe6eba54cd89301a8a820e95 to godot-jolt/jolt@38e6435777e4cd81f8598b777e6c4961656cffec (see diff [here](https://github.com/godot-jolt/jolt/compare/8d1f587da49809bafe6eba54cd89301a8a820e95...38e6435777e4cd81f8598b777e6c4961656cffec)).

This brings in the following relevant changes:

- Allows `SixDOFConstraintSettings::SetLimitedAxis` to accept identical min/max limits.