### PR TITLE
Replaced some utility functions with Godot ones

### DIFF
--- a/src/containers/inline_vector.hpp
+++ b/src/containers/inline_vector.hpp
@@ -2,7 +2,6 @@
 
 #include "containers/inline_allocator.hpp"
 #include "containers/local_vector.hpp"
-#include "misc/utility_functions.hpp"
 
 template<typename TElement, int32_t TCapacity>
 class InlineVector final : public LocalVector<TElement, InlineAllocator<TElement, TCapacity>> {
@@ -12,25 +11,25 @@ public:
 	InlineVector() { Base::reserve(TCapacity); }
 
 	explicit InlineVector(int32_t p_capacity) {
-		const int32_t capacity = max(p_capacity, TCapacity);
+		const int32_t capacity = MAX(p_capacity, TCapacity);
 		Base::reserve(capacity);
 	}
 
 	InlineVector(const InlineVector& p_other) {
-		const int32_t capacity = max(p_other.size(), TCapacity);
+		const int32_t capacity = MAX(p_other.size(), TCapacity);
 		Base::reserve(capacity);
 		Base::operator=(p_other);
 	}
 
 	InlineVector(InlineVector&& p_other) noexcept {
-		const int32_t capacity = max(p_other.size(), TCapacity);
+		const int32_t capacity = MAX(p_other.size(), TCapacity);
 		Base::reserve(capacity);
 		Base::operator=(std::move(p_other));
 	}
 
 	InlineVector(std::initializer_list<TElement> p_list) {
 		const auto list_size = (int32_t)std::distance(p_list.begin(), p_list.end());
-		const int32_t capacity = max(list_size, TCapacity);
+		const int32_t capacity = MAX(list_size, TCapacity);
 		Base::reserve(capacity);
 		Base::operator=(p_list);
 	}

--- a/src/misc/utility_functions.hpp
+++ b/src/misc/utility_functions.hpp
@@ -1,28 +1,5 @@
 #pragma once
 
-template<typename TType, typename... TRest>
-constexpr const TType& min(const TType& p_first, const TType& p_second, const TRest&... p_rest) {
-	if constexpr (sizeof...(p_rest) == 0) {
-		return p_first < p_second ? p_first : p_second;
-	} else {
-		return min(min(p_first, p_second), p_rest...);
-	}
-}
-
-template<typename TType, typename... TRest>
-constexpr const TType& max(const TType& p_first, const TType& p_second, const TRest&... p_rest) {
-	if constexpr (sizeof...(p_rest) == 0) {
-		return p_first > p_second ? p_first : p_second;
-	} else {
-		return max(max(p_first, p_second), p_rest...);
-	}
-}
-
-template<typename TType>
-constexpr const TType& clamp(const TType& p_value, const TType& p_min, const TType& p_max) {
-	return min(max(p_value, p_min), p_max);
-}
-
 template<typename TValue, typename TAlignment>
 constexpr TValue align_up(TValue p_value, TAlignment p_alignment) {
 	return (p_value + p_alignment - 1) & ~(p_alignment - 1);

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -204,7 +204,7 @@ Vector3 JoltAreaImpl3D::compute_gravity(const Vector3& p_position) const {
 
 	const Vector3 point = get_transform_scaled().xform(gravity_vector);
 	const Vector3 to_point = point - p_position;
-	const float to_point_dist_sq = max(to_point.length_squared(), CMP_EPSILON);
+	const float to_point_dist_sq = MAX(to_point.length_squared(), CMP_EPSILON);
 	const Vector3 to_point_dir = to_point / Math::sqrt(to_point_dist_sq);
 
 	if (point_gravity_distance == 0.0f) {

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -439,7 +439,7 @@ void JoltBodyImpl3D::set_max_contacts_reported(int32_t p_count) {
 	};
 
 	contacts.resize(p_count);
-	contact_count = min(contact_count, p_count);
+	contact_count = MIN(contact_count, p_count);
 
 	const bool use_manifold_reduction = !reports_contacts();
 

--- a/src/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.cpp
@@ -257,8 +257,8 @@ void JoltPhysicsDirectBodyState3D::_integrate_forces() {
 
 	linear_velocity += _get_total_gravity() * step;
 
-	linear_velocity *= max(1.0f - (float)_get_total_linear_damp() * step, 0.0f);
-	angular_velocity *= max(1.0f - (float)_get_total_angular_damp() * step, 0.0f);
+	linear_velocity *= MAX(1.0f - (float)_get_total_linear_damp() * step, 0.0f);
+	angular_velocity *= MAX(1.0f - (float)_get_total_angular_damp() * step, 0.0f);
 
 	_set_linear_velocity(linear_velocity);
 	_set_angular_velocity(angular_velocity);

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -40,7 +40,7 @@ String JoltBoxShapeImpl3D::to_string() const {
 
 JPH::ShapeRefC JoltBoxShapeImpl3D::_build() const {
 	const float min_half_extent = half_extents[half_extents.min_axis_index()];
-	const float shrunk_margin = min(margin, min_half_extent * MARGIN_FACTOR);
+	const float shrunk_margin = MIN(margin, min_half_extent * MARGIN_FACTOR);
 	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
 
 	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), actual_margin);

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -52,7 +52,9 @@ String JoltCylinderShapeImpl3D::to_string() const {
 
 JPH::ShapeRefC JoltCylinderShapeImpl3D::_build() const {
 	const float half_height = height / 2.0f;
-	const float shrunk_margin = min(margin, half_height * MARGIN_FACTOR, radius * MARGIN_FACTOR);
+	const float height_margin = half_height * MARGIN_FACTOR;
+	const float radius_margin = radius * MARGIN_FACTOR;
+	const float shrunk_margin = MIN(margin, MIN(height_margin, radius_margin));
 	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
 
 	const JPH::CylinderShapeSettings shape_settings(half_height, radius, actual_margin);

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -510,8 +510,8 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 	bool p_recovery_as_collision,
 	PhysicsServer3DExtensionMotionResult* p_result
 ) const {
-	p_margin = max(p_margin, 0.0001f);
-	p_max_collisions = min(p_max_collisions, 32);
+	p_margin = MAX(p_margin, 0.0001f);
+	p_max_collisions = MIN(p_max_collisions, 32);
 
 	Vector3 scale;
 	Transform3D transform = Math::decomposed(p_transform, scale);
@@ -644,7 +644,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 
 	// Figure out the number of steps we need in our binary search in order to achieve millimeter
 	// precision, within reason. Derived from `2^-step_count * motion_length = 0.001`.
-	const int32_t step_count = clamp(int32_t(logf(1000.0f * motion_length) / Mathf_LN2), 4, 16);
+	const int32_t step_count = CLAMP(int32_t(logf(1000.0f * motion_length) / Mathf_LN2), 4, 16);
 
 	bool collided = false;
 
@@ -766,7 +766,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 			combined_priority += other_body->get_collision_priority();
 		}
 
-		const float average_priority = max(combined_priority / (float)hit_count, CMP_EPSILON);
+		const float average_priority = MAX(combined_priority / (float)hit_count, CMP_EPSILON);
 
 		recovered = true;
 
@@ -870,8 +870,8 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 			shape_unsafe_fraction
 		);
 
-		p_safe_fraction = min(p_safe_fraction, shape_safe_fraction);
-		p_unsafe_fraction = min(p_unsafe_fraction, shape_unsafe_fraction);
+		p_safe_fraction = MIN(p_safe_fraction, shape_safe_fraction);
+		p_unsafe_fraction = MIN(p_unsafe_fraction, shape_unsafe_fraction);
 	}
 
 	return collided;
@@ -925,7 +925,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 	// wall ever so slightly, which `move_and_slide` will interpret as being trapped in a corner and
 	// stop the character altogether. We still need distances smaller than this (like none at all)
 	// to actually emit contacts though, so we clamp it by the distance moved.
-	const float min_contact_depth = min(0.0001f, p_distance);
+	const float min_contact_depth = MIN(0.0001f, p_distance);
 
 	int32_t count = 0;
 

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -62,7 +62,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id1,
 		   const JPH::Body& p_body2,
 		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2) {
-			return abs(min(p_body1.GetFriction(), p_body2.GetFriction()));
+			return ABS(MIN(p_body1.GetFriction(), p_body2.GetFriction()));
 		}
 	);
 
@@ -71,7 +71,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id1,
 		   const JPH::Body& p_body2,
 		   [[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id2) {
-			return clamp(p_body1.GetRestitution() + p_body2.GetRestitution(), 0.0f, 1.0f);
+			return CLAMP(p_body1.GetRestitution() + p_body2.GetRestitution(), 0.0f, 1.0f);
 		}
 	);
 


### PR DESCRIPTION
Related to #763.

This replaces the custom `min`, `max` and `clamp` functions found in `utility_functions.hpp` with the `MIN`, `MAX` and `CLAMP` functions provided by godot-cpp.

It also replaces all usages of the C `abs` function with godot-cpp's `ABS`.