### PR TITLE
Changed `SeparationRayShape3D` to not treat convex as solid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `SeparationRayShape3D` to not treat other convex shapes as solid, meaning it will now only
+  ever collide with the hull of other convex shapes, which better matches Godot Physics.
+
 ## [0.12.0] - 2024-01-07
 
 ### Changed

--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -69,12 +69,7 @@ void collide_ray_vs_shape(
 
 	JPH::RayCastSettings ray_cast_settings;
 	ray_cast_settings.mBackFaceMode = p_collide_shape_settings.mBackFaceMode;
-
-	// NOTE(mihe): Treating convex shapes as solid deviates from how these shapes behave in Godot
-	// Physics, where no collision is registered when fully enveloped by a convex shape. It's not
-	// clear to me whether the behavior of Godot Physics is desired or just the result of a simple
-	// implementation. I assume it's the latter, hence the deviation.
-	ray_cast_settings.mTreatConvexAsSolid = true;
+	ray_cast_settings.mTreatConvexAsSolid = false;
 
 	JoltQueryCollectorClosest<JPH::CastRayCollector> ray_collector;
 


### PR DESCRIPTION
Fixes #759.

This changes `JoltCustomRayShape`, which powers `SeparationRayShape3D`, to not use `mTreatConvexAsSolid` for its internal ray-cast. This fixes a deliberate discrepancy between this extension and Godot Physics, which apparently prevented users from having a ray shape that could go through perpendicular convex walls and not collide inside it, as seen in #759.