### PR TITLE
Fixed move assignment operator in `JoltShapeInstance3D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Breaking changes are denoted with ⚠️.
   when using both linear and angular asymmetrical limits.
 - Fixed issue where the equilibrium point for `Generic6DOFJoint3D` and `JoltGeneric6DOFJoint3D`
   would be moved when using asymmetrical limits.
+- Fixed crash that could occur under rare circumstances when shutting down the editor after having
+  added/removed collision shapes.
 
 ## [0.11.0] - 2023-12-01
 

--- a/src/shapes/jolt_shape_instance_3d.cpp
+++ b/src/shapes/jolt_shape_instance_3d.cpp
@@ -17,9 +17,14 @@ JoltShapeInstance3D::JoltShapeInstance3D(
 	shape->add_owner(parent);
 }
 
-JoltShapeInstance3D::JoltShapeInstance3D(JoltShapeInstance3D&& p_other) noexcept {
-	*this = std::move(p_other);
-}
+JoltShapeInstance3D::JoltShapeInstance3D(JoltShapeInstance3D&& p_other) noexcept
+	: transform(p_other.transform)
+	, scale(p_other.scale)
+	, jolt_ref(std::move(p_other.jolt_ref))
+	, parent(std::exchange(p_other.parent, nullptr))
+	, shape(std::exchange(p_other.shape, nullptr))
+	, id(p_other.id)
+	, disabled(p_other.disabled) { }
 
 JoltShapeInstance3D::~JoltShapeInstance3D() {
 	if (shape != nullptr) {
@@ -54,9 +59,9 @@ JoltShapeInstance3D& JoltShapeInstance3D::operator=(JoltShapeInstance3D&& p_othe
 	if (this != &p_other) {
 		transform = p_other.transform;
 		scale = p_other.scale;
-		parent = std::exchange(p_other.parent, nullptr);
-		shape = std::exchange(p_other.shape, nullptr);
 		jolt_ref = std::move(p_other.jolt_ref);
+		std::swap(parent, p_other.parent);
+		std::swap(shape, p_other.shape);
 		id = p_other.id;
 		disabled = p_other.disabled;
 	}


### PR DESCRIPTION
Hopefully fixes #722.

This changes the move assignment operator in `JoltShapeInstance3D` to correctly hand off the old values to the temporary in order for the temporary to correctly decrement the reference counter for the actual `JoltShapeImpl3D`.

While I haven't been able to confirm this, this was most likely the cause for the crash, as you could otherwise potentially end up with "leaks" in the reference counting that would cause a crash once the shape was destroyed.