### PR TITLE
Updated Jolt to 36869b03a0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Breaking changes are denoted with ⚠️.
   would be moved when using asymmetrical limits.
 - Fixed crash that could occur under rare circumstances when shutting down the editor after having
   added/removed collision shapes.
+- Fixed issue where a `RigidBody3D` with locked axes colliding with a `StaticBody3D` (or another
+  frozen `RigidBody3D` using `FREEZE_MODE_STATIC`) would result in NaNs.
+- Fixed issue where `HingeJoint3D` and `JoltHingeJoint3D` would sometimes dull forces applied to
+  either of its bodies when at either of its limits.
 
 ## [0.11.0] - 2023-12-01
 

--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 38e6435777e4cd81f8598b777e6c4961656cffec
+	GIT_COMMIT 36869b03a0f0f542ab56575265a33dda9706fa8d
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -301,7 +301,7 @@ void JoltAreaImpl3D::_create_in_space() {
 	jolt_settings->mUseManifoldReduction = false;
 
 	if (JoltProjectSettings::areas_detect_static_bodies()) {
-		jolt_settings->mSensorDetectsStatic = true;
+		jolt_settings->mCollideKinematicVsNonDynamic = true;
 	}
 
 	_create_end();

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -238,12 +238,10 @@ bool JoltContactListener3D::_try_evaluate_area_overlap(
 		return false;
 	}
 
-	const bool is_actually_overlapping = p_manifold.mPenetrationDepth >= 0.0f;
-
 	auto evaluate = [&](auto&& p_area, auto&& p_object, const JPH::SubShapeIDPair& p_shape_pair) {
 		const MutexLock write_lock(write_mutex);
 
-		if (is_actually_overlapping && p_area.can_monitor(p_object)) {
+		if (p_area.can_monitor(p_object)) {
 			if (!area_overlaps.has(p_shape_pair)) {
 				area_overlaps.insert(p_shape_pair);
 				area_enters.insert(p_shape_pair);


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@38e6435777e4cd81f8598b777e6c4961656cffec to godot-jolt/jolt@3755a33ffd279a3d926a6d71ae077b4faa1c1f12 (see diff [here](https://github.com/godot-jolt/jolt/compare/38e6435777e4cd81f8598b777e6c4961656cffec...3755a33ffd279a3d926a6d71ae077b4faa1c1f12)).

This brings in the following relevant changes:

- Fixes issue with sensors utilizing speculative contact distance
- Fixes issue with hinge constraints enforcing the wrong limit
- Fixes NaN propagation when bodies with locked axes collide with static bodies
- Replaces `mSensorDetectsStatic` flag in favor of `mCollideKinematicVsNonDynamic`

Fixes #733.
Fixes #734.