### PR TITLE
Updated Jolt to 4615f9ca7f

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -33,7 +33,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 7d8dea5196d54fbe2a3132217aac171d440de4bb
+	GIT_COMMIT 4615f9ca7fc15e3a114986a5c7339933be56e8a1
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@7d8dea5196d54fbe2a3132217aac171d440de4bb to godot-jolt/jolt@4615f9ca7fc15e3a114986a5c7339933be56e8a1 (see diff [here](https://github.com/godot-jolt/jolt/compare/7d8dea5196d54fbe2a3132217aac171d440de4bb...4615f9ca7fc15e3a114986a5c7339933be56e8a1)).

This brings in the following relevant changes:

- Fixes division by zero in `JPH::Body::GetBodyCreationSettings`