### PR TITLE
Added base offset to `_cast_motion_impl`

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -618,6 +618,8 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 		return false;
 	}
 
+	const JPH::Vec3 base_offset = transform_com.GetTranslation();
+
 	JoltCustomMotionShape motion_shape(static_cast<const JPH::ConvexShape&>(p_jolt_shape));
 
 	auto collides = [&](const JPH::Body& p_other_body, float p_fraction) {
@@ -627,16 +629,12 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 
 		JoltQueryCollectorAny<JPH::CollideShapeCollector> collide_collector;
 
-		JPH::CollisionDispatch::sCollideShapeVsShape(
+		other_shape.CollideShape(
 			&motion_shape,
-			other_shape.mShape,
 			scale,
-			other_shape.GetShapeScale(),
 			transform_com,
-			other_shape.GetCenterOfMassTransform(),
-			JPH::SubShapeIDCreator(),
-			JPH::SubShapeIDCreator(),
 			p_settings,
+			base_offset,
 			collide_collector,
 			p_shape_filter
 		);


### PR DESCRIPTION
Apparently `JPH::TransformedShape` has a convenience method for performing collision checks against it, which will deal with all the scaled stuff, as well as allowing you to pass in a base offset.

I figured the base offset might help a teeny tiny bit with precision, or at the very least make the code cleaner, since we don't have to use the more verbose `JPH::CollisionDispatch::sCollideShapeVsShape` anymore.