### PR TITLE
Removed manual shifting of reference frames for 6DOF joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Breaking changes are denoted with ⚠️.
 
 - Fixed issue where contact shape indices would sometimes always be the same index.
 - Fixed runtime crash when setting the `max_contacts_reported` property to a lower value.
+- Fixed issue where `Generic6DOFJoint3D` and `JoltGeneric6DOFJoint3D` would yield odd limit shapes
+  when using both linear and angular limits.
+- Fixed issue where the equilibrium point for `Generic6DOFJoint3D` and `JoltGeneric6DOFJoint3D`
+  would be moved when using asymmetrical limits.
 
 ## [0.11.0] - 2023-12-01
 


### PR DESCRIPTION
This removes the shifting of reference frames that was previously being done, where the reference frame of node A would be shifted in order to center the limits at 0, as this ended up causing a number of issues.

It would result in issues like having weird "limit shapes" when you incorporated both linear and angular limits, as well as problems with things like the "Equilibrium Point" properties, as the equilibrium points would erroneously be moved whenever you used asymmetrical limits.

Now instead the above mentioned centering is handled by Jolt internally, thanks to some recent changes, and we can instead throw pretty much any limits we want at the joint.