### PR TITLE
Updated Jolt to 36d1418f5c

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 36869b03a0f0f542ab56575265a33dda9706fa8d
+	GIT_COMMIT 36d1418f5c2fa7bc4851793cd28354224b64f36f
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@36869b03a0f0f542ab56575265a33dda9706fa8d to godot-jolt/jolt@36d1418f5c2fa7bc4851793cd28354224b64f36f (see diff [here](https://github.com/godot-jolt/jolt/compare/36869b03a0f0f542ab56575265a33dda9706fa8d...36d1418f5c2fa7bc4851793cd28354224b64f36f)).

This brings in the following relevant changes:

- Fixes broken 32-bit Linux builds by adding the `-mfpmath=sse` flag