### PR TITLE
Inverted direction of 6DOF equilibrium point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Breaking changes are denoted with ⚠️.
   Bullet behaves in Godot 3, and yields more intuitive outcomes for the 6DOF joints.
 - ⚠️ Changed `Generic6DOFJoint3D` and `ConeTwistJointImpl3D`, as well as their substitute joints, to
   use pyramid-shaped angular limits instead of cone-shaped limits, to better match Godot Physics.
+- ⚠️ Inverted the direction of the "Equilibrium Point" properties for `Generic6DOFJoint3D` and
+  `JoltGeneric6DOFJoint3D`, to match how it behaves in Bullet in Godot 3.
 
 ### Added
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -615,20 +615,18 @@ void JoltGeneric6DOFJointImpl3D::_update_spring_equilibrium(int32_t p_axis) {
 
 	if (p_axis >= AXIS_LINEAR_X && p_axis <= AXIS_LINEAR_Z) {
 		const Vector3 target_position = Vector3(
-			(float)-spring_equilibrium[AXIS_LINEAR_X],
-			(float)-spring_equilibrium[AXIS_LINEAR_Y],
-			(float)-spring_equilibrium[AXIS_LINEAR_Z]
+			(float)spring_equilibrium[AXIS_LINEAR_X],
+			(float)spring_equilibrium[AXIS_LINEAR_Y],
+			(float)spring_equilibrium[AXIS_LINEAR_Z]
 		);
 
 		constraint->SetTargetPositionCS(to_jolt(target_position));
 	} else {
-		// HACK(mihe): These are flipped to match Bullet in Godot 3, presumably for the same
-		// reason that the angular motor velocity needs to be flipped. Godot 4 does not
-		// currently have springs implemented, so can't be used as a reference.
+		// NOTE(mihe): We flip the direction since Jolt is CCW but Godot is CW.
 		const Basis target_orientation = Basis::from_euler(
-			{(float)spring_equilibrium[AXIS_ANGULAR_X],
-			 (float)spring_equilibrium[AXIS_ANGULAR_Y],
-			 (float)spring_equilibrium[AXIS_ANGULAR_Z]}
+			{(float)-spring_equilibrium[AXIS_ANGULAR_X],
+			 (float)-spring_equilibrium[AXIS_ANGULAR_Y],
+			 (float)-spring_equilibrium[AXIS_ANGULAR_Z]}
 		);
 
 		constraint->SetTargetOrientationCS(to_jolt(target_orientation));


### PR DESCRIPTION
It turned out that as a result of the discrepancy between Bullet (in Godot 3) and Godot Physics when it comes to single-body joints, as described in #725, and me having used Bullet as a reference when implementing the equilibrium point, I had mistook the direction in which the equilibrium point is meant to go.

This PR inverts the direction to correct for this.