### PR TITLE
Added support for kinematic vs kinematic/static contact reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Breaking changes are denoted with ⚠️.
 - Added new project setting, "World Node", for controlling which of the two nodes in a single-body
   joint becomes the "world node" when omitting one of the nodes. This allows for reverting back to
   the behavior of Godot Physics if needed, effectively undoing the breaking change mentioned above.
+- Added new project setting, "Report All Kinematic Contacts", for allowing `RigidBody3D` frozen with
+  `FREEZE_MODE_KINEMATIC` to report contacts/collisions with other kinematic/static bodies, at a
+  potentially heavy performance/memory cost.
 - Added support for using NaN to indicate holes in `HeightMapShape3D`.
 - Added support for holes in a non-square `HeightMapShape3D`.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -217,6 +217,22 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       </td>
     </tr>
     <tr>
+      <td>Collisions</td>
+      <td>Report All Kinematic Contacts</td>
+      <td>
+        Whether or not a <code>RigidBody3D</code> frozen with <code>FREEZE_MODE_KINEMATIC</code> is
+        able to collide with (and thus reports contacts for) other kinematic/static bodies.
+      </td>
+      <td>
+        ⚠️ Much like the "Areas Detect Static Bodies" setting, this setting can come at a heavy
+        performance and memory cost if you allow many/large frozen kinematic bodies with a non-zero
+        <code>max_contacts_reported</code> to overlap with complex static geometry, such as
+        <code>ConcavePolygonShape3D</code> or <code>HeightMapShape3D</code>.
+        <br><br>It is strongly recommended that you set up your collision layers and masks in such a
+        way that only a few small such kinematic bodies to detect static bodies.
+      </td>
+    </tr>
+    <tr>
       <td>Joints</td>
       <td>World Node</td>
       <td>

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -103,6 +103,8 @@ public:
 
 	bool reports_contacts() const override { return !contacts.is_empty(); }
 
+	bool reports_all_kinematic_contacts() const;
+
 	void add_contact(
 		const JoltBodyImpl3D* p_collider,
 		float p_depth,
@@ -282,6 +284,8 @@ private:
 	void _update_group_filter();
 
 	void _update_joint_constraints();
+
+	void _update_possible_kinematic_contacts();
 
 	void _destroy_joint_constraints();
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -13,6 +13,7 @@ constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
 constexpr char USE_SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
 constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_3d/collisions/areas_detect_static_bodies";
+constexpr char KINEMATIC_CONTACTS[] = "physics/jolt_3d/collisions/report_all_kinematic_contacts";
 
 constexpr char JOINT_WORLD_NODE[] = "physics/jolt_3d/joints/world_node";
 
@@ -136,6 +137,7 @@ void JoltProjectSettings::register_settings() {
 
 	register_setting_plain(USE_SHAPE_MARGINS, true);
 	register_setting_plain(AREAS_DETECT_STATIC, false);
+	register_setting_plain(KINEMATIC_CONTACTS, false);
 
 	register_setting_enum(JOINT_WORLD_NODE, JOINT_WORLD_NODE_A, "Node A,Node B");
 
@@ -183,6 +185,11 @@ bool JoltProjectSettings::use_shape_margins() {
 
 bool JoltProjectSettings::areas_detect_static_bodies() {
 	static const auto value = get_setting<bool>(AREAS_DETECT_STATIC);
+	return value;
+}
+
+bool JoltProjectSettings::report_all_kinematic_contacts() {
+	static const auto value = get_setting<bool>(KINEMATIC_CONTACTS);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -14,6 +14,8 @@ public:
 
 	static bool areas_detect_static_bodies();
 
+	static bool report_all_kinematic_contacts();
+
 	static bool use_joint_world_node_a();
 
 	static float get_ccd_movement_threshold();


### PR DESCRIPTION
Fixes #682.

This adds a new project setting called "Report All Kinematic Contacts", which will allow for contacts to be reported in collisions between kinematic bodies and other kinematic/static bodies, as opposed to only between kinematic and dynamic bodies, much like how things work in Godot Physics.

Given that this uses the same solution as "Areas Detect Static Bodies" it also comes with the exact same performance warning with regards to overlapping with complex static geometry.