### PR TITLE
Corrected some math functions/constants

### DIFF
--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -128,7 +128,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <cmath>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -110,7 +110,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_height_field() const {
 			// HACK(mihe): Godot has undocumented (accidental?) support for holes by passing NaN as
 			// the height value, whereas Jolt uses `FLT_MAX` instead, so we translate any NaN to
 			// `FLT_MAX` in order to be drop-in compatible.
-			row_rev[x] = std::isnan(height) ? FLT_MAX : height;
+			row_rev[x] = Math::is_nan(height) ? FLT_MAX : height;
 		}
 	}
 
@@ -175,7 +175,7 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_mesh() const {
 
 	auto is_vertex_hole = [&](int32_t p_index) {
 		const float height = vertices[(size_t)p_index].y;
-		return height == FLT_MAX || std::isnan(height);
+		return height == FLT_MAX || Math::is_nan(height);
 	};
 
 	auto is_triangle_hole = [&](int32_t p_index0, int32_t p_index1, int32_t p_index2) {

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -646,7 +646,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 
 	// Figure out the number of steps we need in our binary search in order to achieve millimeter
 	// precision, within reason. Derived from `2^-step_count * motion_length = 0.001`.
-	const int32_t step_count = clamp(int32_t(logf(1000.0f * motion_length) / Math_LN2), 4, 16);
+	const int32_t step_count = clamp(int32_t(logf(1000.0f * motion_length) / Mathf_LN2), 4, 16);
 
 	bool collided = false;
 


### PR DESCRIPTION
This replaces the `std::isnan` usage introduced in #731 with Godot's `Math::is_nan`. It also replaces an occurrence of `Math_LN2` that should've been `Mathf_LN2`.