### PR TITLE
Added clearing of locked axes when changing velocities/forces

### DIFF
--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -271,6 +271,10 @@ private:
 
 	JPH::MassProperties _calculate_mass_properties() const;
 
+	Vector3 _stop_locked_linear_axes(Vector3 p_vector) const;
+
+	Vector3 _stop_locked_angular_axes(Vector3 p_vector) const;
+
 	void _stop_locked_axes(JPH::Body& p_jolt_body) const;
 
 	void _update_mass_properties();


### PR DESCRIPTION
As talked about in #734, Jolt assumes that the user will not apply forces/impulses/velocities on any currently locked axes, so this PR makes sure to explicitly clear those to avoid any problems with that.