### PR TITLE
Added proper support for holes to `HeightMapShape3D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,12 @@ Breaking changes are denoted with ⚠️.
 - Added new project setting, "World Node", for controlling which of the two nodes in a single-body
   joint becomes the "world node" when omitting one of the nodes. This allows for reverting back to
   the behavior of Godot Physics if needed, effectively undoing the breaking change mentioned above.
+- Added support for using NaN to indicate holes in `HeightMapShape3D`.
+- Added support for holes in a non-square `HeightMapShape3D`.
 
 ### Fixed
 
+- ⚠️ Fixed issue with non-square `HeightMapShape3D` not using back-face collision.
 - Fixed issue where contact shape indices would sometimes always be the same index across all
   contacts with a particular body.
 - Fixed runtime crash when setting the `max_contacts_reported` property to a lower value.

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -128,6 +128,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
Fixes #688.
Complements #691.

This changes a number of things related to `HeightMapShape3D`:

1. Non-square height maps had been left out of [#691](https://github.com/godot-jolt/godot-jolt/pull/691) and thus weren't using back-face collision, which is now fixed.
2. Non-square height maps (and technically 3x3 height maps) didn't support holes, which they now do.
3. Holes can now be specified using NaN instead of `FLT_MAX`, to line up with the undocumented support for holes in Godot.