### PR TITLE
Added project setting for enhanced internal edge removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Breaking changes are denoted with ⚠️.
 ### Added
 
 - Added support for `SoftBody3D`.
+- ⚠️ Added new project setting, "Use Enhanced Internal Edge Detection", which can help alleviate
+  collisions with internal edges of `ConcavePolygonShape3D` and `HeightMapShape3D` shapes, also
+  known as ghost collisions. This setting is enabled by default and may change the behavior of
+  character controllers relying things like `move_and_slide`.
 
 ## [0.12.0] - 2024-01-07
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -203,6 +203,21 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Collisions</td>
+      <td>Use Enhanced Internal Edge Removal</td>
+      <td>
+        Whether or not to enable the enhanced internal edge removal, which means that extra effort
+        will be made to try to remove collisions with internal edges of `ConcavePolygonShape3D` and
+        `HeightMapShape3D`. This makes physics bodies move smoother over such shapes, at the cost of
+        performance.
+      </td>
+      <td>
+        Note that this applies to `RigidBody3D` as well as physics queries like `get_rest_info`,
+        `move_and_collide` and `move_and_slide`, which means that `CharacterBody3D` also benefits
+        from this.
+      </td>
+    </tr>
+    <tr>
+      <td>Collisions</td>
       <td>Areas Detect Static Bodies</td>
       <td>
         Whether or not <code>Area3D</code> is able to detect overlaps with <code>StaticBody3D</code>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -206,14 +206,15 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>Use Enhanced Internal Edge Removal</td>
       <td>
         Whether or not to enable the enhanced internal edge removal, which means that extra effort
-        will be made to try to remove collisions with internal edges of `ConcavePolygonShape3D` and
-        `HeightMapShape3D`. This makes physics bodies move smoother over such shapes, at the cost of
-        performance.
+        will be made to try to remove collisions with internal edges of
+        <code>ConcavePolygonShape3D</code> and <code>HeightMapShape3D</code>. This makes physics
+        bodies move smoother over such shapes, at the cost of performance.
       </td>
       <td>
-        Note that this applies to `RigidBody3D` as well as physics queries like `get_rest_info`,
-        `move_and_collide` and `move_and_slide`, which means that `CharacterBody3D` also benefits
-        from this.
+        Note that this applies to <code>RigidBody3D</code> as well as queries like
+        <code>get_rest_info</code>, <code>move_and_collide</code> and <code>move_and_slide</code>.
+        <br><br>Also note that enabling this setting will leave the "Active Edge Threshold" setting
+        unused.
       </td>
     </tr>
     <tr>
@@ -340,6 +341,8 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
         result in things like <code>RigidBody3D</code> sinking into triangle edges or
         <code>move_and_slide</code> behaving in weird ways when going over or pressing up against
         triangle edges.
+        <br><br>Note that this setting has no effect when using the "Use Enhanced Internal Edge
+        Removal" setting.
       </td>
     </tr>
     <tr>

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1191,6 +1191,10 @@ void JoltBodyImpl3D::_add_to_space() {
 	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
 	jolt_settings->mMaxAngularVelocity = JoltProjectSettings::get_max_angular_velocity();
 
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		jolt_settings->mEnhancedInternalEdgeRemoval = true;
+	}
+
 	// HACK(mihe): We need to defer the setting of mass properties, to allow for modifying the
 	// inverse inertia for the axis-locking, which we can't do until the body is created, so we set
 	// it to some random values and calculate it properly once the body is created instead.

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -95,6 +95,7 @@
 #include <Jolt/Physics/Collision/ContactListener.h>
 #include <Jolt/Physics/Collision/EstimateCollisionResponse.h>
 #include <Jolt/Physics/Collision/GroupFilter.h>
+#include <Jolt/Physics/Collision/InternalEdgeRemovingCollector.h>
 #include <Jolt/Physics/Collision/NarrowPhaseQuery.h>
 #include <Jolt/Physics/Collision/ObjectLayer.h>
 #include <Jolt/Physics/Collision/RayCast.h>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -139,7 +139,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
 	register_setting_plain(SHAPE_MARGINS, true);
