### PR TITLE
Attempt to add memory monitors

### DIFF
--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -6,27 +6,90 @@
 #include "shapes/jolt_custom_ray_shape.hpp"
 #include "shapes/jolt_custom_user_data_shape.hpp"
 
-#ifdef GDJ_USE_MIMALLOC
+#ifdef GDJ_CONFIG_EDITOR
+#include "servers/jolt_physics_server_3d.hpp"
+#include <unordered_map>
 
+std::unordered_map<void*, size_t> alloc_size_map;
+#endif // GDJ_CONFIG_EDITOR
+
+#ifdef GDJ_USE_MIMALLOC
 #include <mimalloc-new-delete.h>
+#endif // GDJ_USE_MIMALLOC
 
 void* jolt_alloc(size_t p_size) {
-	return mi_malloc(p_size);
+#ifdef GDJ_USE_MIMALLOC
+	void* block = mi_malloc(p_size);
+#else
+	void* block = malloc(p_size);
+#endif // GDJ_USE_MIMALLOC
+
+#ifdef GDJ_CONFIG_EDITOR
+	if (block != nullptr){
+		JoltPhysicsServer3D::update_current_memory((int64_t)p_size);
+		alloc_size_map.insert({block, p_size});
+	}
+#endif // GDJ_CONFIG_EDITOR
+
+	return block;
 }
 
 void jolt_free(void* p_mem) {
+#ifdef GDJ_USE_MIMALLOC
 	mi_free(p_mem);
+#else
+	free(p_mem);
+#endif // GDJ_USE_MIMALLOC
+
+#ifdef GDJ_CONFIG_EDITOR
+	JoltPhysicsServer3D::update_current_memory(-(int64_t)alloc_size_map.at(p_mem));
+	alloc_size_map.erase(p_mem);
+#endif // GDJ_CONFIG_EDITOR
 }
 
 void* jolt_aligned_alloc(size_t p_size, size_t p_alignment) {
-	return mi_malloc_aligned(p_size, p_alignment);
+#ifdef GDJ_USE_MIMALLOC
+	void* block = mi_malloc_aligned(p_size, p_alignment);
+#else
+
+#ifdef JPH_PLATFORM_WINDOWS
+	void* block = _aligned_malloc(p_size, p_alignment);
+#else
+	void* block = nullptr;
+	posix_memalign(&block, p_alignment, p_size);
+#endif // JPH_PLATFORM_WINDOWS
+
+#endif // GDJ_USE_MIMALLOC
+
+#ifdef GDJ_CONFIG_EDITOR
+	if (block != nullptr) {
+		// I don't know how to calculate effective allocation size of aligned alloc
+		JoltPhysicsServer3D::update_current_memory((int64_t)p_size);
+		alloc_size_map.insert({block, p_size});
+	}
+#endif // GDJ_CONFIG_EDITOR
+
+	return block;
 }
 
 void jolt_aligned_free(void* p_mem) {
+#ifdef GDJ_USE_MIMALLOC
 	mi_free(p_mem);
-}
+#else
+
+#ifdef JPH_PLATFORM_WINDOWS
+	_aligned_free(p_mem);
+#else
+	free(p_mem);
+#endif // JPH_PLATFORM_WINDOWS
 
 #endif // GDJ_USE_MIMALLOC
+
+#ifdef GDJ_CONFIG_EDITOR
+	JoltPhysicsServer3D::update_current_memory(-(int64_t)alloc_size_map.at(p_mem));
+	alloc_size_map.erase(p_mem);
+#endif // GDJ_CONFIG_EDITOR
+}
 
 #ifdef JPH_ENABLE_ASSERTS
 
@@ -55,14 +118,10 @@ bool jolt_assert(const char* p_expr, const char* p_msg, const char* p_file, uint
 #endif // JPH_ENABLE_ASSERTS
 
 void jolt_initialize() {
-#ifdef GDJ_USE_MIMALLOC
 	JPH::Allocate = &jolt_alloc;
 	JPH::Free = &jolt_free;
 	JPH::AlignedAllocate = &jolt_aligned_alloc;
 	JPH::AlignedFree = &jolt_aligned_free;
-#else // GDJ_USE_MIMALLOC
-	JPH::RegisterDefaultAllocator();
-#endif // GDJ_USE_MIMALLOC
 
 #ifdef JPH_ENABLE_ASSERTS
 	JPH::Trace = &jolt_trace;

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -76,8 +76,14 @@ public:
 		G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING_FREQUENCY,
 	};
 
+	static inline int64_t current_memory = 0;
+	static inline int64_t max_memory = 0;
+
 private:
 	static void _bind_methods();
+
+	void init_performance_monitor();
+	void finish_performance_monitor();
 
 public:
 	JoltPhysicsServer3D();
@@ -739,6 +745,11 @@ public:
 	float generic_6dof_joint_get_applied_force(const RID& p_joint);
 
 	float generic_6dof_joint_get_applied_torque(const RID& p_joint);
+
+	static void update_current_memory(int64_t change);
+
+	double get_current_memory(int64_t p_format) const;
+	double get_max_memory(int64_t p_format) const;
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;


### PR DESCRIPTION
I tried to implement a memory monitor described in this [Issue](https://github.com/godot-jolt/godot-jolt/issues/357).

It uses custom allocators to track the memory usage in debug builds and provides a performance monitor to the Godot editor under a `Jolt Physics` category. There are monitors for current and maximal memory usage formatted to MiB. 

There could be a ProjectSetting for the formatting, but I don't really know about that. The memory is reported as a decimal value, but Godot's performance monitor does not format custom monitor values. It could be changed to report the value as an integer, but at the expense of monitor granularity.


![image](https://github.com/godot-jolt/godot-jolt/assets/72454967/888747a3-3552-4a5b-89fa-c1a5c4e0f095)
_How it looks in the editor_


This might not be an ideal implementation whatsoever, so any feedback or critique would be highly appreciated as I don't have that much experience with C++.