### PR TITLE
Mirrored linear limits gizmo for applicable joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Breaking changes are denoted with ⚠️.
   use pyramid-shaped angular limits instead of cone-shaped limits, to better match Godot Physics.
 - ⚠️ Inverted the direction of the "Equilibrium Point" properties for `Generic6DOFJoint3D` and
   `JoltGeneric6DOFJoint3D`, to match how it behaves in Bullet in Godot 3.
+- Mirrored the way in which linear limits are visualized for `JoltSliderJoint3D` and
+  `JoltGeneric6DOFJoint3D`.
 
 ### Added
 

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -57,13 +57,9 @@ void draw_linear_limits(
 	};
 
 	if (p_limit_enabled && p_limit_upper >= p_limit_lower) {
-		// HACK(mihe): Since Godot's linear constraints seem to be inverted, and we emulate that
-		// even for the custom joints, we're forced to flip these to line up with the actual range
-		// of motion.
-
-		draw_line(-p_limit_upper, -p_limit_lower);
-		draw_square(-p_limit_upper);
-		draw_square(-p_limit_lower);
+		draw_line(p_limit_lower, p_limit_upper);
+		draw_square(p_limit_lower);
+		draw_square(p_limit_upper);
 	} else {
 		draw_line(GIZMO_RADIUS, -GIZMO_RADIUS);
 	}


### PR DESCRIPTION
This changes the linear limits visualization for the editor gizmos of `JoltSliderJoint3D` as well as `JoltGeneric6DOFJoint3D` to be mirrored compared to what they were previously, so that the lower and upper limits swap places.

Until now the visualization of the linear limits has deliberately been inverted, where linear limits of something like [0, 5] would show a range of movement in the negative of that axis. This was to match how the corresponding gizmo would behave in both Godot 3 and Godot 4.

However, given that `node_a` dictates the space for the linear limits, it would stand to argue that if `node_a` is made static and `node_b` is not, then the visualized range-of-motion should correspond with how `node_b` is able to move, which has not been the case until now.

Besides getting rid of this arbitrary inversion which has been bothering me since I first implemented the gizmos, this new behavior also lines up with how NVIDIA Omniverse USD Composer visualizes the linear limits for its joint gizmos, which should hopefully lend some credibility to this way of doing it.