### PR TITLE
Updated Jolt to 4a74ff08e4

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 36d1418f5c2fa7bc4851793cd28354224b64f36f
+	GIT_COMMIT 4a74ff08e4c4f1e6cd6020b4f929ffca517d088b
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@36d1418f5c2fa7bc4851793cd28354224b64f36f to godot-jolt/jolt@4a74ff08e4c4f1e6cd6020b4f929ffca517d088b (see diff [here](https://github.com/godot-jolt/jolt/compare/36d1418f5c2fa7bc4851793cd28354224b64f36f...4a74ff08e4c4f1e6cd6020b4f929ffca517d088b)).

This brings in the following relevant changes:

- `SetLinearVelocity` now locks/clears any non-allowed DOFs