### PR TITLE
Updated godot-cpp to 43d02f2d7c (4.2-stable)

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -19,7 +19,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT c0dd7eeada027006d4ebed62a44ac9378d4147d3
+	GIT_COMMIT 43d02f2d7c0a051d7134904168ce92615d11713e
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@c0dd7eeada027006d4ebed62a44ac9378d4147d3 aka 4.2-stable to godot-jolt/godot-cpp@43d02f2d7c0a051d7134904168ce92615d11713e aka 4.2-stable (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/c0dd7eeada027006d4ebed62a44ac9378d4147d3...43d02f2d7c0a051d7134904168ce92615d11713e)).

Fixes #735.