### PR TITLE
Added support for `SoftBody3D`

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -233,6 +233,15 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       </td>
     </tr>
     <tr>
+      <td>Soft Bodies</td>
+      <td>Point Margin</td>
+      <td>
+        How much of a margin to add to the soft body points. This can keep soft bodies (like cloth)
+        from laying perfectly flush against other surfaces, thereby preventing Z-fighting.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>Joints</td>
       <td>World Node</td>
       <td>

--- a/src/containers/symmetric_bit_table.hpp
+++ b/src/containers/symmetric_bit_table.hpp
@@ -18,7 +18,7 @@ public:
 
 		const int32_t index = _calculate_index(p_x, p_y);
 		const int32_t byte_index = index / 8;
-		const auto bit_index = uint32_t(index % 8);
+		const auto bit_index = uint8_t(index % 8);
 
 		bits[byte_index] |= (1U << bit_index);
 	}
@@ -29,7 +29,7 @@ public:
 
 		const int32_t index = _calculate_index(p_x, p_y);
 		const int32_t byte_index = index / 8;
-		const auto bit_index = uint32_t(index % 8);
+		const auto bit_index = uint8_t(index % 8);
 
 		bits[byte_index] &= ~(1U << bit_index);
 	}
@@ -40,9 +40,9 @@ public:
 
 		const int32_t index = _calculate_index(p_x, p_y);
 		const int32_t byte_index = index / 8;
-		const auto bit_index = uint32_t(index % 8);
+		const auto bit_index = uint8_t(index % 8);
 
-		return (bits[byte_index] >> bit_index) & 1U;
+		return (uint8_t(bits[byte_index] >> bit_index) & 1U) != 0;
 	}
 
 private:

--- a/src/containers/symmetric_bit_table.hpp
+++ b/src/containers/symmetric_bit_table.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "containers/local_vector.hpp"
+
+class SymmetricBitTable {
+public:
+	SymmetricBitTable(int32_t p_size)
+		: size(p_size) {
+		const int32_t total_bits = (size * (size + 1)) / 2;
+		const int32_t total_bytes = (total_bits + 7) / 8;
+		bits.resize(total_bytes);
+		memset(bits.ptr(), 0, (size_t)bits.size());
+	}
+
+	void set(int32_t p_x, int32_t p_y) {
+		ERR_FAIL_INDEX(p_x, size);
+		ERR_FAIL_INDEX(p_y, size);
+
+		const int32_t index = calculate_index(p_x, p_y);
+		const int32_t byte_index = index / 8;
+		const int32_t bit_index = index % 8;
+
+		bits[byte_index] |= (1 << bit_index);
+	}
+
+	void unset(int32_t p_x, int32_t p_y) {
+		ERR_FAIL_INDEX(p_x, size);
+		ERR_FAIL_INDEX(p_y, size);
+
+		const int32_t index = calculate_index(p_x, p_y);
+		const int32_t byte_index = index / 8;
+		const int32_t bit_index = index % 8;
+
+		bits[byte_index] &= ~(1 << bit_index);
+	}
+
+	bool has(int32_t p_x, int32_t p_y) const {
+		CRASH_BAD_INDEX(p_x, size);
+		CRASH_BAD_INDEX(p_y, size);
+
+		const int32_t index = calculate_index(p_x, p_y);
+		const int32_t byte_index = index / 8;
+		const int32_t bit_index = index % 8;
+
+		return (bits[byte_index] >> bit_index) & 1;
+	}
+
+private:
+	int32_t calculate_index(int32_t p_x, int32_t p_y) const {
+		if (p_x < p_y) {
+			std::swap(p_x, p_y);
+		}
+
+		return (p_x * (p_x + 1)) / 2 + p_y;
+	}
+
+	LocalVector<uint8_t> bits;
+
+	int32_t size = 0;
+};

