### PR TITLE
Fixed rotation order of euler angles within joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ Breaking changes are denoted with ⚠️.
   Bullet behaves in Godot 3, and yields more intuitive outcomes for the 6DOF joints.
 - ⚠️ Changed `Generic6DOFJoint3D` and `ConeTwistJointImpl3D`, as well as their substitute joints, to
   use pyramid-shaped angular limits instead of cone-shaped limits, to better match Godot Physics.
-- ⚠️ Inverted the direction of the "Equilibrium Point" properties for `Generic6DOFJoint3D` and
+- ⚠️ Inverted the direction of the `equilibrium_point` properties for `Generic6DOFJoint3D` and
   `JoltGeneric6DOFJoint3D`, to match how it behaves in Bullet in Godot 3.
+- ⚠️ Changed the rotation order of the `equilibrium_point` properties for `Generic6DOFJoint3D` and
+  `JoltGeneric6DOFJoint3D`, from YXZ to XYZ, to match the rotation order of the angular limits.
 - Mirrored the way in which linear limits are visualized for `JoltSliderJoint3D` and
   `JoltGeneric6DOFJoint3D`.
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -625,7 +625,8 @@ void JoltGeneric6DOFJointImpl3D::_update_spring_equilibrium(int32_t p_axis) {
 		const Basis target_orientation = Basis::from_euler(
 			{(float)-spring_equilibrium[AXIS_ANGULAR_X],
 			 (float)-spring_equilibrium[AXIS_ANGULAR_Y],
-			 (float)-spring_equilibrium[AXIS_ANGULAR_Z]}
+			 (float)-spring_equilibrium[AXIS_ANGULAR_Z]},
+			EULER_ORDER_XYZ
 		);
 
 		constraint->SetTargetOrientationCS(to_jolt(target_orientation));

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -179,7 +179,7 @@ void JoltJointImpl3D::_shift_reference_frames(
 	const Basis& basis_a = local_ref_a.basis;
 	const Basis& basis_b = local_ref_b.basis;
 
-	const Basis shifted_basis_a = basis_a * Basis::from_euler(p_angular_shift);
+	const Basis shifted_basis_a = basis_a * Basis::from_euler(p_angular_shift, EULER_ORDER_XYZ);
 	const Vector3 shifted_origin_a = origin_a - basis_a.xform(p_linear_shift);
 
 	p_shifted_ref_a = Transform3D(shifted_basis_a, shifted_origin_a);


### PR DESCRIPTION
This changes the rotation order for all places within the joints where euler angles are converted into matrices/quaternions, from the default YXZ to XYZ, to match the rotation order that Jolt (as well as Bullet and Godot Physics) uses internally for the 6DOF joint.

While this technically affects `JoltJointImpl3D::_shift_reference_frames`, this change has no real impact there, since the 6DOF joints no longer rely on shifting the reference frames, as of #724. The only real change, which is technically a breaking one, is with the 6DOF spring equilibrium.