-	register_setting_plain(EDGE_REMOVAL, false);
+	register_setting_plain(EDGE_REMOVAL, true);
 	register_setting_plain(AREAS_DETECT_STATIC, false);
 	register_setting_plain(KINEMATIC_CONTACTS, false);
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -250,7 +250,10 @@ float JoltProjectSettings::get_position_correction() {
 }
 
 float JoltProjectSettings::get_active_edge_threshold() {
-	static const auto value = Math::cos(get_setting<float>(ACTIVE_EDGE_THRESHOLD));
+	static const auto value = use_enhanced_edge_removal()
+		? 0.996195f // Math::cos(5 degrees)
+		: Math::cos(get_setting<float>(ACTIVE_EDGE_THRESHOLD));
+
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -11,7 +11,8 @@ constexpr char SLEEP_ENABLED[] = "physics/jolt_3d/sleep/enabled";
 constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_threshold";
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
-constexpr char USE_SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
+constexpr char SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
+constexpr char EDGE_REMOVAL[] = "physics/jolt_3d/collisions/use_enhanced_internal_edge_removal";
 constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_3d/collisions/areas_detect_static_bodies";
 constexpr char KINEMATIC_CONTACTS[] = "physics/jolt_3d/collisions/report_all_kinematic_contacts";
 
@@ -137,7 +138,8 @@ void JoltProjectSettings::register_settings() {
 	register_setting_hinted(SLEEP_VELOCITY_THRESHOLD, 0.03f, U"suffix:m/s");
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
-	register_setting_plain(USE_SHAPE_MARGINS, true);
+	register_setting_plain(SHAPE_MARGINS, true);
+	register_setting_plain(EDGE_REMOVAL, false);
 	register_setting_plain(AREAS_DETECT_STATIC, false);
 	register_setting_plain(KINEMATIC_CONTACTS, false);
 
@@ -183,7 +185,7 @@ float JoltProjectSettings::get_sleep_time_threshold() {
 }
 
 bool JoltProjectSettings::use_shape_margins() {
-	static const auto value = get_setting<bool>(USE_SHAPE_MARGINS);
+	static const auto value = get_setting<bool>(SHAPE_MARGINS);
 	return value;
 }
 
@@ -194,6 +196,11 @@ bool JoltProjectSettings::areas_detect_static_bodies() {
 
 bool JoltProjectSettings::report_all_kinematic_contacts() {
 	static const auto value = get_setting<bool>(KINEMATIC_CONTACTS);
+	return value;
+}
+
+bool JoltProjectSettings::use_enhanced_edge_removal() {
+	static const auto value = get_setting<bool>(EDGE_REMOVAL);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -16,6 +16,8 @@ public:
 
 	static bool report_all_kinematic_contacts();
 
+	static bool use_enhanced_edge_removal();
+
 	static float get_soft_body_point_margin();
 
 	static bool use_joint_world_node_a();

--- a/src/shapes/jolt_custom_motion_shape.cpp
+++ b/src/shapes/jolt_custom_motion_shape.cpp
@@ -37,6 +37,19 @@ JPH::AABox JoltCustomMotionShape::GetLocalBounds() const {
 	return aabb;
 }
 
+void JoltCustomMotionShape::GetSupportingFace(
+	[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,
+	[[maybe_unused]] JPH::Vec3Arg p_direction,
+	[[maybe_unused]] JPH::Vec3Arg p_scale,
+	[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
+	[[maybe_unused]] JPH::Shape::SupportingFace& p_vertices
+) const {
+	// HACK(mihe): This is technically called when using the enhanced internal edge removal, but
+	// `JPH::InternalEdgeRemovingCollector` will only ever use the faces of the second shape in the
+	// collision pair, and this shape will always be the first in the pair, so we can safely skip
+	// this.
+}
+
 const JPH::ConvexShape::Support* JoltCustomMotionShape::GetSupportFunction(
 	JPH::ConvexShape::ESupportMode p_mode,
 	JPH::ConvexShape::SupportBuffer& p_buffer,

--- a/src/shapes/jolt_custom_motion_shape.hpp
+++ b/src/shapes/jolt_custom_motion_shape.hpp
@@ -41,14 +41,12 @@ public:
 	}
 
 	void GetSupportingFace(
-		[[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id,
-		[[maybe_unused]] JPH::Vec3Arg p_direction,
-		[[maybe_unused]] JPH::Vec3Arg p_scale,
-		[[maybe_unused]] JPH::Mat44Arg p_center_of_mass_transform,
-		[[maybe_unused]] JPH::Shape::SupportingFace& p_vertices
-	) const override {
-		ERR_FAIL_NOT_IMPL();
-	}
+		const JPH::SubShapeID& p_sub_shape_id,
+		JPH::Vec3Arg p_direction,
+		JPH::Vec3Arg p_scale,
+		JPH::Mat44Arg p_center_of_mass_transform,
+		JPH::Shape::SupportingFace& p_vertices
+	) const override;
 
 	JPH::uint64 GetSubShapeUserData([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id
 	) const override {

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -170,7 +170,6 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -255,7 +254,6 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -315,7 +313,6 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -386,7 +383,6 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -756,7 +752,6 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 	settings.mMaxSeparationDistance = p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -863,7 +858,6 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 	JPH::CollideShapeSettings settings;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -935,7 +929,6 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 	settings.mMaxSeparationDistance = p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
-		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -169,10 +169,15 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 	JPH::CollideShapeSettings settings;
 	settings.mMaxSeparationDistance = (float)p_margin;
 
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
+
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	JoltQueryCollectorAnyMulti<JPH::CollideShapeCollector, 32> collector(p_max_results);
+	JoltQueryCollectorAnyMultiNoEdges<32> collector(p_max_results);
 
 	space->get_narrow_phase_query().CollideShape(
 		jolt_shape,
@@ -185,6 +190,8 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 		query_filter,
 		query_filter
 	);
+
+	collector.finish();
 
 	const int32_t hit_count = collector.get_hit_count();
 
@@ -247,6 +254,11 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	JPH::CollideShapeSettings settings;
 	settings.mMaxSeparationDistance = (float)p_margin;
 
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
+
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
@@ -302,12 +314,17 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 	JPH::CollideShapeSettings settings;
 	settings.mMaxSeparationDistance = (float)p_margin;
 
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
+
 	const Vector3& base_offset = transform_com.origin;
 
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	JoltQueryCollectorAnyMulti<JPH::CollideShapeCollector, 32> collector(p_max_results);
+	JoltQueryCollectorAnyMultiNoEdges<32> collector(p_max_results);
 
 	space->get_narrow_phase_query().CollideShape(
 		jolt_shape,
@@ -321,7 +338,7 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 		query_filter
 	);
 
-	if (!collector.had_hit()) {
+	if (!collector.finish()) {
 		return false;
 	}
 
@@ -368,12 +385,17 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	JPH::CollideShapeSettings settings;
 	settings.mMaxSeparationDistance = (float)p_margin;
 
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
+
 	const Vector3& base_offset = transform_com.origin;
 
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
-	JoltQueryCollectorClosest<JPH::CollideShapeCollector> collector;
+	JoltQueryCollectorClosestNoEdges collector;
 
 	space->get_narrow_phase_query().CollideShape(
 		jolt_shape,
@@ -387,7 +409,7 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 		query_filter
 	);
 
-	if (!collector.had_hit()) {
+	if (!collector.finish()) {
 		return false;
 	}
 
@@ -637,7 +659,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 
 		const JPH::TransformedShape other_shape = p_other_body.GetTransformedShape();
 
-		JoltQueryCollectorAny<JPH::CollideShapeCollector> collide_collector;
+		JoltQueryCollectorAnyNoEdges collide_collector;
 
 		other_shape.CollideShape(
 			&motion_shape,
@@ -649,7 +671,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(
 			p_shape_filter
 		);
 
-		return collide_collector.had_hit();
+		return collide_collector.finish();
 	};
 
 	// Figure out the number of steps we need in our binary search in order to achieve millimeter
@@ -731,14 +753,18 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 	Transform3D transform_com = p_transform.translated_local(com_scaled);
 
 	JPH::CollideShapeSettings settings;
-	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
 	settings.mMaxSeparationDistance = p_margin;
+
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
 
 	const Vector3& base_offset = transform_com.origin;
 
 	const JoltMotionFilter3D motion_filter(p_body);
 
-	JoltQueryCollectorAnyMulti<JPH::CollideShapeCollector, 32> collector;
+	JoltQueryCollectorAnyMultiNoEdges<32> collector;
 
 	bool recovered = false;
 
@@ -758,7 +784,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 			motion_filter
 		);
 
-		if (!collector.had_hit()) {
+		if (!collector.finish()) {
 			break;
 		}
 
@@ -834,7 +860,12 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 ) const {
 	const Transform3D body_transform = p_transform.scaled_local(p_scale);
 
-	const JPH::CollideShapeSettings settings;
+	JPH::CollideShapeSettings settings;
+
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
 
 	const JoltMotionFilter3D motion_filter(p_body, p_collide_separation_ray);
 
@@ -901,14 +932,18 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 	const Transform3D transform_com = p_transform.translated_local(com_scaled);
 
 	JPH::CollideShapeSettings settings;
-	settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideOnlyWithActive;
 	settings.mMaxSeparationDistance = p_margin;
+
+	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
+		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
+	}
 
 	const Vector3& base_offset = transform_com.origin;
 
 	const JoltMotionFilter3D motion_filter(p_body);
 
-	JoltQueryCollectorClosestMulti<JPH::CollideShapeCollector, 32> collector(p_max_collisions);
+	JoltQueryCollectorClosestMultiNoEdges<32> collector(p_max_collisions);
 
 	space->get_narrow_phase_query().CollideShape(
 		jolt_shape,
@@ -923,7 +958,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(
 		motion_filter
 	);
 
-	const bool collided = collector.had_hit();
+	const bool collided = collector.finish();
 
 	if (!collided || p_result == nullptr) {
 		return collided;

--- a/src/spaces/jolt_query_collectors.hpp
+++ b/src/spaces/jolt_query_collectors.hpp
@@ -175,7 +175,7 @@ public:
 	using Hit = typename TInnerCollector::ResultType;
 
 	template<typename... TArgs>
-	JoltQueryCollectorNoEdges(TArgs&&... p_args)
+	explicit JoltQueryCollectorNoEdges(TArgs&&... p_args)
 		: Base(inner_collector)
 		, inner_collector(std::forward<TArgs>(p_args)...) { }
 


### PR DESCRIPTION
Fixes #530.
Fixes #587.
Fixes #764.
Fixes #771.

This adds a project setting for enabling Jolt's new "enhanced internal edge removal", which helps alleviate ghost collisions.

Note that this applies not only to `RigidBody3D` but also physics queries like `move_and_collide` and `move_and_slide`, which means `CharacterBody3D` benefits from this as well.