--- a/src/containers/symmetric_bit_table.hpp
+++ b/src/containers/symmetric_bit_table.hpp
@@ -4,7 +4,7 @@
 
 class SymmetricBitTable {
 public:
-	SymmetricBitTable(int32_t p_size)
+	explicit SymmetricBitTable(int32_t p_size)
 		: size(p_size) {
 		const int32_t total_bits = (size * (size + 1)) / 2;
 		const int32_t total_bytes = (total_bits + 7) / 8;
@@ -16,37 +16,37 @@ public:
 		ERR_FAIL_INDEX(p_x, size);
 		ERR_FAIL_INDEX(p_y, size);
 
-		const int32_t index = calculate_index(p_x, p_y);
+		const int32_t index = _calculate_index(p_x, p_y);
 		const int32_t byte_index = index / 8;
-		const int32_t bit_index = index % 8;
+		const auto bit_index = uint32_t(index % 8);
 
-		bits[byte_index] |= (1 << bit_index);
+		bits[byte_index] |= (1U << bit_index);
 	}
 
 	void unset(int32_t p_x, int32_t p_y) {
 		ERR_FAIL_INDEX(p_x, size);
 		ERR_FAIL_INDEX(p_y, size);
 
-		const int32_t index = calculate_index(p_x, p_y);
+		const int32_t index = _calculate_index(p_x, p_y);
 		const int32_t byte_index = index / 8;
-		const int32_t bit_index = index % 8;
+		const auto bit_index = uint32_t(index % 8);
 
-		bits[byte_index] &= ~(1 << bit_index);
+		bits[byte_index] &= ~(1U << bit_index);
 	}
 
 	bool has(int32_t p_x, int32_t p_y) const {
 		CRASH_BAD_INDEX(p_x, size);
 		CRASH_BAD_INDEX(p_y, size);
 
-		const int32_t index = calculate_index(p_x, p_y);
+		const int32_t index = _calculate_index(p_x, p_y);
 		const int32_t byte_index = index / 8;
-		const int32_t bit_index = index % 8;
+		const auto bit_index = uint32_t(index % 8);
 
-		return (bits[byte_index] >> bit_index) & 1;
+		return (bits[byte_index] >> bit_index) & 1U;
 	}
 
 private:
-	int32_t calculate_index(int32_t p_x, int32_t p_y) const {
+	int32_t _calculate_index(int32_t p_x, int32_t p_y) const {
 		if (p_x < p_y) {
 			std::swap(p_x, p_y);
 		}

--- a/src/misc/type_conversions.hpp
+++ b/src/misc/type_conversions.hpp
@@ -33,6 +33,10 @@ _FORCE_INLINE_ String to_godot(const JPH::String& p_str) {
 	return String::utf8(p_str.c_str(), (int32_t)p_str.length());
 }
 
+_FORCE_INLINE_ AABB to_godot(const JPH::AABox& p_aabb) {
+	return {to_godot(p_aabb.mMin), to_godot(p_aabb.mMax - p_aabb.mMin)};
+}
+
 _FORCE_INLINE_ JPH::Vec3 to_jolt(const Vector3& p_vec) {
 	return {p_vec.x, p_vec.y, p_vec.z};
 }
@@ -60,4 +64,8 @@ _FORCE_INLINE_ JPH::Color to_jolt(const Color& p_color) {
 _FORCE_INLINE_ JPH::String to_jolt(const String& p_str) {
 	const CharString str_utf8 = p_str.utf8();
 	return {str_utf8.get_data(), (size_t)str_utf8.length()};
+}
+
+_FORCE_INLINE_ JPH::AABox to_jolt(const AABB& p_aabb) {
+	return {to_jolt(p_aabb.position), to_jolt(p_aabb.position + p_aabb.size)};
 }

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -24,8 +24,10 @@ bool JoltAreaImpl3D::is_default_area() const {
 	return space != nullptr && space->get_default_area() == this;
 }
 
-void JoltAreaImpl3D::set_default_area() {
-	_update_default_gravity();
+void JoltAreaImpl3D::set_default_area(bool p_value) {
+	if (p_value) {
+		_update_default_gravity();
+	}
 }
 
 void JoltAreaImpl3D::set_transform(const Transform3D& p_transform) {

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "objects/jolt_object_impl_3d.hpp"
+#include "objects/jolt_shaped_object_impl_3d.hpp"
 
 class JoltBodyImpl3D;
+class JoltSoftBodyImpl3D;
 
-class JoltAreaImpl3D final : public JoltObjectImpl3D {
+class JoltAreaImpl3D final : public JoltShapedObjectImpl3D {
 	struct BodyIDHasher {
 		static uint32_t hash(const JPH::BodyID& p_id) {
 			return hash_fmix32(p_id.GetIndexAndSequenceNumber());
@@ -56,6 +57,12 @@ public:
 
 	JoltAreaImpl3D();
 
+	bool is_default_area() const;
+
+	void set_default_area();
+
+	void set_transform(const Transform3D& p_transform);
+
 	Variant get_param(PhysicsServer3D::AreaParameter p_param) const;
 
 	void set_param(PhysicsServer3D::AreaParameter p_param, const Variant& p_value);
@@ -74,11 +81,15 @@ public:
 
 	bool can_monitor(const JoltBodyImpl3D& p_other) const;
 
+	bool can_monitor(const JoltSoftBodyImpl3D& p_other) const;
+
 	bool can_monitor(const JoltAreaImpl3D& p_other) const;
 
-	bool can_interact_with(const JoltBodyImpl3D& p_other) const;
+	bool can_interact_with(const JoltBodyImpl3D& p_other) const override;
 
-	bool can_interact_with(const JoltAreaImpl3D& p_other) const;
+	bool can_interact_with(const JoltSoftBodyImpl3D& p_other) const override;
+
+	bool can_interact_with(const JoltAreaImpl3D& p_other) const override;
 
 	Vector3 get_velocity_at_position(const Vector3& p_position) const override;
 
@@ -86,7 +97,7 @@ public:
 
 	bool is_point_gravity() const { return point_gravity; }
 
-	void set_point_gravity(bool p_enabled) { point_gravity = p_enabled; }
+	void set_point_gravity(bool p_enabled);
 
 	float get_priority() const { return priority; }
 
@@ -94,11 +105,11 @@ public:
 
 	float get_gravity() const { return gravity; }
 
-	void set_gravity(float p_gravity) { gravity = p_gravity; }
+	void set_gravity(float p_gravity);
 
 	float get_point_gravity_distance() const { return point_gravity_distance; }
 
-	void set_point_gravity_distance(float p_distance) { point_gravity_distance = p_distance; }
+	void set_point_gravity_distance(float p_distance);
 
 	float get_linear_damp() const { return linear_damp; }
 
@@ -110,7 +121,7 @@ public:
 
 	OverrideMode get_gravity_mode() const { return gravity_mode; }
 
-	void set_gravity_mode(OverrideMode p_mode) { gravity_mode = p_mode; }
+	void set_gravity_mode(OverrideMode p_mode);
 
 	OverrideMode get_linear_damp_mode() const { return linear_damp_mode; }
 
@@ -122,7 +133,7 @@ public:
 
 	Vector3 get_gravity_vector() const { return gravity_vector; }
 
-	void set_gravity_vector(const Vector3& p_vector) { gravity_vector = p_vector; }
+	void set_gravity_vector(const Vector3& p_vector);
 
 	Vector3 compute_gravity(const Vector3& p_position) const;
 
@@ -165,9 +176,11 @@ public:
 private:
 	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 
+	JPH::ObjectLayer _get_object_layer() const override;
+
 	JPH::EMotionType _get_motion_type() const override { return JPH::EMotionType::Kinematic; }
 
-	void _create_in_space() override;
+	void _add_to_space() override;
 
 	void _add_shape_pair(
 		Overlap& p_overlap,
@@ -207,6 +220,8 @@ private:
 
 	void _update_group_filter();
 
+	void _update_default_gravity();
+
 	void _space_changing() override;
 
 	void _space_changed() override;
@@ -216,6 +231,8 @@ private:
 	void _area_monitoring_changed();
 
 	void _monitorable_changed();
+
+	void _gravity_changed();
 
 	OverlapsById bodies_by_id;
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -59,7 +59,7 @@ public:
 
 	bool is_default_area() const;
 
-	void set_default_area();
+	void set_default_area(bool p_value);
 
 	void set_transform(const Transform3D& p_transform);
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -4,6 +4,7 @@
 #include "objects/jolt_area_impl_3d.hpp"
 #include "objects/jolt_group_filter.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
+#include "objects/jolt_soft_body_impl_3d.hpp"
 #include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
 #include "spaces/jolt_space_3d.hpp"
@@ -41,13 +42,41 @@ bool integrate(TValue& p_value, PhysicsServer3D::AreaSpaceOverrideMode p_mode, T
 } // namespace
 
 JoltBodyImpl3D::JoltBodyImpl3D()
-	: JoltObjectImpl3D(JoltObjectImpl3D::OBJECT_TYPE_BODY) { }
+	: JoltShapedObjectImpl3D(OBJECT_TYPE_BODY) { }
 
 JoltBodyImpl3D::~JoltBodyImpl3D() {
 	memdelete_safely(direct_state);
 }
 
-Variant JoltBodyImpl3D::get_state(PhysicsServer3D::BodyState p_state) {
+void JoltBodyImpl3D::set_transform(const Transform3D& p_transform) {
+	Vector3 new_scale;
+	const Transform3D new_transform = Math::decomposed(p_transform, new_scale);
+
+	if (!scale.is_equal_approx(new_scale)) {
+		scale = new_scale;
+		_shapes_changed();
+	}
+
+	if (is_kinematic()) {
+		kinematic_transform = p_transform;
+	} else {
+		if (space == nullptr) {
+			jolt_settings->mPosition = to_jolt(new_transform.origin);
+			jolt_settings->mRotation = to_jolt(new_transform.basis);
+		} else {
+			space->get_body_iface().SetPositionAndRotation(
+				jolt_id,
+				to_jolt(new_transform.origin),
+				to_jolt(new_transform.basis),
+				JPH::EActivation::DontActivate
+			);
+		}
+	}
+
+	_transform_changed();
+}
+
+Variant JoltBodyImpl3D::get_state(PhysicsServer3D::BodyState p_state) const {
 	switch (p_state) {
 		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
 			return get_transform_scaled();
@@ -1020,27 +1049,12 @@ void JoltBodyImpl3D::set_friction(float p_friction) {
 	body->SetFriction(p_friction);
 }
 
-float JoltBodyImpl3D::get_gravity_scale() const {
-	if (space == nullptr) {
-		return jolt_settings->mGravityFactor;
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return body->GetMotionPropertiesUnchecked()->GetGravityFactor();
-}
-
 void JoltBodyImpl3D::set_gravity_scale(float p_scale) {
-	if (space == nullptr) {
-		jolt_settings->mGravityFactor = p_scale;
+	if (gravity_scale == p_scale) {
 		return;
 	}
 
-	const JoltWritableBody3D body = space->write_body(jolt_id);
-	ERR_FAIL_COND(body.is_invalid());
-
-	body->GetMotionPropertiesUnchecked()->SetGravityFactor(p_scale);
+	gravity_scale = p_scale;
 
 	_motion_changed();
 }
@@ -1105,13 +1119,17 @@ void JoltBodyImpl3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_enab
 	}
 }
 
-bool JoltBodyImpl3D::can_collide_with(const JoltBodyImpl3D& p_other) const {
-	return (collision_mask & p_other.get_collision_layer()) != 0;
-}
-
 bool JoltBodyImpl3D::can_interact_with(const JoltBodyImpl3D& p_other) const {
 	return (can_collide_with(p_other) || p_other.can_collide_with(*this)) &&
 		!has_collision_exception(p_other.get_rid()) && !p_other.has_collision_exception(rid);
+}
+
+bool JoltBodyImpl3D::can_interact_with(const JoltSoftBodyImpl3D& p_other) const {
+	return p_other.can_interact_with(*this);
+}
+
+bool JoltBodyImpl3D::can_interact_with(const JoltAreaImpl3D& p_other) const {
+	return p_other.can_interact_with(*this);
 }
 
 JPH::BroadPhaseLayer JoltBodyImpl3D::_get_broad_phase_layer() const {
@@ -1128,6 +1146,12 @@ JPH::BroadPhaseLayer JoltBodyImpl3D::_get_broad_phase_layer() const {
 			ERR_FAIL_D_MSG(vformat("Unhandled body mode: '%d'", mode));
 		}
 	}
+}
+
+JPH::ObjectLayer JoltBodyImpl3D::_get_object_layer() const {
+	ERR_FAIL_NULL_D(space);
+
+	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
 }
 
 JPH::EMotionType JoltBodyImpl3D::_get_motion_type() const {
@@ -1148,9 +1172,21 @@ JPH::EMotionType JoltBodyImpl3D::_get_motion_type() const {
 	}
 }
 
-void JoltBodyImpl3D::_create_in_space() {
-	_create_begin();
+void JoltBodyImpl3D::_add_to_space() {
+	ON_SCOPE_EXIT {
+		delete_safely(jolt_settings);
+	};
 
+	jolt_shape = build_shape();
+
+	JPH::CollisionGroup::GroupID group_id = 0;
+	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
+	JoltGroupFilter::encode_object(this, group_id, sub_group_id);
+
+	jolt_settings->mUserData = reinterpret_cast<JPH::uint64>(this);
+	jolt_settings->mObjectLayer = _get_object_layer();
+	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
+	jolt_settings->mMotionType = _get_motion_type();
 	jolt_settings->mAllowDynamicOrKinematic = true;
 	jolt_settings->mCollideKinematicVsNonDynamic = reports_all_kinematic_contacts();
 	jolt_settings->mUseManifoldReduction = !reports_contacts();
@@ -1164,7 +1200,28 @@ void JoltBodyImpl3D::_create_in_space() {
 	jolt_settings->mMassPropertiesOverride.mMass = 1.0f;
 	jolt_settings->mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
 
-	_create_end();
+	jolt_settings->SetShape(jolt_shape);
+
+	JPH::BodyInterface& body_iface = space->get_body_iface();
+	JPH::Body* body = body_iface.CreateBody(*jolt_settings);
+
+	ERR_FAIL_NULL_MSG(
+		body,
+		vformat(
+			"Failed to create underlying Jolt body for '%s'. "
+			"Consider increasing maximum number of bodies in project settings. "
+			"Maximum number of bodies is currently set to %d.",
+			to_string(),
+			JoltProjectSettings::get_max_bodies()
+		)
+	);
+
+	jolt_id = body->GetID();
+
+	// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or less
+	// impossible to have a body be sleeping when created, so we default to always starting out as
+	// awake/active.
+	body_iface.AddBody(jolt_id, JPH::EActivation::Activate);
 }
 
 void JoltBodyImpl3D::_integrate_forces(float p_step, JPH::Body& p_jolt_body) {
@@ -1212,16 +1269,6 @@ void JoltBodyImpl3D::_pre_step_kinematic(float p_step, JPH::Body& p_jolt_body) {
 		// are set as active (and thereby have their state synchronized on every step) only if its
 		// max reported contacts is non-zero.
 		sync_state = true;
-	}
-}
-
-void JoltBodyImpl3D::_apply_transform(const Transform3D& p_transform) {
-	if (is_kinematic()) {
-		kinematic_transform = p_transform;
-	}
-
-	if (!is_kinematic() || space == nullptr) {
-		JoltObjectImpl3D::_apply_transform(p_transform);
 	}
 }
 
@@ -1410,7 +1457,7 @@ void JoltBodyImpl3D::_update_gravity(JPH::Body& p_jolt_body) {
 		gravity += space->get_default_area()->compute_gravity(position);
 	}
 
-	gravity *= p_jolt_body.GetMotionPropertiesUnchecked()->GetGravityFactor();
+	gravity *= gravity_scale;
 }
 
 void JoltBodyImpl3D::_update_damp() {
@@ -1535,16 +1582,22 @@ void JoltBodyImpl3D::_mode_changed() {
 }
 
 void JoltBodyImpl3D::_shapes_built() {
+	JoltShapedObjectImpl3D::_shapes_built();
+
 	_update_mass_properties();
 	_update_joint_constraints();
 	wake_up();
 }
 
 void JoltBodyImpl3D::_space_changing() {
+	JoltShapedObjectImpl3D::_space_changing();
+
 	_destroy_joint_constraints();
 }
 
 void JoltBodyImpl3D::_space_changed() {
+	JoltShapedObjectImpl3D::_space_changed();
+
 	_update_kinematic_transform();
 	_update_mass_properties();
 	_update_group_filter();

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1562,16 +1562,17 @@ void JoltBodyImpl3D::_destroy_joint_constraints() {
 }
 
 void JoltBodyImpl3D::_update_group_filter() {
+	JPH::GroupFilter* group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
+
 	if (space == nullptr) {
+		jolt_settings->mCollisionGroup.SetGroupFilter(group_filter);
 		return;
 	}
 
 	const JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
-	body->GetCollisionGroup().SetGroupFilter(
-		!exceptions.is_empty() ? JoltGroupFilter::instance : nullptr
-	);
+	body->GetCollisionGroup().SetGroupFilter(group_filter);
 }
 
 void JoltBodyImpl3D::_mode_changed() {

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -57,20 +57,18 @@ void JoltBodyImpl3D::set_transform(const Transform3D& p_transform) {
 		_shapes_changed();
 	}
 
-	if (is_kinematic()) {
+	if (space == nullptr) {
+		jolt_settings->mPosition = to_jolt(new_transform.origin);
+		jolt_settings->mRotation = to_jolt(new_transform.basis);
+	} else if (is_kinematic()) {
 		kinematic_transform = p_transform;
 	} else {
-		if (space == nullptr) {
-			jolt_settings->mPosition = to_jolt(new_transform.origin);
-			jolt_settings->mRotation = to_jolt(new_transform.basis);
-		} else {
-			space->get_body_iface().SetPositionAndRotation(
-				jolt_id,
-				to_jolt(new_transform.origin),
-				to_jolt(new_transform.basis),
-				JPH::EActivation::DontActivate
-			);
-		}
+		space->get_body_iface().SetPositionAndRotation(
+			jolt_id,
+			to_jolt(new_transform.origin),
+			to_jolt(new_transform.basis),
+			JPH::EActivation::DontActivate
+		);
 	}
 
 	_transform_changed();

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include "objects/jolt_object_impl_3d.hpp"
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
+#include "objects/jolt_shaped_object_impl_3d.hpp"
 
 class JoltAreaImpl3D;
 class JoltJointImpl3D;
+class JoltSoftBodyImpl3D;
 
-class JoltBodyImpl3D final : public JoltObjectImpl3D {
+class JoltBodyImpl3D final : public JoltShapedObjectImpl3D {
 public:
 	using DampMode = PhysicsServer3D::BodyDampMode;
 
@@ -38,7 +39,9 @@ public:
 
 	~JoltBodyImpl3D() override;
 
-	Variant get_state(PhysicsServer3D::BodyState p_state);
+	void set_transform(const Transform3D& p_transform);
+
+	Variant get_state(PhysicsServer3D::BodyState p_state) const;
 
 	void set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value);
 
@@ -208,7 +211,7 @@ public:
 
 	void set_friction(float p_friction);
 
-	float get_gravity_scale() const;
+	float get_gravity_scale() const { return gravity_scale; };
 
 	void set_gravity_scale(float p_scale);
 
@@ -244,16 +247,20 @@ public:
 
 	bool are_axes_locked() const { return locked_axes != 0; }
 
-	bool can_collide_with(const JoltBodyImpl3D& p_other) const;
+	bool can_interact_with(const JoltBodyImpl3D& p_other) const override;
 
-	bool can_interact_with(const JoltBodyImpl3D& p_other) const;
+	bool can_interact_with(const JoltSoftBodyImpl3D& p_other) const override;
+
+	bool can_interact_with(const JoltAreaImpl3D& p_other) const override;
 
 private:
 	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 
+	JPH::ObjectLayer _get_object_layer() const override;
+
 	JPH::EMotionType _get_motion_type() const override;
 
-	void _create_in_space() override;
+	void _add_to_space() override;
 
 	void _integrate_forces(float p_step, JPH::Body& p_jolt_body);
 
@@ -262,8 +269,6 @@ private:
 	void _pre_step_rigid(float p_step, JPH::Body& p_jolt_body);
 
 	void _pre_step_kinematic(float p_step, JPH::Body& p_jolt_body);
-
-	void _apply_transform(const Transform3D& p_transform) override;
 
 	JPH::EAllowedDOFs _calculate_allowed_dofs() const;
 
@@ -305,7 +310,7 @@ private:
 
 	void _joints_changed();
 
-	void _transform_changed() override;
+	void _transform_changed();
 
 	void _motion_changed();
 
@@ -362,6 +367,8 @@ private:
 	float total_linear_damp = 0.0f;
 
 	float total_angular_damp = 0.0f;
+
+	float gravity_scale = 1.0f;
 
 	float collision_priority = 1.0f;
 

--- a/src/objects/jolt_group_filter.cpp
+++ b/src/objects/jolt_group_filter.cpp
@@ -42,35 +42,7 @@ bool JoltGroupFilter::CanCollide(
 		p_group2.GetSubGroupID()
 	);
 
-	const JoltAreaImpl3D* area1 = object1->is_area()
-		? reinterpret_cast<const JoltAreaImpl3D*>(object1)
-		: nullptr;
-
-	const JoltAreaImpl3D* area2 = object2->is_area()
-		? reinterpret_cast<const JoltAreaImpl3D*>(object2)
-		: nullptr;
-
-	const JoltBodyImpl3D* body1 = area1 == nullptr
-		? reinterpret_cast<const JoltBodyImpl3D*>(object1)
-		: nullptr;
-
-	const JoltBodyImpl3D* body2 = area2 == nullptr
-		? reinterpret_cast<const JoltBodyImpl3D*>(object2)
-		: nullptr;
-
-	if (body1 != nullptr && body2 != nullptr) {
-		return body1->can_interact_with(*body2);
-	}
-
-	if (area1 != nullptr && area2 != nullptr) {
-		return area1->can_interact_with(*area2);
-	} else if (area1 != nullptr && body2 != nullptr) {
-		return area1->can_interact_with(*body2);
-	} else if (area2 != nullptr && body1 != nullptr) {
-		return area2->can_interact_with(*body1);
-	} else {
-		return false;
-	}
+	return object1->can_interact_with(*object2);
 }
 
 // NOLINTNEXTLINE(bugprone-sizeof-expression)

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -1,25 +1,17 @@
 #include "jolt_object_impl_3d.hpp"
 
+// #include "objects/jolt_area_impl_3d.hpp"
+// #include "objects/jolt_body_impl_3d.hpp"
 #include "objects/jolt_group_filter.hpp"
+// #include "objects/jolt_soft_body_impl_3d.hpp"
 #include "servers/jolt_project_settings.hpp"
-#include "shapes/jolt_custom_empty_shape.hpp"
-#include "shapes/jolt_shape_impl_3d.hpp"
 #include "spaces/jolt_layer_mapper.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
 JoltObjectImpl3D::JoltObjectImpl3D(ObjectType p_object_type)
-	: object_type(p_object_type) {
-	jolt_settings->mAllowSleeping = true;
-	jolt_settings->mFriction = 1.0f;
-	jolt_settings->mRestitution = 0.0f;
-	jolt_settings->mLinearDamping = 0.0f;
-	jolt_settings->mAngularDamping = 0.0f;
-	jolt_settings->mGravityFactor = 1.0f;
-}
+	: object_type(p_object_type) { }
 
-JoltObjectImpl3D::~JoltObjectImpl3D() {
-	delete_safely(jolt_settings);
-}
+JoltObjectImpl3D::~JoltObjectImpl3D() = default;
 
 GodotObject* JoltObjectImpl3D::get_instance() const {
 	return internal::gdextension_interface_object_get_instance_from_id(instance_id);
@@ -47,19 +39,12 @@ void JoltObjectImpl3D::set_space(JoltSpace3D* p_space) {
 	_space_changing();
 
 	if (space != nullptr) {
-		const JoltWritableBody3D body = space->write_body(jolt_id);
-		ERR_FAIL_COND(body.is_invalid());
-
-		jolt_settings = new JPH::BodyCreationSettings(body->GetBodyCreationSettings());
-
 		_remove_from_space();
-		_destroy_in_space();
 	}
 
 	space = p_space;
 
 	if (space != nullptr) {
-		_create_in_space();
 		_add_to_space();
 	}
 
@@ -86,358 +71,38 @@ void JoltObjectImpl3D::set_collision_mask(uint32_t p_mask) {
 	_collision_mask_changed();
 }
 
-Transform3D JoltObjectImpl3D::get_transform_unscaled() const {
-	if (space == nullptr) {
-		return {to_godot(jolt_settings->mRotation), to_godot(jolt_settings->mPosition)};
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return {to_godot(body->GetRotation()), to_godot(body->GetPosition())};
-}
-
-Transform3D JoltObjectImpl3D::get_transform_scaled() const {
-	return get_transform_unscaled().scaled_local(scale);
-}
-
-void JoltObjectImpl3D::set_transform(Transform3D p_transform) {
-	Vector3 new_scale;
-	Math::decompose(p_transform, new_scale);
-
-	// HACK(mihe): Ideally we would do an exact comparison here, but that would likely mismatch
-	// quite often due to the nature of floating-point numbers. This does mean that the transform we
-	// get back won't necessarily be the same one we set. We could solve this by storing the scale
-	// regardless of approximate equality, but then we run the risk of many small changes creating a
-	// large discrepancy between the transform reported and the one actually used by Jolt.
-	if (!scale.is_equal_approx(new_scale)) {
-		scale = new_scale;
-		_shapes_changed();
-	}
-
-	_apply_transform(p_transform);
-
-	_transform_changed();
-}
-
-Basis JoltObjectImpl3D::get_basis() const {
-	if (space == nullptr) {
-		return to_godot(jolt_settings->mRotation);
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetRotation());
-}
-
-Vector3 JoltObjectImpl3D::get_position() const {
-	if (space == nullptr) {
-		return to_godot(jolt_settings->mPosition);
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetPosition());
-}
-
-Vector3 JoltObjectImpl3D::get_center_of_mass() const {
-	ERR_FAIL_NULL_D_MSG(
-		space,
-		vformat(
-			"Failed to retrieve center-of-mass of '%s'. "
-			"Doing so without a physics space is not supported by Godot Jolt. "
-			"If this relates to a node, try adding the node to a scene tree first.",
-			to_string()
-		)
-	);
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetCenterOfMassPosition());
-}
-
-Vector3 JoltObjectImpl3D::get_center_of_mass_local() const {
-	ERR_FAIL_NULL_D_MSG(
-		space,
-		vformat(
-			"Failed to retrieve local center-of-mass of '%s'. "
-			"Doing so without a physics space is not supported by Godot Jolt. "
-			"If this relates to a node, try adding the node to a scene tree first.",
-			to_string()
-		)
-	);
-
-	return get_transform_scaled().xform_inv(get_center_of_mass());
-}
-
-Vector3 JoltObjectImpl3D::get_linear_velocity() const {
-	if (space == nullptr) {
-		return to_godot(jolt_settings->mLinearVelocity);
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetLinearVelocity());
-}
-
-Vector3 JoltObjectImpl3D::get_angular_velocity() const {
-	if (space == nullptr) {
-		return to_godot(jolt_settings->mAngularVelocity);
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return to_godot(body->GetAngularVelocity());
-}
-
-JPH::ShapeRefC JoltObjectImpl3D::try_build_shape() {
-	int32_t built_shape_count = 0;
-	const JoltShapeInstance3D* last_built_shape = nullptr;
-
-	for (JoltShapeInstance3D& shape : shapes) {
-		if (shape.is_enabled() && shape.try_build()) {
-			built_shape_count += 1;
-			last_built_shape = &shape;
-		}
-	}
-
-	if (built_shape_count == 0) {
-		return {};
-	}
-
-	JPH::ShapeRefC result;
-
-	if (built_shape_count == 1) {
-		result = JoltShapeImpl3D::with_transform(
-			last_built_shape->get_jolt_ref(),
-			last_built_shape->get_transform_unscaled(),
-			last_built_shape->get_scale()
-		);
-	} else {
-		int32_t shape_index = 0;
-
-		result = JoltShapeImpl3D::as_compound([&](auto&& p_add_shape) {
-			if (shape_index >= shapes.size()) {
-				return false;
-			}
-
-			const JoltShapeInstance3D& shape = shapes[shape_index++];
-
-			if (shape.is_enabled() && shape.is_built()) {
-				p_add_shape(
-					shape.get_jolt_ref(),
-					shape.get_transform_unscaled(),
-					shape.get_scale()
-				);
-			}
-
-			return true;
-		});
-	}
-
-	if (has_custom_center_of_mass()) {
-		result = JoltShapeImpl3D::with_center_of_mass(result, get_center_of_mass_custom());
-	}
-
-	if (scale != Vector3(1.0f, 1.0f, 1.0f)) {
-		result = JoltShapeImpl3D::with_scale(result, scale);
-	}
-
-	return result;
-}
-
-void JoltObjectImpl3D::build_shape() {
-	if (space == nullptr) {
-		_shapes_built();
-		return;
-	}
-
-	const JoltWritableBody3D body = space->write_body(jolt_id);
-	ERR_FAIL_COND(body.is_invalid());
-
-	previous_jolt_shape = jolt_shape;
-
-	jolt_shape = try_build_shape();
-
-	if (jolt_shape == nullptr) {
-		jolt_shape = new JoltCustomEmptyShape();
-	}
-
-	if (jolt_shape == previous_jolt_shape) {
-		return;
-	}
-
-	space->get_body_iface().SetShape(jolt_id, jolt_shape, false, JPH::EActivation::DontActivate);
-
-	_shapes_built();
-}
-
-void JoltObjectImpl3D::add_shape(
-	JoltShapeImpl3D* p_shape,
-	Transform3D p_transform,
-	bool p_disabled
-) {
-	Vector3 shape_scale;
-	Math::decompose(p_transform, shape_scale);
-
-	shapes.emplace_back(this, p_shape, p_transform, shape_scale, p_disabled);
-
-	_shapes_changed();
-}
-
-void JoltObjectImpl3D::remove_shape(const JoltShapeImpl3D* p_shape) {
-	shapes.erase_if([&](const JoltShapeInstance3D& p_instance) {
-		return p_instance.get_shape() == p_shape;
-	});
-
-	_shapes_changed();
-}
-
-void JoltObjectImpl3D::remove_shape(int32_t p_index) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
-
-	shapes.remove_at(p_index);
-
-	_shapes_changed();
-}
-
-JoltShapeImpl3D* JoltObjectImpl3D::get_shape(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, shapes.size());
-
-	return shapes[p_index].get_shape();
-}
-
-void JoltObjectImpl3D::set_shape(int32_t p_index, JoltShapeImpl3D* p_shape) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
-
-	shapes[p_index] = JoltShapeInstance3D(this, p_shape);
-
-	_shapes_changed();
-}
-
-void JoltObjectImpl3D::clear_shapes() {
-	shapes.clear();
-
-	_shapes_changed();
-}
-
-int32_t JoltObjectImpl3D::find_shape_index(uint32_t p_shape_instance_id) const {
-	return shapes.find_if([&](const JoltShapeInstance3D& p_shape) {
-		return p_shape.get_id() == p_shape_instance_id;
-	});
-}
-
-int32_t JoltObjectImpl3D::find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const {
-	ERR_FAIL_NULL_V(jolt_shape, -1);
-
-	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
-}
-
-JoltShapeImpl3D* JoltObjectImpl3D::find_shape(uint32_t p_shape_instance_id) const {
-	const int32_t shape_index = find_shape_index(p_shape_instance_id);
-	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
-}
-
-JoltShapeImpl3D* JoltObjectImpl3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
-	const int32_t shape_index = find_shape_index(p_sub_shape_id);
-	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
-}
-
-Transform3D JoltObjectImpl3D::get_shape_transform_unscaled(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, shapes.size());
-
-	return shapes[p_index].get_transform_unscaled();
-}
-
-Transform3D JoltObjectImpl3D::get_shape_transform_scaled(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, shapes.size());
-
-	return shapes[p_index].get_transform_scaled();
-}
-
-Vector3 JoltObjectImpl3D::get_shape_scale(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, shapes.size());
-
-	return shapes[p_index].get_scale();
-}
-
-void JoltObjectImpl3D::set_shape_transform(int32_t p_index, Transform3D p_transform) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
-
-	Vector3 new_scale;
-	Math::decompose(p_transform, new_scale);
-
-	JoltShapeInstance3D& shape = shapes[p_index];
-
-	if (shape.get_transform_unscaled() == p_transform && shape.get_scale() == new_scale) {
-		return;
-	}
-
-	shape.set_transform(p_transform);
-	shape.set_scale(new_scale);
-
-	_shapes_changed();
-}
-
-bool JoltObjectImpl3D::is_shape_disabled(int32_t p_index) const {
-	ERR_FAIL_INDEX_D(p_index, shapes.size());
-
-	return shapes[p_index].is_disabled();
-}
-
-void JoltObjectImpl3D::set_shape_disabled(int32_t p_index, bool p_disabled) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
-
-	JoltShapeInstance3D& shape = shapes[p_index];
-
-	if (shape.is_disabled() == p_disabled) {
-		return;
-	}
-
-	if (p_disabled) {
-		shape.disable();
-	} else {
-		shape.enable();
-	}
-
-	_shapes_changed();
-}
-
-void JoltObjectImpl3D::_add_to_space() {
-	// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or less
-	// impossible to have a body be sleeping when created, so we default to always starting out as
-	// active.
-	space->get_body_iface().AddBody(jolt_id, JPH::EActivation::Activate);
-}
-
 void JoltObjectImpl3D::_remove_from_space() {
-	space->get_body_iface().RemoveBody(jolt_id);
-}
+	QUIET_FAIL_COND(jolt_id.IsInvalid());
 
-void JoltObjectImpl3D::_destroy_in_space() {
+	space->get_body_iface().RemoveBody(jolt_id);
 	space->get_body_iface().DestroyBody(jolt_id);
 
 	jolt_id = {};
 }
 
-void JoltObjectImpl3D::_apply_transform(const Transform3D& p_transform) {
-	if (space == nullptr) {
-		jolt_settings->mPosition = to_jolt(p_transform.origin);
-		jolt_settings->mRotation = to_jolt(p_transform.basis);
-		return;
-	}
+void JoltObjectImpl3D::_reset_space() {
+	ERR_FAIL_NULL(space);
 
-	space->get_body_iface().SetPositionAndRotation(
-		jolt_id,
-		to_jolt(p_transform.origin),
-		to_jolt(p_transform.basis),
-		JPH::EActivation::DontActivate
-	);
+	_space_changing();
+	_remove_from_space();
+	_add_to_space();
+	_space_changed();
+}
+
+bool JoltObjectImpl3D::can_collide_with(const JoltObjectImpl3D& p_other) const {
+	return (collision_mask & p_other.get_collision_layer()) != 0;
+}
+
+bool JoltObjectImpl3D::can_interact_with(const JoltObjectImpl3D& p_other) const {
+	if (const JoltBodyImpl3D* other_body = p_other.as_body()) {
+		return can_interact_with(*other_body);
+	} else if (const JoltAreaImpl3D* other_area = p_other.as_area()) {
+		return can_interact_with(*other_area);
+	} else if (const JoltSoftBodyImpl3D* other_soft_body = p_other.as_soft_body()) {
+		return can_interact_with(*other_soft_body);
+	} else {
+		ERR_FAIL_D_MSG(vformat("Unhandled object type: '%d'", p_other.get_type()));
+	}
 }
 
 void JoltObjectImpl3D::pre_step(
@@ -448,63 +113,11 @@ void JoltObjectImpl3D::pre_step(
 void JoltObjectImpl3D::post_step(
 	[[maybe_unused]] float p_step,
 	[[maybe_unused]] JPH::Body& p_jolt_body
-) {
-	previous_jolt_shape = nullptr;
-}
+) { }
 
 String JoltObjectImpl3D::to_string() const {
 	Object* instance = ObjectDB::get_instance(instance_id);
 	return instance != nullptr ? instance->to_string() : "<unknown>";
-}
-
-JPH::ObjectLayer JoltObjectImpl3D::_get_object_layer() const {
-	if (space == nullptr) {
-		return jolt_settings->mObjectLayer;
-	}
-
-	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
-}
-
-void JoltObjectImpl3D::_create_begin() {
-	jolt_shape = try_build_shape();
-
-	if (jolt_shape == nullptr) {
-		jolt_shape = new JoltCustomEmptyShape();
-	}
-
-	JPH::CollisionGroup::GroupID group_id = 0;
-	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
-	JoltGroupFilter::encode_object(this, group_id, sub_group_id);
-
-	jolt_settings->mObjectLayer = _get_object_layer();
-	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
-	jolt_settings->mMotionType = _get_motion_type();
-	jolt_settings->SetShape(jolt_shape);
-}
-
-JPH::Body* JoltObjectImpl3D::_create_end() {
-	ON_SCOPE_EXIT {
-		delete_safely(jolt_settings);
-	};
-
-	JPH::Body* body = space->get_body_iface().CreateBody(*jolt_settings);
-
-	ERR_FAIL_NULL_D_MSG(
-		body,
-		vformat(
-			"Failed to create Jolt body for '%s'. "
-			"Consider increasing maximum number of bodies in project settings. "
-			"Maximum number of bodies is currently set to %d.",
-			to_string(),
-			JoltProjectSettings::get_max_bodies()
-		)
-	);
-
-	body->SetUserData(reinterpret_cast<JPH::uint64>(this));
-
-	jolt_id = body->GetID();
-
-	return body;
 }
 
 void JoltObjectImpl3D::_update_object_layer() {
@@ -521,8 +134,4 @@ void JoltObjectImpl3D::_collision_layer_changed() {
 
 void JoltObjectImpl3D::_collision_mask_changed() {
 	_update_object_layer();
-}
-
-void JoltObjectImpl3D::_shapes_changed() {
-	build_shape();
 }

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -1,9 +1,6 @@
 #include "jolt_object_impl_3d.hpp"
 
-// #include "objects/jolt_area_impl_3d.hpp"
-// #include "objects/jolt_body_impl_3d.hpp"
 #include "objects/jolt_group_filter.hpp"
-// #include "objects/jolt_soft_body_impl_3d.hpp"
 #include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_layer_mapper.hpp"
 #include "spaces/jolt_space_3d.hpp"

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -1,0 +1,348 @@
+#include "jolt_shaped_object_impl_3d.hpp"
+
+#include "shapes/jolt_custom_empty_shape.hpp"
+#include "shapes/jolt_shape_impl_3d.hpp"
+#include "spaces/jolt_space_3d.hpp"
+
+JoltShapedObjectImpl3D::JoltShapedObjectImpl3D(ObjectType p_object_type)
+	: JoltObjectImpl3D(p_object_type) {
+	jolt_settings->mAllowSleeping = true;
+	jolt_settings->mFriction = 1.0f;
+	jolt_settings->mRestitution = 0.0f;
+	jolt_settings->mLinearDamping = 0.0f;
+	jolt_settings->mAngularDamping = 0.0f;
+	jolt_settings->mGravityFactor = 0.0f;
+}
+
+JoltShapedObjectImpl3D::~JoltShapedObjectImpl3D() {
+	delete_safely(jolt_settings);
+}
+
+Transform3D JoltShapedObjectImpl3D::get_transform_unscaled() const {
+	if (space == nullptr) {
+		return {to_godot(jolt_settings->mRotation), to_godot(jolt_settings->mPosition)};
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return {to_godot(body->GetRotation()), to_godot(body->GetPosition())};
+}
+
+Transform3D JoltShapedObjectImpl3D::get_transform_scaled() const {
+	return get_transform_unscaled().scaled_local(scale);
+}
+
+Basis JoltShapedObjectImpl3D::get_basis() const {
+	if (space == nullptr) {
+		return to_godot(jolt_settings->mRotation);
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetRotation());
+}
+
+Vector3 JoltShapedObjectImpl3D::get_position() const {
+	if (space == nullptr) {
+		return to_godot(jolt_settings->mPosition);
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetPosition());
+}
+
+Vector3 JoltShapedObjectImpl3D::get_center_of_mass() const {
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve center-of-mass of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetCenterOfMassPosition());
+}
+
+Vector3 JoltShapedObjectImpl3D::get_center_of_mass_local() const {
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve local center-of-mass of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	return get_transform_scaled().xform_inv(get_center_of_mass());
+}
+
+Vector3 JoltShapedObjectImpl3D::get_linear_velocity() const {
+	if (space == nullptr) {
+		return to_godot(jolt_settings->mLinearVelocity);
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetLinearVelocity());
+}
+
+Vector3 JoltShapedObjectImpl3D::get_angular_velocity() const {
+	if (space == nullptr) {
+		return to_godot(jolt_settings->mAngularVelocity);
+	}
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetAngularVelocity());
+}
+
+JPH::ShapeRefC JoltShapedObjectImpl3D::try_build_shape() {
+	int32_t built_shape_count = 0;
+	const JoltShapeInstance3D* last_built_shape = nullptr;
+
+	for (JoltShapeInstance3D& shape : shapes) {
+		if (shape.is_enabled() && shape.try_build()) {
+			built_shape_count += 1;
+			last_built_shape = &shape;
+		}
+	}
+
+	if (built_shape_count == 0) {
+		return {};
+	}
+
+	JPH::ShapeRefC result;
+
+	if (built_shape_count == 1) {
+		result = JoltShapeImpl3D::with_transform(
+			last_built_shape->get_jolt_ref(),
+			last_built_shape->get_transform_unscaled(),
+			last_built_shape->get_scale()
+		);
+	} else {
+		int32_t shape_index = 0;
+
+		result = JoltShapeImpl3D::as_compound([&](auto&& p_add_shape) {
+			if (shape_index >= shapes.size()) {
+				return false;
+			}
+
+			const JoltShapeInstance3D& shape = shapes[shape_index++];
+
+			if (shape.is_enabled() && shape.is_built()) {
+				p_add_shape(
+					shape.get_jolt_ref(),
+					shape.get_transform_unscaled(),
+					shape.get_scale()
+				);
+			}
+
+			return true;
+		});
+	}
+
+	if (has_custom_center_of_mass()) {
+		result = JoltShapeImpl3D::with_center_of_mass(result, get_center_of_mass_custom());
+	}
+
+	if (scale != Vector3(1.0f, 1.0f, 1.0f)) {
+		result = JoltShapeImpl3D::with_scale(result, scale);
+	}
+
+	return result;
+}
+
+JPH::ShapeRefC JoltShapedObjectImpl3D::build_shape() {
+	JPH::ShapeRefC new_shape = try_build_shape();
+
+	if (new_shape == nullptr) {
+		new_shape = new JoltCustomEmptyShape();
+	}
+
+	return new_shape;
+}
+
+void JoltShapedObjectImpl3D::update_shape() {
+	if (space == nullptr) {
+		_shapes_built();
+		return;
+	}
+
+	const JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	previous_jolt_shape = jolt_shape;
+	jolt_shape = build_shape();
+
+	if (jolt_shape == previous_jolt_shape) {
+		return;
+	}
+
+	space->get_body_iface().SetShape(jolt_id, jolt_shape, false, JPH::EActivation::DontActivate);
+
+	_shapes_built();
+}
+
+void JoltShapedObjectImpl3D::add_shape(
+	JoltShapeImpl3D* p_shape,
+	Transform3D p_transform,
+	bool p_disabled
+) {
+	Vector3 shape_scale;
+	Math::decompose(p_transform, shape_scale);
+
+	shapes.emplace_back(this, p_shape, p_transform, shape_scale, p_disabled);
+
+	_shapes_changed();
+}
+
+void JoltShapedObjectImpl3D::remove_shape(const JoltShapeImpl3D* p_shape) {
+	shapes.erase_if([&](const JoltShapeInstance3D& p_instance) {
+		return p_instance.get_shape() == p_shape;
+	});
+
+	_shapes_changed();
+}
+
+void JoltShapedObjectImpl3D::remove_shape(int32_t p_index) {
+	ERR_FAIL_INDEX(p_index, shapes.size());
+
+	shapes.remove_at(p_index);
+
+	_shapes_changed();
+}
+
+JoltShapeImpl3D* JoltShapedObjectImpl3D::get_shape(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_shape();
+}
+
+void JoltShapedObjectImpl3D::set_shape(int32_t p_index, JoltShapeImpl3D* p_shape) {
+	ERR_FAIL_INDEX(p_index, shapes.size());
+
+	shapes[p_index] = JoltShapeInstance3D(this, p_shape);
+
+	_shapes_changed();
+}
+
+void JoltShapedObjectImpl3D::clear_shapes() {
+	shapes.clear();
+
+	_shapes_changed();
+}
+
+int32_t JoltShapedObjectImpl3D::find_shape_index(uint32_t p_shape_instance_id) const {
+	return shapes.find_if([&](const JoltShapeInstance3D& p_shape) {
+		return p_shape.get_id() == p_shape_instance_id;
+	});
+}
+
+int32_t JoltShapedObjectImpl3D::find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const {
+	ERR_FAIL_NULL_V(jolt_shape, -1);
+
+	return find_shape_index((uint32_t)jolt_shape->GetSubShapeUserData(p_sub_shape_id));
+}
+
+JoltShapeImpl3D* JoltShapedObjectImpl3D::find_shape(uint32_t p_shape_instance_id) const {
+	const int32_t shape_index = find_shape_index(p_shape_instance_id);
+	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
+}
+
+JoltShapeImpl3D* JoltShapedObjectImpl3D::find_shape(const JPH::SubShapeID& p_sub_shape_id) const {
+	const int32_t shape_index = find_shape_index(p_sub_shape_id);
+	return shape_index != -1 ? shapes[shape_index].get_shape() : nullptr;
+}
+
+Transform3D JoltShapedObjectImpl3D::get_shape_transform_unscaled(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_transform_unscaled();
+}
+
+Transform3D JoltShapedObjectImpl3D::get_shape_transform_scaled(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_transform_scaled();
+}
+
+Vector3 JoltShapedObjectImpl3D::get_shape_scale(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].get_scale();
+}
+
+void JoltShapedObjectImpl3D::set_shape_transform(int32_t p_index, Transform3D p_transform) {
+	ERR_FAIL_INDEX(p_index, shapes.size());
+
+	Vector3 new_scale;
+	Math::decompose(p_transform, new_scale);
+
+	JoltShapeInstance3D& shape = shapes[p_index];
+
+	if (shape.get_transform_unscaled() == p_transform && shape.get_scale() == new_scale) {
+		return;
+	}
+
+	shape.set_transform(p_transform);
+	shape.set_scale(new_scale);
+
+	_shapes_changed();
+}
+
+bool JoltShapedObjectImpl3D::is_shape_disabled(int32_t p_index) const {
+	ERR_FAIL_INDEX_D(p_index, shapes.size());
+
+	return shapes[p_index].is_disabled();
+}
+
+void JoltShapedObjectImpl3D::set_shape_disabled(int32_t p_index, bool p_disabled) {
+	ERR_FAIL_INDEX(p_index, shapes.size());
+
+	JoltShapeInstance3D& shape = shapes[p_index];
+
+	if (shape.is_disabled() == p_disabled) {
+		return;
+	}
+
+	if (p_disabled) {
+		shape.disable();
+	} else {
+		shape.enable();
+	}
+
+	_shapes_changed();
+}
+
+void JoltShapedObjectImpl3D::post_step(float p_step, JPH::Body& p_jolt_body) {
+	JoltObjectImpl3D::post_step(p_step, p_jolt_body);
+
+	previous_jolt_shape = nullptr;
+}
+
+void JoltShapedObjectImpl3D::_shapes_changed() {
+	update_shape();
+}
+
+void JoltShapedObjectImpl3D::_space_changing() {
+	JoltObjectImpl3D::_space_changing();
+
+	if (space != nullptr) {
+		const JoltWritableBody3D body = space->write_body(jolt_id);
+		ERR_FAIL_COND(body.is_invalid());
+
+		jolt_settings = new JPH::BodyCreationSettings(body->GetBodyCreationSettings());
+	}
+}

--- a/src/objects/jolt_shaped_object_impl_3d.hpp
+++ b/src/objects/jolt_shaped_object_impl_3d.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "objects/jolt_object_impl_3d.hpp"
+
+class JoltShapedObjectImpl3D : public JoltObjectImpl3D {
+public:
+	explicit JoltShapedObjectImpl3D(ObjectType p_object_type);
+
+	virtual ~JoltShapedObjectImpl3D() = 0;
+
+	Transform3D get_transform_unscaled() const;
+
+	Transform3D get_transform_scaled() const;
+
+	Vector3 get_scale() const { return scale; }
+
+	Basis get_basis() const;
+
+	Vector3 get_position() const;
+
+	Vector3 get_center_of_mass() const;
+
+	Vector3 get_center_of_mass_local() const;
+
+	Vector3 get_linear_velocity() const;
+
+	Vector3 get_angular_velocity() const;
+
+	virtual bool has_custom_center_of_mass() const = 0;
+
+	virtual Vector3 get_center_of_mass_custom() const = 0;
+
+	JPH::ShapeRefC try_build_shape();
+
+	JPH::ShapeRefC build_shape();
+
+	void update_shape();
+
+	const JPH::Shape* get_jolt_shape() const { return jolt_shape; }
+
+	const JPH::Shape* get_previous_jolt_shape() const { return previous_jolt_shape; }
+
+	void add_shape(JoltShapeImpl3D* p_shape, Transform3D p_transform, bool p_disabled);
+
+	void remove_shape(const JoltShapeImpl3D* p_shape);
+
+	void remove_shape(int32_t p_index);
+
+	JoltShapeImpl3D* get_shape(int32_t p_index) const;
+
+	void set_shape(int32_t p_index, JoltShapeImpl3D* p_shape);
+
+	void clear_shapes();
+
+	int32_t get_shape_count() const { return shapes.size(); }
+
+	int32_t find_shape_index(uint32_t p_shape_instance_id) const;
+
+	int32_t find_shape_index(const JPH::SubShapeID& p_sub_shape_id) const;
+
+	JoltShapeImpl3D* find_shape(uint32_t p_shape_instance_id) const;
+
+	JoltShapeImpl3D* find_shape(const JPH::SubShapeID& p_sub_shape_id) const;
+
+	Transform3D get_shape_transform_unscaled(int32_t p_index) const;
+
+	Transform3D get_shape_transform_scaled(int32_t p_index) const;
+
+	Vector3 get_shape_scale(int32_t p_index) const;
+
+	void set_shape_transform(int32_t p_index, Transform3D p_transform);
+
+	bool is_shape_disabled(int32_t p_index) const;
+
+	void set_shape_disabled(int32_t p_index, bool p_disabled);
+
+	void post_step(float p_step, JPH::Body& p_jolt_body) override;
+
+protected:
+	friend class JoltShapeImpl3D;
+
+	virtual JPH::EMotionType _get_motion_type() const = 0;
+
+	virtual void _shapes_changed();
+
+	virtual void _shapes_built() { }
+
+	void _space_changing() override;
+
+	Vector3 scale = {1.0f, 1.0f, 1.0f};
+
+	JPH::ShapeRefC jolt_shape;
+
+	JPH::ShapeRefC previous_jolt_shape;
+
+	JPH::BodyCreationSettings* jolt_settings = new JPH::BodyCreationSettings();
+};

--- a/src/objects/jolt_shaped_object_impl_3d.hpp
+++ b/src/objects/jolt_shaped_object_impl_3d.hpp
@@ -6,7 +6,7 @@ class JoltShapedObjectImpl3D : public JoltObjectImpl3D {
 public:
 	explicit JoltShapedObjectImpl3D(ObjectType p_object_type);
 
-	virtual ~JoltShapedObjectImpl3D() = 0;
+	~JoltShapedObjectImpl3D() override;
 
 	Transform3D get_transform_unscaled() const;
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -76,7 +76,7 @@ void JoltSoftBodyImpl3D::set_mesh(const RID& p_mesh) {
 void JoltSoftBodyImpl3D::set_simulation_precision(int32_t p_precision) {
 	QUIET_FAIL_COND(simulation_precision == p_precision);
 
-	simulation_precision = p_precision;
+	simulation_precision = MAX(p_precision, 0);
 
 	_simulation_precision_changed();
 }
@@ -84,7 +84,7 @@ void JoltSoftBodyImpl3D::set_simulation_precision(int32_t p_precision) {
 void JoltSoftBodyImpl3D::set_mass(float p_mass) {
 	QUIET_FAIL_COND(mass == p_mass);
 
-	mass = p_mass;
+	mass = MAX(p_mass, 0.0f);
 
 	_mass_changed();
 }
@@ -96,13 +96,13 @@ float JoltSoftBodyImpl3D::get_stiffness_coefficient() const {
 void JoltSoftBodyImpl3D::set_stiffness_coefficient(float p_coefficient) {
 	QUIET_FAIL_COND(stiffness_coefficient == p_coefficient);
 
-	stiffness_coefficient = clamp(p_coefficient, 0.0f, 1.0f);
+	stiffness_coefficient = CLAMP(p_coefficient, 0.0f, 1.0f);
 }
 
 void JoltSoftBodyImpl3D::set_pressure(float p_pressure) {
 	QUIET_FAIL_COND(pressure == p_pressure);
 
-	pressure = p_pressure;
+	pressure = MAX(p_pressure, 0.0f);
 
 	_pressure_changed();
 }
@@ -110,7 +110,7 @@ void JoltSoftBodyImpl3D::set_pressure(float p_pressure) {
 void JoltSoftBodyImpl3D::set_linear_damping(float p_damping) {
 	QUIET_FAIL_COND(linear_damping == p_damping);
 
-	linear_damping = p_damping;
+	linear_damping = MAX(p_damping, 0.0f);
 
 	_damping_changed();
 }
@@ -567,7 +567,7 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 		// HACK(mihe): Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt
 		// uses actual stiffness for its edge constraints, we crudely map one to the other with an
 		// arbitrary constant.
-		const float stiffness = max(stiffness_coefficient * 100'000.0f, 0.00001f);
+		const float stiffness = MAX(stiffness_coefficient * 100'000.0f, 0.00001f);
 		const float inverse_stiffness = 1.0f / stiffness;
 
 		SymmetricBitTable marked_edges((int32_t)physics_vertices.size());

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -487,17 +487,6 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 	if (iter_shared_data == mesh_to_shared.end()) {
 		RenderingServer* rendering = RenderingServer::get_singleton();
 
-		iter_shared_data = mesh_to_shared.emplace(mesh);
-
-		Shared& shared_data = iter_shared_data->second;
-
-		LocalVector<int32_t>& mesh_to_physics = shared_data.mesh_to_physics;
-		JPH::SoftBodySharedSettings& settings = *shared_data.settings;
-
-		JPH::Array<SoftBodyVertex>& physics_vertices = settings.mVertices;
-		JPH::Array<SoftBodyFace>& physics_faces = settings.mFaces;
-		JPH::Array<SoftBodyEdge>& physics_edges = settings.mEdgeConstraints;
-
 		const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
 		ERR_FAIL_COND_D(mesh_data.is_empty());
 
@@ -506,6 +495,14 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 
 		const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
 		ERR_FAIL_COND_D(mesh_vertices.is_empty());
+
+		iter_shared_data = mesh_to_shared.emplace(mesh);
+
+		LocalVector<int32_t>& mesh_to_physics = iter_shared_data->second.mesh_to_physics;
+		JPH::SoftBodySharedSettings& settings = *iter_shared_data->second.settings;
+		JPH::Array<SoftBodyVertex>& physics_vertices = settings.mVertices;
+		JPH::Array<SoftBodyFace>& physics_faces = settings.mFaces;
+		JPH::Array<SoftBodyEdge>& physics_edges = settings.mEdgeConstraints;
 
 		HashMap<Vector3, int32_t> vertex_to_physics;
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -567,7 +567,7 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 		// HACK(mihe): Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt
 		// uses actual stiffness for its edge constraints, we crudely map one to the other with an
 		// arbitrary constant.
-		const float stiffness = MAX(stiffness_coefficient * 1000000.0f, 0.000001f);
+		const float stiffness = MAX(Math::pow(stiffness_coefficient, 3.0f) * 1000000.0f, 0.000001f);
 		const float inverse_stiffness = 1.0f / stiffness;
 
 		SymmetricBitTable marked_edges((int32_t)physics_vertices.size());

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -169,20 +169,8 @@ void JoltSoftBodyImpl3D::set_state(PhysicsServer3D::BodyState p_state, const Var
 }
 
 Transform3D JoltSoftBodyImpl3D::get_transform() const {
-	ERR_FAIL_NULL_D_MSG(
-		space,
-		vformat(
-			"Failed to retrieve transform for '%s'. "
-			"Doing so without a physics space is not supported by Godot Jolt. "
-			"If this relates to a node, try adding the node to a scene tree first.",
-			to_string()
-		)
-	);
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_D(body.is_invalid());
-
-	return {to_godot(body->GetRotation()), to_godot(body->GetPosition())};
+	// Since any transform gets baked into the vertices anyway we can just return identity here.
+	return {};
 }
 
 void JoltSoftBodyImpl3D::set_transform(const Transform3D& p_transform) {

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -546,7 +546,7 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 		// HACK(mihe): Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt
 		// uses actual stiffness for its edge constraints, we crudely map one to the other with an
 		// arbitrary constant.
-		const float stiffness = stiffness_coefficient * 100'000.0f;
+		const float stiffness = max(stiffness_coefficient * 100'000.0f, 0.00001f);
 		const float inverse_stiffness = 1.0f / stiffness;
 
 		SymmetricBitTable marked_edges((int32_t)physics_vertices.size());

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -1,0 +1,722 @@
+#include "jolt_soft_body_impl_3d.hpp"
+
+#include "objects/jolt_area_impl_3d.hpp"
+#include "objects/jolt_body_impl_3d.hpp"
+#include "objects/jolt_group_filter.hpp"
+#include "servers/jolt_project_settings.hpp"
+#include "spaces/jolt_broad_phase_layer.hpp"
+#include "spaces/jolt_space_3d.hpp"
+
+JoltSoftBodyImpl3D::JoltSoftBodyImpl3D()
+	: JoltObjectImpl3D(OBJECT_TYPE_SOFT_BODY) {
+	jolt_settings->mRestitution = 0.0f;
+	jolt_settings->mFriction = 1.0f;
+	jolt_settings->mUpdatePosition = false;
+	jolt_settings->mMakeRotationIdentity = false;
+}
+
+JoltSoftBodyImpl3D::~JoltSoftBodyImpl3D() {
+	delete_safely(jolt_settings);
+}
+
+void JoltSoftBodyImpl3D::add_collision_exception(const RID& p_excepted_body) {
+	exceptions.push_back(p_excepted_body);
+
+	_exceptions_changed();
+}
+
+void JoltSoftBodyImpl3D::remove_collision_exception(const RID& p_excepted_body) {
+	exceptions.erase(p_excepted_body);
+
+	_exceptions_changed();
+}
+
+bool JoltSoftBodyImpl3D::has_collision_exception(const RID& p_excepted_body) const {
+	return exceptions.find(p_excepted_body) >= 0;
+}
+
+TypedArray<RID> JoltSoftBodyImpl3D::get_collision_exceptions() const {
+	TypedArray<RID> result;
+	result.resize(exceptions.size());
+
+	for (int32_t i = 0; i < exceptions.size(); ++i) {
+		result[i] = exceptions[i];
+	}
+
+	return result;
+}
+
+bool JoltSoftBodyImpl3D::can_interact_with(const JoltBodyImpl3D& p_other) const {
+	return (can_collide_with(p_other) || p_other.can_collide_with(*this)) &&
+		!has_collision_exception(p_other.get_rid()) && !p_other.has_collision_exception(rid);
+}
+
+bool JoltSoftBodyImpl3D::can_interact_with(const JoltSoftBodyImpl3D& p_other) const {
+	return (can_collide_with(p_other) || p_other.can_collide_with(*this)) &&
+		!has_collision_exception(p_other.get_rid()) && !p_other.has_collision_exception(rid);
+}
+
+bool JoltSoftBodyImpl3D::can_interact_with(const JoltAreaImpl3D& p_other) const {
+	return p_other.can_interact_with(*this);
+}
+
+Vector3 JoltSoftBodyImpl3D::get_velocity_at_position([[maybe_unused]] const Vector3& p_position
+) const {
+	return {0.0f, 0.0f, 0.0f};
+}
+
+void JoltSoftBodyImpl3D::set_mesh(const RID& p_mesh) {
+	QUIET_FAIL_COND(mesh == p_mesh);
+
+	mesh = p_mesh;
+
+	_mesh_changed();
+}
+
+void JoltSoftBodyImpl3D::set_simulation_precision(int32_t p_precision) {
+	QUIET_FAIL_COND(simulation_precision == p_precision);
+
+	simulation_precision = p_precision;
+
+	_simulation_precision_changed();
+}
+
+void JoltSoftBodyImpl3D::set_mass(float p_mass) {
+	QUIET_FAIL_COND(mass == p_mass);
+
+	mass = p_mass;
+
+	_mass_changed();
+}
+
+float JoltSoftBodyImpl3D::get_stiffness_coefficient() const {
+	return stiffness_coefficient;
+}
+
+void JoltSoftBodyImpl3D::set_stiffness_coefficient(float p_coefficient) {
+	QUIET_FAIL_COND(stiffness_coefficient == p_coefficient);
+
+	stiffness_coefficient = clamp(p_coefficient, 0.0f, 1.0f);
+}
+
+void JoltSoftBodyImpl3D::set_pressure(float p_pressure) {
+	QUIET_FAIL_COND(pressure == p_pressure);
+
+	pressure = p_pressure;
+
+	_pressure_changed();
+}
+
+void JoltSoftBodyImpl3D::set_linear_damping(float p_damping) {
+	QUIET_FAIL_COND(linear_damping == p_damping);
+
+	linear_damping = p_damping;
+
+	_damping_changed();
+}
+
+float JoltSoftBodyImpl3D::get_drag() const {
+	// Drag is not a thing in Jolt, and not supported by Godot Physics either.
+	return 0.0f;
+}
+
+void JoltSoftBodyImpl3D::set_drag([[maybe_unused]] float p_drag) {
+	// Drag is not a thing in Jolt, and not supported by Godot Physics either.
+}
+
+Variant JoltSoftBodyImpl3D::get_state(PhysicsServer3D::BodyState p_state) const {
+	switch (p_state) {
+		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
+			return get_transform();
+		}
+		case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
+		case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
+		case PhysicsServer3D::BODY_STATE_SLEEPING: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
+		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
+			ERR_FAIL_D_NOT_IMPL();
+		}
+		default: {
+			ERR_FAIL_D_MSG(vformat("Unhandled body state: '%d'", p_state));
+		}
+	}
+}
+
+void JoltSoftBodyImpl3D::set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value) {
+	switch (p_state) {
+		case PhysicsServer3D::BODY_STATE_TRANSFORM: {
+			set_transform(p_value);
+		} break;
+		case PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
+		case PhysicsServer3D::BODY_STATE_ANGULAR_VELOCITY: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
+		case PhysicsServer3D::BODY_STATE_SLEEPING: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
+		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
+			ERR_FAIL_NOT_IMPL();
+		} break;
+		default: {
+			ERR_FAIL_MSG(vformat("Unhandled body state: '%d'", p_state));
+		} break;
+	}
+}
+
+Transform3D JoltSoftBodyImpl3D::get_transform() const {
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve transform for '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return {to_godot(body->GetRotation()), to_godot(body->GetPosition())};
+}
+
+void JoltSoftBodyImpl3D::set_transform(const Transform3D& p_transform) {
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to set transform for '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	// HACK(mihe): For whatever reason this has to be interpreted as a relative global-space
+	// transform rather than an absolute one, because `SoftBody3D` will immediately upon entering
+	// the scene tree set itself to be top-level and also set its transform to be identity, while
+	// still expecting to stay in its original position.
+	//
+	// We also discard any scaling, since we have no way of scaling the actual edge lengths.
+	const JPH::Mat44 relative_transform = to_jolt(p_transform.orthonormalized());
+
+	auto& motion_properties = static_cast<JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	JPH::Array<JPH::SoftBodyVertex>& physics_vertices = motion_properties.GetVertices();
+
+	for (JPH::SoftBodyVertex& vertex : physics_vertices) {
+		vertex.mPosition = vertex.mPreviousPosition = relative_transform * vertex.mPosition;
+		vertex.mVelocity = JPH::Vec3::sZero();
+	}
+}
+
+AABB JoltSoftBodyImpl3D::get_bounds() const {
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve world bounds of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	return to_godot(body->GetWorldSpaceBounds());
+}
+
+void JoltSoftBodyImpl3D::update_rendering_server(
+	PhysicsServer3DRenderingServerHandler* p_rendering_server_handler
+) {
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to update rendering server with state of '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	const Vector3 center_of_mass = to_godot(body->GetCenterOfMassPosition());
+
+	const auto& motion_properties = static_cast<const JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	const JPH::Array<JPH::SoftBodyVertex>& physics_vertices = motion_properties.GetVertices();
+
+	Vector3 face[3];
+
+	for (int32_t i = 0; i < shared->mesh_to_physics.size(); i += 3) {
+		for (int32_t j = 0; j < 3; ++j) {
+			const int32_t mesh_index = i + j;
+			const auto physics_index = (size_t)shared->mesh_to_physics[mesh_index];
+			const Vector3 local_vertex = to_godot(physics_vertices[physics_index].mPosition);
+			face[j] = center_of_mass + local_vertex;
+			p_rendering_server_handler->set_vertex(mesh_index, face[j]);
+		}
+
+		const Vector3 v0_to_v1 = face[1] - face[0];
+		const Vector3 v0_to_v2 = face[2] - face[0];
+		const Vector3 normal = v0_to_v2.cross(v0_to_v1).normalized();
+
+		for (int32_t j = 0; j < 3; ++j) {
+			p_rendering_server_handler->set_normal(i + j, normal);
+		}
+	}
+
+	p_rendering_server_handler->set_aabb(get_bounds());
+}
+
+Vector3 JoltSoftBodyImpl3D::get_vertex_position(int32_t p_index) {
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed to retrieve point position for '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	ERR_FAIL_INDEX_D(p_index, shared->mesh_to_physics.size());
+	const int32_t physics_index = shared->mesh_to_physics[p_index];
+
+	const JoltReadableBody3D body = space->read_body(jolt_id);
+	ERR_FAIL_COND_D(body.is_invalid());
+
+	const auto& motion_properties = static_cast<const JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	const JPH::Array<JPH::SoftBodyVertex>& physics_vertices = motion_properties.GetVertices();
+	const JPH::SoftBodyVertex& physics_vertex = physics_vertices[(size_t)physics_index];
+
+	return to_godot(body->GetCenterOfMassPosition() + physics_vertex.mPosition);
+}
+
+void JoltSoftBodyImpl3D::set_vertex_position(int32_t p_index, const Vector3& p_position) {
+	ERR_FAIL_NULL_MSG(
+		space,
+		vformat(
+			"Failed to set point position for '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	ERR_FAIL_INDEX(p_index, shared->mesh_to_physics.size());
+	const int32_t physics_index = shared->mesh_to_physics[p_index];
+
+	const float last_step = space->get_last_step();
+	QUIET_FAIL_COND(last_step == 0.0f);
+
+	JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	auto& motion_properties = static_cast<JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	JPH::Array<JPH::SoftBodyVertex>& physics_vertices = motion_properties.GetVertices();
+	JPH::SoftBodyVertex& physics_vertex = physics_vertices[(size_t)physics_index];
+
+	const JPH::Vec3 local_position = to_jolt(p_position) - body->GetCenterOfMassPosition();
+	const JPH::Vec3 displacement = local_position - physics_vertex.mPosition;
+	const JPH::Vec3 velocity = displacement / last_step;
+
+	physics_vertex.mVelocity = velocity;
+}
+
+void JoltSoftBodyImpl3D::pin_vertex(int32_t p_index) {
+	pinned_vertices.insert(p_index);
+
+	_pins_changed();
+}
+
+void JoltSoftBodyImpl3D::unpin_vertex(int32_t p_index) {
+	pinned_vertices.erase(p_index);
+
+	_pins_changed();
+}
+
+void JoltSoftBodyImpl3D::unpin_all_vertices() {
+	pinned_vertices.clear();
+
+	_pins_changed();
+}
+
+bool JoltSoftBodyImpl3D::is_vertex_pinned(int32_t p_index) const {
+	ERR_FAIL_NULL_D_MSG(
+		space,
+		vformat(
+			"Failed retrieve pin status of point for '%s'. "
+			"Doing so without a physics space is not supported by Godot Jolt. "
+			"If this relates to a node, try adding the node to a scene tree first.",
+			to_string()
+		)
+	);
+
+	ERR_FAIL_INDEX_D(p_index, shared->mesh_to_physics.size());
+	const int32_t physics_index = shared->mesh_to_physics[p_index];
+
+	return pinned_vertices.has(physics_index);
+}
+
+String JoltSoftBodyImpl3D::to_string() const {
+	Object* instance = ObjectDB::get_instance(instance_id);
+	return instance != nullptr ? instance->to_string() : "<unknown>";
+}
+
+JPH::BroadPhaseLayer JoltSoftBodyImpl3D::_get_broad_phase_layer() const {
+	return JoltBroadPhaseLayer::BODY_DYNAMIC;
+}
+
+JPH::ObjectLayer JoltSoftBodyImpl3D::_get_object_layer() const {
+	ERR_FAIL_NULL_D(space);
+
+	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
+}
+
+void JoltSoftBodyImpl3D::_space_changing() {
+	JoltObjectImpl3D::_space_changing();
+
+	_deref_shared_data();
+
+	if (space != nullptr && !jolt_id.IsInvalid()) {
+		const JoltWritableBody3D body = space->write_body(jolt_id);
+		ERR_FAIL_COND(body.is_invalid());
+
+		jolt_settings = new JPH::SoftBodyCreationSettings(body->GetSoftBodyCreationSettings());
+		jolt_settings->mSettings = nullptr;
+	}
+}
+
+void JoltSoftBodyImpl3D::_space_changed() {
+	JoltObjectImpl3D::_space_changed();
+
+	_update_mass();
+	_update_pressure();
+	_update_damping();
+	_update_simulation_precision();
+	_update_group_filter();
+}
+
+void JoltSoftBodyImpl3D::_add_to_space() {
+	QUIET_FAIL_NULL(space);
+	QUIET_FAIL_COND(!mesh.is_valid());
+
+	ON_SCOPE_EXIT {
+		delete_safely(jolt_settings);
+	};
+
+	const bool has_valid_shared = _ref_shared_data();
+	ERR_FAIL_COND(!has_valid_shared);
+
+	JPH::CollisionGroup::GroupID group_id = 0;
+	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
+	JoltGroupFilter::encode_object(this, group_id, sub_group_id);
+
+	jolt_settings->mSettings = shared->settings;
+	jolt_settings->mUserData = reinterpret_cast<JPH::uint64>(this);
+	jolt_settings->mObjectLayer = _get_object_layer();
+	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
+	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
+
+	JPH::BodyInterface& body_iface = space->get_body_iface();
+
+	JPH::Body* body = body_iface.CreateSoftBody(*jolt_settings);
+
+	ERR_FAIL_NULL_MSG(
+		body,
+		vformat(
+			"Failed to create Jolt body for '%s'. "
+			"Consider increasing maximum number of bodies in project settings. "
+			"Maximum number of bodies is currently set to %d.",
+			to_string(),
+			JoltProjectSettings::get_max_bodies()
+		)
+	);
+
+	jolt_id = body->GetID();
+
+	body_iface.AddBody(jolt_id, JPH::EActivation::Activate);
+}
+
+bool JoltSoftBodyImpl3D::_ref_shared_data() {
+	using SoftBodyVertex = JPH::SoftBodySharedSettings::Vertex;
+	using SoftBodyFace = JPH::SoftBodySharedSettings::Face;
+	using SoftBodyEdge = JPH::SoftBodySharedSettings::Edge;
+
+	auto iter_shared_data = mesh_to_shared.find(mesh);
+
+	if (iter_shared_data == mesh_to_shared.end()) {
+		RenderingServer* rendering = RenderingServer::get_singleton();
+
+		const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
+		ERR_FAIL_COND_D(mesh_data.is_empty());
+
+		const PackedInt32Array mesh_indices = mesh_data[RenderingServer::ARRAY_INDEX];
+		ERR_FAIL_COND_D(mesh_indices.is_empty());
+
+		const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
+		ERR_FAIL_COND_D(mesh_vertices.is_empty());
+
+		iter_shared_data = mesh_to_shared.emplace(mesh);
+
+		LocalVector<int32_t>& mesh_to_physics = iter_shared_data->second.mesh_to_physics;
+		JPH::SoftBodySharedSettings& settings = *iter_shared_data->second.settings;
+		JPH::Array<SoftBodyVertex>& physics_vertices = settings.mVertices;
+		JPH::Array<SoftBodyFace>& physics_faces = settings.mFaces;
+		JPH::Array<SoftBodyEdge>& physics_edges = settings.mEdgeConstraints;
+
+		HashMap<Vector3, int32_t> vertex_to_physics;
+
+		const auto mesh_vertex_count = (int32_t)mesh_vertices.size();
+		const auto mesh_index_count = (int32_t)mesh_indices.size();
+
+		mesh_to_physics.resize(mesh_vertex_count);
+		physics_vertices.reserve((size_t)mesh_vertex_count);
+		vertex_to_physics.reserve(mesh_vertex_count);
+
+		int32_t physics_index_count = 0;
+
+		auto is_face_degenerate = [](const int32_t p_face[3]) {
+			return p_face[0] == p_face[1] || p_face[0] == p_face[2] || p_face[1] == p_face[2];
+		};
+
+		for (int32_t i = 0; i < mesh_index_count; i += 3) {
+			int32_t physics_face[3];
+			int32_t mesh_face[3];
+
+			for (int32_t j = 0; j < 3; ++j) {
+				const int32_t mesh_index = mesh_indices[i + j];
+				const Vector3 vertex = mesh_vertices[mesh_index];
+
+				auto iter_physics_index = vertex_to_physics.find(vertex);
+
+				if (iter_physics_index == vertex_to_physics.end()) {
+					physics_vertices.emplace_back(JPH::Float3(vertex.x, vertex.y, vertex.z));
+					iter_physics_index = vertex_to_physics.insert(vertex, physics_index_count++);
+				}
+
+				mesh_face[j] = mesh_index;
+				physics_face[j] = iter_physics_index->second;
+				mesh_to_physics[mesh_index] = iter_physics_index->second;
+			}
+
+			ERR_CONTINUE_MSG(
+				is_face_degenerate(physics_face),
+				vformat(
+					"Failed to append face to soft body '%s'. "
+					"Face was found to be degenerate. "
+					"Face consist of indices %d, %d and %d.",
+					to_string(),
+					mesh_face[0],
+					mesh_face[1],
+					mesh_face[2]
+				)
+			);
+
+			physics_faces.emplace_back(
+				(JPH::uint32)physics_face[2],
+				(JPH::uint32)physics_face[1],
+				(JPH::uint32)physics_face[0]
+			);
+		}
+
+		// HACK(mihe): Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt
+		// uses actual stiffness for its edge constraints, we crudely map one to the other with an
+		// arbitrary constant.
+		const float stiffness = stiffness_coefficient * 100'000.0f;
+		const float inverse_stiffness = 1.0f / stiffness;
+
+		SymmetricBitTable marked_edges((int32_t)physics_vertices.size());
+
+		auto try_add_edge = [&](int32_t p_physics_index_a, int32_t p_physics_index_b) {
+			if (!marked_edges.has(p_physics_index_a, p_physics_index_b)) {
+				physics_edges.emplace_back(
+					(JPH::uint32)p_physics_index_a,
+					(JPH::uint32)p_physics_index_b,
+					inverse_stiffness
+				);
+
+				marked_edges.set(p_physics_index_a, p_physics_index_b);
+			}
+		};
+
+		for (SoftBodyFace& face : physics_faces) {
+			try_add_edge((int32_t)face.mVertex[0], (int32_t)face.mVertex[1]);
+			try_add_edge((int32_t)face.mVertex[1], (int32_t)face.mVertex[2]);
+			try_add_edge((int32_t)face.mVertex[2], (int32_t)face.mVertex[0]);
+		}
+
+		settings.CalculateEdgeLengths();
+		settings.Optimize();
+	} else {
+		iter_shared_data->second.ref_count++;
+	}
+
+	shared = &iter_shared_data->second;
+
+	return true;
+}
+
+void JoltSoftBodyImpl3D::_deref_shared_data() {
+	QUIET_FAIL_NULL(shared);
+
+	auto iter = mesh_to_shared.find(mesh);
+	QUIET_FAIL_COND(iter == mesh_to_shared.end());
+
+	if (--iter->second.ref_count == 0) {
+		mesh_to_shared.remove(iter);
+	}
+
+	shared = nullptr;
+}
+
+void JoltSoftBodyImpl3D::_update_mass() {
+	QUIET_FAIL_NULL(space);
+	QUIET_FAIL_COND(jolt_id.IsInvalid());
+
+	JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	auto& motion_properties = static_cast<JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	JPH::Array<JPH::SoftBodyVertex>& physics_vertices = motion_properties.GetVertices();
+
+	const float inverse_vertex_mass = mass == 0.0f ? 1.0f : (float)physics_vertices.size() / mass;
+
+	for (JPH::SoftBodyVertex& vertex : physics_vertices) {
+		vertex.mInvMass = inverse_vertex_mass;
+	}
+
+	for (int32_t pin_mesh_index : pinned_vertices) {
+		const int32_t pin_physics_index = shared->mesh_to_physics[pin_mesh_index];
+		ERR_FAIL_INDEX(pin_physics_index, (int32_t)physics_vertices.size());
+
+		physics_vertices[(size_t)pin_physics_index].mInvMass = 0.0f;
+	}
+}
+
+void JoltSoftBodyImpl3D::_update_pressure() {
+	if (space == nullptr) {
+		jolt_settings->mPressure = pressure;
+		return;
+	}
+
+	QUIET_FAIL_COND(jolt_id.IsInvalid());
+
+	JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	auto& motion_properties = static_cast<JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	motion_properties.SetPressure(pressure);
+}
+
+void JoltSoftBodyImpl3D::_update_damping() {
+	if (space == nullptr) {
+		jolt_settings->mLinearDamping = linear_damping;
+		return;
+	}
+
+	QUIET_FAIL_COND(jolt_id.IsInvalid());
+
+	JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	auto& motion_properties = static_cast<JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	motion_properties.SetLinearDamping(linear_damping);
+}
+
+void JoltSoftBodyImpl3D::_update_simulation_precision() {
+	if (space == nullptr) {
+		jolt_settings->mNumIterations = (JPH::uint32)simulation_precision;
+		return;
+	}
+
+	QUIET_FAIL_COND(jolt_id.IsInvalid());
+
+	JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	auto& motion_properties = static_cast<JPH::SoftBodyMotionProperties&>(
+		*body->GetMotionPropertiesUnchecked()
+	);
+
+	motion_properties.SetNumIterations((JPH::uint32)simulation_precision);
+}
+
+void JoltSoftBodyImpl3D::_update_group_filter() {
+	JPH::GroupFilter* group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
+
+	if (space == nullptr) {
+		jolt_settings->mCollisionGroup.SetGroupFilter(group_filter);
+		return;
+	}
+
+	QUIET_FAIL_COND(jolt_id.IsInvalid());
+
+	const JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	body->GetCollisionGroup().SetGroupFilter(group_filter);
+}
+
+void JoltSoftBodyImpl3D::_mesh_changed() {
+	if (space != nullptr) {
+		_deref_shared_data();
+		_reset_space();
+	}
+}
+
+void JoltSoftBodyImpl3D::_mass_changed() {
+	_update_mass();
+}
+
+void JoltSoftBodyImpl3D::_pressure_changed() {
+	_update_pressure();
+}
+
+void JoltSoftBodyImpl3D::_damping_changed() {
+	_update_damping();
+}
+
+void JoltSoftBodyImpl3D::_simulation_precision_changed() {
+	_update_simulation_precision();
+}
+
+void JoltSoftBodyImpl3D::_pins_changed() {
+	_update_mass();
+}
+
+void JoltSoftBodyImpl3D::_exceptions_changed() {
+	_update_group_filter();
+}

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -613,6 +613,7 @@ void JoltSoftBodyImpl3D::_update_mass() {
 	}
 
 	for (int32_t pin_mesh_index : pinned_vertices) {
+		ERR_FAIL_INDEX(pin_mesh_index, shared->mesh_to_physics.size());
 		const int32_t pin_physics_index = shared->mesh_to_physics[pin_mesh_index];
 		ERR_FAIL_INDEX(pin_physics_index, (int32_t)physics_vertices.size());
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -710,11 +710,15 @@ void JoltSoftBodyImpl3D::_update_group_filter() {
 	body->GetCollisionGroup().SetGroupFilter(group_filter);
 }
 
-void JoltSoftBodyImpl3D::_mesh_changed() {
+void JoltSoftBodyImpl3D::_try_rebuild() {
 	if (space != nullptr) {
 		_deref_shared_data();
 		_reset_space();
 	}
+}
+
+void JoltSoftBodyImpl3D::_mesh_changed() {
+	_try_rebuild();
 }
 
 void JoltSoftBodyImpl3D::_damping_changed() {

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -499,7 +499,10 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 		iter_shared_data = mesh_to_shared.emplace(mesh);
 
 		LocalVector<int32_t>& mesh_to_physics = iter_shared_data->second.mesh_to_physics;
+
 		JPH::SoftBodySharedSettings& settings = *iter_shared_data->second.settings;
+		settings.mVertexRadius = JoltProjectSettings::get_soft_body_point_margin();
+
 		JPH::Array<SoftBodyVertex>& physics_vertices = settings.mVertices;
 		JPH::Array<SoftBodyFace>& physics_faces = settings.mFaces;
 		JPH::Array<SoftBodyEdge>& physics_edges = settings.mEdgeConstraints;

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -94,8 +94,6 @@ float JoltSoftBodyImpl3D::get_stiffness_coefficient() const {
 }
 
 void JoltSoftBodyImpl3D::set_stiffness_coefficient(float p_coefficient) {
-	QUIET_FAIL_COND(stiffness_coefficient == p_coefficient);
-
 	stiffness_coefficient = CLAMP(p_coefficient, 0.0f, 1.0f);
 }
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -567,7 +567,7 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 		// HACK(mihe): Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt
 		// uses actual stiffness for its edge constraints, we crudely map one to the other with an
 		// arbitrary constant.
-		const float stiffness = MAX(stiffness_coefficient * 100'000.0f, 0.00001f);
+		const float stiffness = MAX(stiffness_coefficient * 1000000.0f, 0.000001f);
 		const float inverse_stiffness = 1.0f / stiffness;
 
 		SymmetricBitTable marked_edges((int32_t)physics_vertices.size());

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -78,7 +78,7 @@ void JoltSoftBodyImpl3D::set_simulation_precision(int32_t p_precision) {
 
 	simulation_precision = MAX(p_precision, 0);
 
-	_simulation_precision_changed();
+	_update_simulation_precision();
 }
 
 void JoltSoftBodyImpl3D::set_mass(float p_mass) {
@@ -86,7 +86,7 @@ void JoltSoftBodyImpl3D::set_mass(float p_mass) {
 
 	mass = MAX(p_mass, 0.0f);
 
-	_mass_changed();
+	_update_mass();
 }
 
 float JoltSoftBodyImpl3D::get_stiffness_coefficient() const {
@@ -102,7 +102,7 @@ void JoltSoftBodyImpl3D::set_pressure(float p_pressure) {
 
 	pressure = MAX(p_pressure, 0.0f);
 
-	_pressure_changed();
+	_update_pressure();
 }
 
 void JoltSoftBodyImpl3D::set_linear_damping(float p_damping) {
@@ -110,7 +110,7 @@ void JoltSoftBodyImpl3D::set_linear_damping(float p_damping) {
 
 	linear_damping = MAX(p_damping, 0.0f);
 
-	_damping_changed();
+	_update_damping();
 }
 
 float JoltSoftBodyImpl3D::get_drag() const {
@@ -717,20 +717,8 @@ void JoltSoftBodyImpl3D::_mesh_changed() {
 	}
 }
 
-void JoltSoftBodyImpl3D::_mass_changed() {
-	_update_mass();
-}
-
-void JoltSoftBodyImpl3D::_pressure_changed() {
-	_update_pressure();
-}
-
 void JoltSoftBodyImpl3D::_damping_changed() {
 	_update_damping();
-}
-
-void JoltSoftBodyImpl3D::_simulation_precision_changed() {
-	_update_simulation_precision();
 }
 
 void JoltSoftBodyImpl3D::_pins_changed() {

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -117,6 +117,8 @@ private:
 
 	void _update_group_filter();
 
+	void _try_rebuild();
+
 	void _mesh_changed();
 
 	void _damping_changed();

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -16,7 +16,7 @@ class JoltSoftBodyImpl3D final : public JoltObjectImpl3D {
 public:
 	JoltSoftBodyImpl3D();
 
-	~JoltSoftBodyImpl3D();
+	~JoltSoftBodyImpl3D() override;
 
 	void add_collision_exception(const RID& p_excepted_body);
 

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -103,8 +103,6 @@ private:
 
 	void _add_to_space() override;
 
-	bool _create_shared(Shared* p_result);
-
 	bool _ref_shared_data();
 
 	void _deref_shared_data();

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -153,7 +153,7 @@ private:
 
 	float linear_damping = 0.01f;
 
-	float stiffness_coefficient = 0.0f;
+	float stiffness_coefficient = 1.0f;
 
 	int32_t simulation_precision = 5;
 };

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "objects/jolt_object_impl_3d.hpp"
+
+class JoltSpace3D;
+
+class JoltSoftBodyImpl3D final : public JoltObjectImpl3D {
+	struct Shared {
+		LocalVector<int32_t> mesh_to_physics;
+
+		JPH::Ref<JPH::SoftBodySharedSettings> settings = new JPH::SoftBodySharedSettings();
+
+		int32_t ref_count = 1;
+	};
+
+public:
+	JoltSoftBodyImpl3D();
+
+	~JoltSoftBodyImpl3D();
+
+	void add_collision_exception(const RID& p_excepted_body);
+
+	void remove_collision_exception(const RID& p_excepted_body);
+
+	bool has_collision_exception(const RID& p_excepted_body) const;
+
+	TypedArray<RID> get_collision_exceptions() const;
+
+	bool can_interact_with(const JoltBodyImpl3D& p_other) const override;
+
+	bool can_interact_with(const JoltSoftBodyImpl3D& p_other) const override;
+
+	bool can_interact_with(const JoltAreaImpl3D& p_other) const override;
+
+	bool reports_contacts() const override { return false; }
+
+	Vector3 get_velocity_at_position(const Vector3& p_position) const override;
+
+	void set_mesh(const RID& p_mesh);
+
+	bool is_pickable() const { return pickable; }
+
+	void set_pickable(bool p_enabled) { pickable = p_enabled; }
+
+	int32_t get_simulation_precision() const { return simulation_precision; }
+
+	void set_simulation_precision(int32_t p_precision);
+
+	float get_mass() const { return mass; }
+
+	void set_mass(float p_mass);
+
+	float get_stiffness_coefficient() const;
+
+	void set_stiffness_coefficient(float p_coefficient);
+
+	float get_pressure() const { return pressure; }
+
+	void set_pressure(float p_pressure);
+
+	float get_linear_damping() const { return linear_damping; }
+
+	void set_linear_damping(float p_damping);
+
+	float get_drag() const;
+
+	void set_drag(float p_drag);
+
+	Variant get_state(PhysicsServer3D::BodyState p_state) const;
+
+	void set_state(PhysicsServer3D::BodyState p_state, const Variant& p_value);
+
+	Transform3D get_transform() const;
+
+	void set_transform(const Transform3D& p_transform);
+
+	AABB get_bounds() const;
+
+	void update_rendering_server(PhysicsServer3DRenderingServerHandler* p_rendering_server_handler);
+
+	Vector3 get_vertex_position(int32_t p_index);
+
+	void set_vertex_position(int32_t p_index, const Vector3& p_position);
+
+	void pin_vertex(int32_t p_index);
+
+	void unpin_vertex(int32_t p_index);
+
+	void unpin_all_vertices();
+
+	bool is_vertex_pinned(int32_t p_index) const;
+
+	String to_string() const;
+
+private:
+	JPH::BroadPhaseLayer _get_broad_phase_layer() const;
+
+	JPH::ObjectLayer _get_object_layer() const;
+
+	void _space_changing() override;
+
+	void _space_changed() override;
+
+	void _add_to_space() override;
+
+	bool _create_shared(Shared* p_result);
+
+	bool _ref_shared_data();
+
+	void _deref_shared_data();
+
+	void _update_mass();
+
+	void _update_pressure();
+
+	void _update_damping();
+
+	void _update_simulation_precision();
+
+	void _update_group_filter();
+
+	void _mesh_changed();
+
+	void _mass_changed();
+
+	void _pressure_changed();
+
+	void _damping_changed();
+
+	void _simulation_precision_changed();
+
+	void _pins_changed();
+
+	void _exceptions_changed();
+
+	inline static HashMap<RID, Shared> mesh_to_shared;
+
+	HashSet<int32_t> pinned_vertices;
+
+	LocalVector<RID> exceptions;
+
+	const Shared* shared = nullptr;
+
+	RID mesh;
+
+	JPH::SoftBodyCreationSettings* jolt_settings = new JPH::SoftBodyCreationSettings();
+
+	float mass = 0.0f;
+
+	float pressure = 0.0f;
+
+	float linear_damping = 0.01f;
+
+	float stiffness_coefficient = 0.0f;
+
+	int32_t simulation_precision = 5;
+};

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -119,13 +119,7 @@ private:
 
 	void _mesh_changed();
 
-	void _mass_changed();
-
-	void _pressure_changed();
-
 	void _damping_changed();
-
-	void _simulation_precision_changed();
 
 	void _pins_changed();
 

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -153,7 +153,7 @@ private:
 
 	float linear_damping = 0.01f;
 
-	float stiffness_coefficient = 1.0f;
+	float stiffness_coefficient = 0.5f;
 
 	int32_t simulation_precision = 5;
 };

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -93,9 +93,9 @@ public:
 	String to_string() const;
 
 private:
-	JPH::BroadPhaseLayer _get_broad_phase_layer() const;
+	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 
-	JPH::ObjectLayer _get_object_layer() const;
+	JPH::ObjectLayer _get_object_layer() const override;
 
 	void _space_changing() override;
 

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -139,6 +139,8 @@ private:
 
 	LocalVector<RID> exceptions;
 
+	LocalVector<Vector3> normals;
+
 	const Shared* shared = nullptr;
 
 	RID mesh;

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -118,6 +118,9 @@
 #include <Jolt/Physics/Constraints/SwingTwistConstraint.h>
 #include <Jolt/Physics/PhysicsScene.h>
 #include <Jolt/Physics/PhysicsSystem.h>
+#include <Jolt/Physics/SoftBody/SoftBodyCreationSettings.h>
+#include <Jolt/Physics/SoftBody/SoftBodyMotionProperties.h>
+#include <Jolt/Physics/SoftBody/SoftBodySharedSettings.h>
 #include <Jolt/RegisterTypes.h>
 
 #ifdef JPH_DEBUG_RENDERER
@@ -153,6 +156,7 @@ using namespace godot;
 #include "containers/inline_vector.hpp"
 #include "containers/local_vector.hpp"
 #include "containers/rid_owner.hpp"
+#include "containers/symmetric_bit_table.hpp"
 #include "misc/bind_macros.hpp"
 #include "misc/error_macros.hpp"
 #include "misc/gdclass_macros.hpp"

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -31,6 +31,7 @@
 #include <godot_cpp/classes/physics_server3d_manager.hpp>
 #include <godot_cpp/classes/physics_server3d_rendering_server_handler.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/rendering_server.hpp>
 #include <godot_cpp/classes/worker_thread_pool.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
@@ -67,7 +68,6 @@
 #ifdef JPH_DEBUG_RENDERER
 
 #include <godot_cpp/classes/camera3d.hpp>
-#include <godot_cpp/classes/rendering_server.hpp>
 #include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/classes/world3d.hpp>

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -5,6 +5,7 @@ class JoltBodyImpl3D;
 class JoltJobSystem;
 class JoltJointImpl3D;
 class JoltShapeImpl3D;
+class JoltSoftBodyImpl3D;
 class JoltSpace3D;
 
 class JoltPhysicsServer3D final : public PhysicsServer3DExtension {
@@ -389,16 +390,17 @@ public:
 
 	uint32_t _soft_body_get_collision_mask(const RID& p_body) const override;
 
-	void _soft_body_add_collision_exception(const RID& p_body, const RID& p_body_b) override;
+	void _soft_body_add_collision_exception(const RID& p_body, const RID& p_excepted_body) override;
 
-	void _soft_body_remove_collision_exception(const RID& p_body, const RID& p_body_b) override;
+	void _soft_body_remove_collision_exception(const RID& p_body, const RID& p_excepted_body)
+		override;
 
 	TypedArray<RID> _soft_body_get_collision_exceptions(const RID& p_body) const override;
 
 	void _soft_body_set_state(
 		const RID& p_body,
 		PhysicsServer3D::BodyState p_state,
-		const Variant& p_variant
+		const Variant& p_value
 	) override;
 
 	Variant _soft_body_get_state(const RID& p_body, PhysicsServer3D::BodyState p_state)
@@ -406,8 +408,7 @@ public:
 
 	void _soft_body_set_transform(const RID& p_body, const Transform3D& p_transform) override;
 
-	void _soft_body_set_simulation_precision(const RID& p_body, int32_t p_simulation_precision)
-		override;
+	void _soft_body_set_simulation_precision(const RID& p_body, int32_t p_precision) override;
 
 	int32_t _soft_body_get_simulation_precision(const RID& p_body) const override;
 
@@ -415,21 +416,19 @@ public:
 
 	double _soft_body_get_total_mass(const RID& p_body) const override;
 
-	void _soft_body_set_linear_stiffness(const RID& p_body, double p_linear_stiffness) override;
+	void _soft_body_set_linear_stiffness(const RID& p_body, double p_coefficient) override;
 
 	double _soft_body_get_linear_stiffness(const RID& p_body) const override;
 
-	void _soft_body_set_pressure_coefficient(const RID& p_body, double p_pressure_coefficient)
-		override;
+	void _soft_body_set_pressure_coefficient(const RID& p_body, double p_coefficient) override;
 
 	double _soft_body_get_pressure_coefficient(const RID& p_body) const override;
 
-	void _soft_body_set_damping_coefficient(const RID& p_body, double p_damping_coefficient)
-		override;
+	void _soft_body_set_damping_coefficient(const RID& p_body, double p_coefficient) override;
 
 	double _soft_body_get_damping_coefficient(const RID& p_body) const override;
 
-	void _soft_body_set_drag_coefficient(const RID& p_body, double p_drag_coefficient) override;
+	void _soft_body_set_drag_coefficient(const RID& p_body, double p_coefficient) override;
 
 	double _soft_body_get_drag_coefficient(const RID& p_body) const override;
 
@@ -623,6 +622,8 @@ public:
 
 	void free_body(JoltBodyImpl3D* p_body);
 
+	void free_soft_body(JoltSoftBodyImpl3D* p_body);
+
 	void free_shape(JoltShapeImpl3D* p_shape);
 
 	void free_joint(JoltJointImpl3D* p_joint);
@@ -746,6 +747,8 @@ private:
 	mutable RID_PtrOwner<JoltAreaImpl3D> area_owner;
 
 	mutable RID_PtrOwner<JoltBodyImpl3D> body_owner;
+
+	mutable RID_PtrOwner<JoltSoftBodyImpl3D> soft_body_owner;
 
 	mutable RID_PtrOwner<JoltShapeImpl3D> shape_owner;
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -15,6 +15,8 @@ constexpr char USE_SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margi
 constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_3d/collisions/areas_detect_static_bodies";
 constexpr char KINEMATIC_CONTACTS[] = "physics/jolt_3d/collisions/report_all_kinematic_contacts";
 
+constexpr char SOFT_BODY_POINT_MARGIN[] = "physics/jolt_3d/soft_bodies/point_margin";
+
 constexpr char JOINT_WORLD_NODE[] = "physics/jolt_3d/joints/world_node";
 
 constexpr char CCD_MOVEMENT_THRESHOLD[] = "physics/jolt_3d/continuous_cd/movement_threshold";
@@ -139,6 +141,8 @@ void JoltProjectSettings::register_settings() {
 	register_setting_plain(AREAS_DETECT_STATIC, false);
 	register_setting_plain(KINEMATIC_CONTACTS, false);
 
+	register_setting_ranged(SOFT_BODY_POINT_MARGIN, 0.01f, U"0,1,0.001,or_greater,suffix:m");
+
 	register_setting_enum(JOINT_WORLD_NODE, JOINT_WORLD_NODE_A, "Node A,Node B");
 
 	register_setting_ranged(CCD_MOVEMENT_THRESHOLD, 75.0f, U"0,100,0.1,suffix:%");
@@ -190,6 +194,11 @@ bool JoltProjectSettings::areas_detect_static_bodies() {
 
 bool JoltProjectSettings::report_all_kinematic_contacts() {
 	static const auto value = get_setting<bool>(KINEMATIC_CONTACTS);
+	return value;
+}
+
+float JoltProjectSettings::get_soft_body_point_margin() {
+	static const auto value = get_setting<float>(SOFT_BODY_POINT_MARGIN);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -16,6 +16,8 @@ public:
 
 	static bool report_all_kinematic_contacts();
 
+	static float get_soft_body_point_margin();
+
 	static bool use_joint_world_node_a();
 
 	static float get_ccd_movement_threshold();

--- a/src/shapes/jolt_custom_ray_shape.hpp
+++ b/src/shapes/jolt_custom_ray_shape.hpp
@@ -131,9 +131,7 @@ public:
 		[[maybe_unused]] float p_delta_time,
 		[[maybe_unused]] JPH::Vec3Arg p_displacement_due_to_gravity,
 		[[maybe_unused]] int p_colliding_shape_index
-	) const override {
-		ERR_FAIL_NOT_IMPL();
-	}
+	) const override { }
 
 	JPH::Shape::Stats GetStats() const override { return {sizeof(*this), 0}; }
 

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -1,6 +1,6 @@
 #include "jolt_shape_impl_3d.hpp"
 
-#include "objects/jolt_object_impl_3d.hpp"
+#include "objects/jolt_shaped_object_impl_3d.hpp"
 #include "shapes/jolt_custom_user_data_shape.hpp"
 
 namespace {
@@ -11,11 +11,11 @@ constexpr float DEFAULT_SOLVER_BIAS = 0.0;
 
 JoltShapeImpl3D::~JoltShapeImpl3D() = default;
 
-void JoltShapeImpl3D::add_owner(JoltObjectImpl3D* p_owner) {
+void JoltShapeImpl3D::add_owner(JoltShapedObjectImpl3D* p_owner) {
 	ref_counts_by_owner[p_owner]++;
 }
 
-void JoltShapeImpl3D::remove_owner(JoltObjectImpl3D* p_owner) {
+void JoltShapeImpl3D::remove_owner(JoltShapedObjectImpl3D* p_owner) {
 	if (--ref_counts_by_owner[p_owner] <= 0) {
 		ref_counts_by_owner.erase(p_owner);
 	}
@@ -313,7 +313,7 @@ String JoltShapeImpl3D::_owners_to_string() const {
 		return "'<unknown>' and 0 other object(s)";
 	}
 
-	const JoltObjectImpl3D& random_owner = *ref_counts_by_owner.begin()->first;
+	const JoltShapedObjectImpl3D& random_owner = *ref_counts_by_owner.begin()->first;
 
 	return vformat("'%s' and %d other object(s)", random_owner.to_string(), owner_count - 1);
 }

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltObjectImpl3D;
+class JoltShapedObjectImpl3D;
 
 class JoltShapeImpl3D {
 public:
@@ -12,9 +12,9 @@ public:
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
 
-	void add_owner(JoltObjectImpl3D* p_owner);
+	void add_owner(JoltShapedObjectImpl3D* p_owner);
 
-	void remove_owner(JoltObjectImpl3D* p_owner);
+	void remove_owner(JoltShapedObjectImpl3D* p_owner);
 
 	void remove_self();
 
@@ -78,7 +78,7 @@ protected:
 
 	String _owners_to_string() const;
 
-	HashMap<JoltObjectImpl3D*, int32_t> ref_counts_by_owner;
+	HashMap<JoltShapedObjectImpl3D*, int32_t> ref_counts_by_owner;
 
 	RID rid;
 

--- a/src/shapes/jolt_shape_instance_3d.cpp
+++ b/src/shapes/jolt_shape_instance_3d.cpp
@@ -3,7 +3,7 @@
 #include "shapes/jolt_shape_impl_3d.hpp"
 
 JoltShapeInstance3D::JoltShapeInstance3D(
-	JoltObjectImpl3D* p_parent,
+	JoltShapedObjectImpl3D* p_parent,
 	JoltShapeImpl3D* p_shape,
 	const Transform3D& p_transform,
 	const Vector3& p_scale,

--- a/src/shapes/jolt_shape_instance_3d.hpp
+++ b/src/shapes/jolt_shape_instance_3d.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-class JoltObjectImpl3D;
+class JoltShapedObjectImpl3D;
 class JoltShapeImpl3D;
 
 class JoltShapeInstance3D {
 public:
 	JoltShapeInstance3D(
-		JoltObjectImpl3D* p_parent,
+		JoltShapedObjectImpl3D* p_parent,
 		JoltShapeImpl3D* p_shape,
 		const Transform3D& p_transform = {},
 		const Vector3& p_scale = {1.0f, 1.0f, 1.0f},
@@ -60,7 +60,7 @@ private:
 
 	JPH::ShapeRefC jolt_ref;
 
-	JoltObjectImpl3D* parent = nullptr;
+	JoltShapedObjectImpl3D* parent = nullptr;
 
 	JoltShapeImpl3D* shape = nullptr;
 

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -3,6 +3,7 @@
 class JoltAreaImpl3D;
 class JoltBodyImpl3D;
 class JoltObjectImpl3D;
+class JoltShapedObjectImpl3D;
 class JoltSpace3D;
 
 class JoltBodyAccessor3D {
@@ -153,8 +154,16 @@ public:
 		}
 	}
 
+	JoltShapedObjectImpl3D* as_shaped() const {
+		if (JoltObjectImpl3D* object = as_object(); object != nullptr && object->is_shaped()) {
+			return reinterpret_cast<JoltShapedObjectImpl3D*>(body->GetUserData());
+		} else {
+			return nullptr;
+		}
+	}
+
 	JoltBodyImpl3D* as_body() const {
-		if (body != nullptr && !body->IsSensor()) {
+		if (JoltObjectImpl3D* object = as_object(); object != nullptr && object->is_body()) {
 			return reinterpret_cast<JoltBodyImpl3D*>(body->GetUserData());
 		} else {
 			return nullptr;
@@ -162,7 +171,7 @@ public:
 	}
 
 	JoltAreaImpl3D* as_area() const {
-		if (body != nullptr && body->IsSensor()) {
+		if (JoltObjectImpl3D* object = as_object(); object != nullptr && object->is_area()) {
 			return reinterpret_cast<JoltAreaImpl3D*>(body->GetUserData());
 		} else {
 			return nullptr;

--- a/src/spaces/jolt_body_accessor_3d.hpp
+++ b/src/spaces/jolt_body_accessor_3d.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "objects/jolt_object_impl_3d.hpp"
+
 class JoltAreaImpl3D;
 class JoltBodyImpl3D;
-class JoltObjectImpl3D;
 class JoltShapedObjectImpl3D;
 class JoltSpace3D;
 

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -5,7 +5,7 @@
 #include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_space_3d.hpp"
 
-void JoltContactListener3D::listen_for(JoltObjectImpl3D* p_object) {
+void JoltContactListener3D::listen_for(JoltShapedObjectImpl3D* p_object) {
 	listening_for.insert(p_object->get_jolt_id());
 }
 
@@ -455,7 +455,7 @@ void JoltContactListener3D::_flush_area_shifts() {
 	for (const JPH::SubShapeIDPair& shape_pair : area_overlaps) {
 		auto is_shifted = [&](const JPH::BodyID& p_body_id, const JPH::SubShapeID& p_sub_shape_id) {
 			const JoltReadableBody3D jolt_body = space->read_body(p_body_id);
-			const JoltObjectImpl3D* object = jolt_body.as_object();
+			const JoltShapedObjectImpl3D* object = jolt_body.as_shaped();
 			ERR_FAIL_NULL_V(object, false);
 
 			if (object->get_previous_jolt_shape() == nullptr) {

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-class JoltObjectImpl3D;
+class JoltShapedObjectImpl3D;
 class JoltSpace3D;
 
 class JoltContactListener3D final : public JPH::ContactListener {
@@ -58,7 +58,7 @@ public:
 	explicit JoltContactListener3D(JoltSpace3D* p_space)
 		: space(p_space) { }
 
-	void listen_for(JoltObjectImpl3D* p_object);
+	void listen_for(JoltShapedObjectImpl3D* p_object);
 
 	void pre_step();
 

--- a/src/spaces/jolt_debug_geometry_3d.cpp
+++ b/src/spaces/jolt_debug_geometry_3d.cpp
@@ -29,6 +29,18 @@ void JoltDebugGeometry3D::_bind_methods() {
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_triangle_outlines);
 	BIND_METHOD(JoltDebugGeometry3D, set_draw_triangle_outlines, "enabled");
 
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_soft_body_vertices);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_soft_body_vertices, "enabled");
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_soft_body_edge_constraints);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_soft_body_edge_constraints, "enabled");
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_soft_body_volume_constraints);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_soft_body_volume_constraints, "enabled");
+
+	BIND_METHOD(JoltDebugGeometry3D, get_draw_soft_body_predicted_bounds);
+	BIND_METHOD(JoltDebugGeometry3D, set_draw_soft_body_predicted_bounds, "enabled");
+
 	BIND_METHOD(JoltDebugGeometry3D, get_draw_constraint_reference_frames);
 	BIND_METHOD(JoltDebugGeometry3D, set_draw_constraint_reference_frames, "enabled");
 
@@ -61,6 +73,14 @@ void JoltDebugGeometry3D::_bind_methods() {
 	BIND_PROPERTY("draw_velocities", Variant::BOOL);
 
 	BIND_PROPERTY("draw_triangle_outlines", Variant::BOOL);
+
+	BIND_PROPERTY("draw_soft_body_vertices", Variant::BOOL);
+
+	BIND_PROPERTY("draw_soft_body_edge_constraints", Variant::BOOL);
+
+	BIND_PROPERTY("draw_soft_body_volume_constraints", Variant::BOOL);
+
+	BIND_PROPERTY("draw_soft_body_predicted_bounds", Variant::BOOL);
 
 	BIND_PROPERTY("draw_constraint_reference_frames", Variant::BOOL);
 
@@ -262,6 +282,62 @@ void JoltDebugGeometry3D::set_draw_triangle_outlines([[maybe_unused]] bool p_ena
 #ifdef JPH_DEBUG_RENDERER
 	JPH::MeshShape::sDrawTriangleOutlines = p_enabled;
 	JPH::HeightFieldShape::sDrawTriangleOutlines = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_soft_body_vertices() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_soft_body_vertices;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_soft_body_vertices([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_soft_body_vertices = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_soft_body_edge_constraints() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_soft_body_edge_constraints;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_soft_body_edge_constraints([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_soft_body_edge_constraints = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_soft_body_volume_constraints() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_soft_body_volume_constraints;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_soft_body_volume_constraints([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_soft_body_volume_constraints = p_enabled;
+#endif // JPH_DEBUG_RENDERER
+}
+
+bool JoltDebugGeometry3D::get_draw_soft_body_predicted_bounds() const {
+#ifdef JPH_DEBUG_RENDERER
+	return draw_settings.draw_soft_body_predicted_bounds;
+#else // JPH_DEBUG_RENDERER
+	return false;
+#endif // JPH_DEBUG_RENDERER
+}
+
+void JoltDebugGeometry3D::set_draw_soft_body_predicted_bounds([[maybe_unused]] bool p_enabled) {
+#ifdef JPH_DEBUG_RENDERER
+	draw_settings.draw_soft_body_predicted_bounds = p_enabled;
 #endif // JPH_DEBUG_RENDERER
 }
 

--- a/src/spaces/jolt_debug_geometry_3d.hpp
+++ b/src/spaces/jolt_debug_geometry_3d.hpp
@@ -56,6 +56,22 @@ public:
 
 	void set_draw_triangle_outlines(bool p_enabled);
 
+	bool get_draw_soft_body_vertices() const;
+
+	void set_draw_soft_body_vertices(bool p_enabled);
+
+	bool get_draw_soft_body_edge_constraints() const;
+
+	void set_draw_soft_body_edge_constraints(bool p_enabled);
+
+	bool get_draw_soft_body_volume_constraints() const;
+
+	void set_draw_soft_body_volume_constraints(bool p_enabled);
+
+	bool get_draw_soft_body_predicted_bounds() const;
+
+	void set_draw_soft_body_predicted_bounds(bool p_enabled);
+
 	bool get_draw_constraint_reference_frames() const;
 
 	void set_draw_constraint_reference_frames(bool p_enabled);

--- a/src/spaces/jolt_debug_renderer_3d.cpp
+++ b/src/spaces/jolt_debug_renderer_3d.cpp
@@ -78,6 +78,10 @@ void JoltDebugRenderer3D::draw(
 		jolt_settings.mDrawVelocity = p_settings.draw_velocities;
 		jolt_settings.mDrawMassAndInertia = false;
 		jolt_settings.mDrawSleepStats = false;
+		jolt_settings.mDrawSoftBodyVertices = p_settings.draw_soft_body_vertices;
+		jolt_settings.mDrawSoftBodyEdgeConstraints = p_settings.draw_soft_body_edge_constraints;
+		jolt_settings.mDrawSoftBodyVolumeConstraints = p_settings.draw_soft_body_volume_constraints;
+		jolt_settings.mDrawSoftBodyPredictedBounds = p_settings.draw_soft_body_predicted_bounds;
 
 		physics_system.DrawBodies(jolt_settings, this);
 	}

--- a/src/spaces/jolt_debug_renderer_3d.hpp
+++ b/src/spaces/jolt_debug_renderer_3d.hpp
@@ -23,6 +23,14 @@ public:
 
 		bool draw_velocities = false;
 
+		bool draw_soft_body_vertices = false;
+
+		bool draw_soft_body_edge_constraints = false;
+
+		bool draw_soft_body_volume_constraints = false;
+
+		bool draw_soft_body_predicted_bounds = false;
+
 		bool draw_constraint_reference_frames = false;
 
 		bool draw_constraint_limits = false;

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -53,6 +53,10 @@ bool JoltMotionFilter3D::ShouldCollide(const JPH::BodyID& p_jolt_id) const {
 }
 
 bool JoltMotionFilter3D::ShouldCollideLocked(const JPH::Body& p_jolt_body) const {
+	if (p_jolt_body.IsSoftBody()) {
+		return false;
+	}
+
 	const auto* object = reinterpret_cast<const JoltObjectImpl3D*>(p_jolt_body.GetUserData());
 
 	if (physics_server.body_test_motion_is_excluding_object(object->get_instance_id()) ||

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -158,7 +158,7 @@ void JoltSpace3D::call_queries() {
 
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
-			if (!jolt_body->IsSensor()) {
+			if (!jolt_body->IsSensor() && !jolt_body->IsSoftBody()) {
 				auto* body = reinterpret_cast<JoltBodyImpl3D*>(jolt_body->GetUserData());
 
 				body->call_queries(*jolt_body);
@@ -346,6 +346,15 @@ JoltPhysicsDirectSpaceState3D* JoltSpace3D::get_direct_state() {
 	return direct_state;
 }
 
+void JoltSpace3D::set_default_area(JoltAreaImpl3D* p_area) {
+	if (default_area == p_area) {
+		return;
+	}
+
+	default_area = p_area;
+	default_area->set_default_area();
+}
+
 void JoltSpace3D::add_joint(JPH::Constraint* p_jolt_ref) {
 	physics_system->AddConstraint(p_jolt_ref);
 }
@@ -442,7 +451,11 @@ void JoltSpace3D::_pre_step(float p_step) {
 
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
-			auto* object = reinterpret_cast<JoltObjectImpl3D*>(jolt_body->GetUserData());
+			if (jolt_body->IsSoftBody()) {
+				continue;
+			}
+
+			auto* object = reinterpret_cast<JoltShapedObjectImpl3D*>(jolt_body->GetUserData());
 
 			object->pre_step(p_step, *jolt_body);
 
@@ -464,6 +477,10 @@ void JoltSpace3D::_post_step(float p_step) {
 
 	for (int32_t i = 0; i < body_count; ++i) {
 		if (JPH::Body* jolt_body = body_accessor.try_get(i)) {
+			if (jolt_body->IsSoftBody()) {
+				continue;
+			}
+
 			auto* object = reinterpret_cast<JoltObjectImpl3D*>(jolt_body->GetUserData());
 
 			object->post_step(p_step, *jolt_body);

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -351,8 +351,15 @@ void JoltSpace3D::set_default_area(JoltAreaImpl3D* p_area) {
 		return;
 	}
 
+	if (default_area != nullptr) {
+		default_area->set_default_area(false);
+	}
+
 	default_area = p_area;
-	default_area->set_default_area();
+
+	if (default_area != nullptr) {
+		default_area->set_default_area(true);
+	}
 }
 
 void JoltSpace3D::add_joint(JPH::Constraint* p_jolt_ref) {

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -66,9 +66,9 @@ public:
 
 	JoltPhysicsDirectSpaceState3D* get_direct_state();
 
-	void set_default_area(JoltAreaImpl3D* p_area) { default_area = p_area; }
-
 	JoltAreaImpl3D* get_default_area() const { return default_area; }
+
+	void set_default_area(JoltAreaImpl3D* p_area);
 
 	float get_last_step() const { return last_step; }
 


### PR DESCRIPTION
Fixes #503.

This adds support for the `SoftBody3D` node.

This also brings with it a number of refactorings:

1. `JoltObjectImpl3D` has partially been split into a new `JoltShapedObjectImpl3D`.
2. `JoltBodyImpl3D` and `JoltAreaImpl3D` now inherit from `JoltShapedObjectImpl3D` instead.
3. Creation of Jolt bodies was simplified/flattened a bit.
4. Much of the group filter is now done in the object's `can_interact_with` method instead.
5. Global gravity is now a tad more complicated, due to needing to use Jolt's actual gravity for soft bodies.

(This will need a lot of testing before it can be merged.)