### PR TITLE
Added support for double-precision

### DIFF
--- a/.github/actions/cmake-configure/action.yml
+++ b/.github/actions/cmake-configure/action.yml
@@ -5,6 +5,8 @@ inputs:
     required: true
   arch:
     default: null
+  double:
+    default: false
   args:
     default: ''
 
@@ -25,4 +27,5 @@ runs:
           --warn-uninitialized `
           -Werror=dev `
           --preset $ConfigurePreset `
+          ${{ inputs.double == 'true' && '-DGDJ_DOUBLE_PRECISION=TRUE' || '' }} `
           ${{ inputs.args }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -29,6 +29,7 @@ jobs:
     name: "\
       ${{ matrix.platform }}-\
       ${{ matrix.arch }}-\
+      ${{ matrix.double == true && 'double-' || '' }}\
       ${{ matrix.editor == true && 'editor-' || '' }}\
       ${{ matrix.config }}"
 
@@ -37,6 +38,7 @@ jobs:
       matrix:
         platform: [linux-android]
         arch: [arm64, arm32, x64, x86]
+        double: [false, true]
         editor: [false, true]
         config: [debug, development, distribution]
 
@@ -49,6 +51,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
+          double: ${{ matrix.double }}
         env:
           CXXFLAGS: -Werror
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: macos-13
     name: "\
       ${{ matrix.platform }}-\
+      ${{ matrix.double == true && 'double-' || '' }}\
       ${{ matrix.editor == true && 'editor-' || '' }}\
       ${{ matrix.config }}"
 
@@ -35,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [macos-ios, macos-ios-simulator]
+        double: [false, true]
         editor: [false, true]
         config: [debug, development, distribution]
 
@@ -49,6 +51,7 @@ jobs:
         uses: ./.github/actions/cmake-configure
         with:
           platform: ${{ matrix.platform }}
+          double: ${{ matrix.double }}
         env:
           CXXFLAGS: -Werror
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,6 +29,7 @@ jobs:
     name: "\
       ${{ matrix.platform }}-\
       ${{ matrix.arch }}-\
+      ${{ matrix.double == true && 'double-' || '' }}\
       ${{ matrix.editor == true && 'editor-' || '' }}\
       ${{ matrix.config }}"
 
@@ -37,6 +38,7 @@ jobs:
       matrix:
         platform: [linux-clang, linux-gcc]
         arch: [x64, x86]
+        double: [false, true]
         editor: [false, true]
         config: [debug, development, distribution]
 
@@ -60,6 +62,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
+          double: ${{ matrix.double }}
         env:
           CXXFLAGS: -Werror
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: macos-13
     name: "\
       ${{ matrix.platform }}-\
+      ${{ matrix.double == true && 'double-' || '' }}\
       ${{ matrix.editor == true && 'editor-' || '' }}\
       ${{ matrix.config }}"
 
@@ -35,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [macos-clang]
+        double: [false, true]
         editor: [false, true]
         config: [debug, development, distribution]
 
@@ -49,6 +51,7 @@ jobs:
         uses: ./.github/actions/cmake-configure
         with:
           platform: ${{ matrix.platform }}
+          double: ${{ matrix.double }}
         env:
           CXXFLAGS: -Werror
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,6 +29,7 @@ jobs:
     name: "\
       ${{ matrix.platform }}-\
       ${{ matrix.arch }}-\
+      ${{ matrix.double == true && 'double-' || '' }}\
       ${{ matrix.editor == true && 'editor-' || '' }}\
       ${{ matrix.config }}"
 
@@ -37,6 +38,7 @@ jobs:
       matrix:
         platform: [windows-msvc, windows-clangcl]
         arch: [x64, x86]
+        double: [false, true]
         editor: [false, true]
         config: [debug, development, distribution]
 
@@ -62,6 +64,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
+          double: ${{ matrix.double }}
           args: ${{ matrix.args }}
         env:
           CXXFLAGS: /WX

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,8 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x64, x86]
+        precision: [single, double]
 
-    name: Build (windows-${{ matrix.arch }})
+    name: Build (windows-${{ matrix.arch }}-${{ matrix.precision }})
 
     steps:
       - name: Checkout code
@@ -35,6 +36,7 @@ jobs:
         with:
           platform: windows-clangcl
           arch: ${{ matrix.arch }}
+          double: ${{ matrix.precision == 'double' && 'true' || 'false' }}
           args: >
             -DCMAKE_INSTALL_PREFIX=dist
             -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
@@ -61,7 +63,7 @@ jobs:
       - name: Upload builds
         uses: actions/upload-artifact@v4
         with:
-          name: windows-${{ matrix.arch }}
+          name: windows-${{ matrix.arch }}-${{ matrix.precision }}
           path: ./dist/**
           retention-days: 1
 
@@ -72,8 +74,9 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x64, x86]
+        precision: [single, double]
 
-    name: Build (linux-${{ matrix.arch }})
+    name: Build (linux-${{ matrix.arch }}-${{ matrix.precision }})
 
     steps:
       - name: Checkout code
@@ -92,6 +95,7 @@ jobs:
         with:
           platform: linux-clang
           arch: ${{ matrix.arch }}
+          double: ${{ matrix.precision == 'double' && 'true' || 'false' }}
           args: >
             -DCMAKE_INSTALL_PREFIX=dist
             -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
@@ -118,14 +122,19 @@ jobs:
       - name: Upload builds
         uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ matrix.arch }}
+          name: linux-${{ matrix.arch }}-${{ matrix.precision }}
           path: ./dist/**
           retention-days: 1
 
   macos:
     runs-on: macos-13
 
-    name: Build (macos)
+    strategy:
+      fail-fast: false
+      matrix:
+        precision: [single, double]
+
+    name: Build (macos-${{ matrix.precision }})
 
     steps:
       - name: Checkout code
@@ -138,6 +147,7 @@ jobs:
         uses: ./.github/actions/cmake-configure
         with:
           platform: macos-clang
+          double: ${{ matrix.precision == 'double' && 'true' || 'false' }}
           args: >
             -DCMAKE_INSTALL_PREFIX=tmp
             -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
@@ -184,14 +194,19 @@ jobs:
       - name: Upload builds
         uses: actions/upload-artifact@v4
         with:
-          name: macos
+          name: macos-${{ matrix.precision }}
           path: ./dist/**
           retention-days: 1
 
   ios:
     runs-on: macos-13
 
-    name: Build (ios)
+    strategy:
+      fail-fast: false
+      matrix:
+        precision: [single, double]
+
+    name: Build (ios-${{ matrix.precision }})
 
     steps:
       - name: Checkout code
@@ -204,6 +219,7 @@ jobs:
         uses: ./.github/actions/cmake-configure
         with:
           platform: macos-ios
+          double: ${{ matrix.precision == 'double' && 'true' || 'false' }}
           args: >
             -DCMAKE_INSTALL_PREFIX=dist
             -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
@@ -228,7 +244,7 @@ jobs:
       - name: Upload builds
         uses: actions/upload-artifact@v4
         with:
-          name: ios
+          name: ios-${{ matrix.precision }}
           path: ./dist/**
           retention-days: 1
 
@@ -239,8 +255,9 @@ jobs:
       fail-fast: false
       matrix:
         arch: [arm64, arm32, x64, x86]
+        precision: [single, double]
 
-    name: Build (android-${{ matrix.arch }})
+    name: Build (android-${{ matrix.arch }}-${{ matrix.precision }})
 
     steps:
       - name: Checkout code
@@ -254,6 +271,7 @@ jobs:
         with:
           platform: linux-android
           arch: ${{ matrix.arch }}
+          double: ${{ matrix.precision == 'double' && 'true' || 'false' }}
           args: >
             -DCMAKE_INSTALL_PREFIX=dist
             -DGDJ_INSTALL_DEBUG_SYMBOLS=TRUE
@@ -280,12 +298,18 @@ jobs:
       - name: Upload builds
         uses: actions/upload-artifact@v4
         with:
-          name: android-${{ matrix.arch }}
+          name: android-${{ matrix.arch }}-${{ matrix.precision }}
           path: ./dist/**
           retention-days: 1
 
   upload:
     runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        precision: [single, double]
+
     needs: [windows, linux, macos, ios, android]
 
     name: Upload
@@ -294,61 +318,61 @@ jobs:
       - name: Download builds (windows-x64)
         uses: actions/download-artifact@v4
         with:
-          name: windows-x64
+          name: windows-x64-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (windows-x86)
         uses: actions/download-artifact@v4
         with:
-          name: windows-x86
+          name: windows-x86-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (linux-x64)
         uses: actions/download-artifact@v4
         with:
-          name: linux-x64
+          name: linux-x64-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (linux-x86)
         uses: actions/download-artifact@v4
         with:
-          name: linux-x86
+          name: linux-x86-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (macos)
         uses: actions/download-artifact@v4
         with:
-          name: macos
+          name: macos-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (ios)
         uses: actions/download-artifact@v4
         with:
-          name: ios
+          name: ios-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (android-arm64)
         uses: actions/download-artifact@v4
         with:
-          name: android-arm64
+          name: android-arm64-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (android-arm32)
         uses: actions/download-artifact@v4
         with:
-          name: android-arm32
+          name: android-arm32-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (android-x64)
         uses: actions/download-artifact@v4
         with:
-          name: android-x64
+          name: android-x64-${{ matrix.precision }}
           path: ./dist
 
       - name: Download builds (android-x86)
         uses: actions/download-artifact@v4
         with:
-          name: android-x86
+          name: android-x86-${{ matrix.precision }}
           path: ./dist
 
       - name: Delete temporary artifacts
@@ -356,16 +380,16 @@ jobs:
         with:
           token: ${{ github.token }}
           name: |
-            windows-x64
-            windows-x86
-            linux-x64
-            linux-x86
-            macos
-            ios
-            android-arm64
-            android-arm32
-            android-x64
-            android-x86
+            windows-x64-${{ matrix.precision }}
+            windows-x86-${{ matrix.precision }}
+            linux-x64-${{ matrix.precision }}
+            linux-x86-${{ matrix.precision }}
+            macos-${{ matrix.precision }}
+            ios-${{ matrix.precision }}
+            android-arm64-${{ matrix.precision }}
+            android-arm32-${{ matrix.precision }}
+            android-x64-${{ matrix.precision }}
+            android-x86-${{ matrix.precision }}
 
       - name: Separate debug symbols
         run: >
@@ -385,13 +409,13 @@ jobs:
       - name: Upload builds
         uses: actions/upload-artifact@v4
         with:
-          name: godot-jolt_${{ github.ref_name }}
+          name: godot-jolt_${{ github.ref_name }}_${{ matrix.precision }}
           path: ./dist/**
           retention-days: 1
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
-          name: godot-jolt_${{ github.ref_name }}_symbols
+          name: godot-jolt_${{ github.ref_name }}_${{ matrix.precision }}_symbols
           path: ./symbols/**
           retention-days: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(target_sse2 $<STREQUAL:${GDJ_X86_INSTRUCTION_SET},SSE2>)
 set(is_msvc_like $<BOOL:${MSVC}>)
 set(is_msvc_cl $<CXX_COMPILER_ID:MSVC>)
 set(is_llvm_clang $<CXX_COMPILER_ID:Clang>)
+set(is_apple_clang $<CXX_COMPILER_ID:AppleClang>)
 set(is_gcc $<CXX_COMPILER_ID:GNU>)
 set(is_clang_cl $<AND:${is_msvc_like},${is_llvm_clang}>)
 
@@ -256,6 +257,7 @@ else()
 		PRIVATE $<${use_avx512}:-mavx512vl> # Enable AVX-512 Vector Length instructions
 		PRIVATE $<${use_avx512}:-mavx512dq> # Enable AVX-512 Doubleword and Quadword instructions
 		PRIVATE $<${is_gcc}:-no-integrated-cpp> # Workaround for GCC ignoring _Pragma (GCC#53431)
+		PRIVATE $<${is_apple_clang}:-faligned-allocation> # Silence non-aligned allocation errors
 	)
 
 	if(APPLE)

--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -10,6 +10,7 @@ set(configurations
 )
 
 set(is_msvc_like $<BOOL:${MSVC}>)
+set(is_double_precision $<BOOL:${GDJ_DOUBLE_PRECISION}>)
 
 set(editor_definitions
 	DEBUG_ENABLED
@@ -19,7 +20,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT 43d02f2d7c0a051d7134904168ce92615d11713e
+	GIT_COMMIT caec7a1feecd56a1db3c4dfd1aa6b4e68c81d010
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES
@@ -28,6 +29,7 @@ gdj_add_external_library(godot-cpp "${configurations}"
 		<BINARY_DIR>/gen/include
 	COMPILE_DEFINITIONS
 		$<${is_msvc_like}:TYPED_METHOD_BIND>
+		$<${is_double_precision}:REAL_T_IS_DOUBLE>
 	COMPILE_DEFINITIONS_EDITORDEBUG
 		${editor_definitions}
 	COMPILE_DEFINITIONS_EDITORDEVELOPMENT
@@ -40,6 +42,7 @@ gdj_add_external_library(godot-cpp "${configurations}"
 		-DCMAKE_INTERPROCEDURAL_OPTIMIZATION_DISTRIBUTION=${GDJ_INTERPROCEDURAL_OPTIMIZATION}
 		-DCMAKE_INTERPROCEDURAL_OPTIMIZATION_EDITORDISTRIBUTION=${GDJ_INTERPROCEDURAL_OPTIMIZATION}
 		-DGDE_X86_INSTRUCTION_SET=${GDJ_X86_INSTRUCTION_SET}
+		-DGDE_DOUBLE_PRECISION=${GDJ_DOUBLE_PRECISION}
 	LIBRARY_CONFIG_DEBUG Debug
 	LIBRARY_CONFIG_DEVELOPMENT Distribution
 	LIBRARY_CONFIG_DISTRIBUTION Distribution

--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -17,6 +17,8 @@ set(use_avx $<BOOL:${GDJ_USE_AVX}>)
 set(use_sse4_2 $<BOOL:${GDJ_USE_SSE4_2}>)
 set(use_sse4_2 $<BOOL:${GDJ_USE_SSE4_2}>)
 
+set(is_double_precision $<BOOL:${GDJ_DOUBLE_PRECISION}>)
+
 set(is_msvc_cl $<CXX_COMPILER_ID:MSVC>)
 
 set(dev_definitions
@@ -49,6 +51,7 @@ gdj_add_external_library(jolt "${configurations}"
 		$<${use_avx}:JPH_USE_AVX>
 		$<${use_sse4_2}:JPH_USE_SSE4_2>
 		$<${use_sse4_2}:JPH_USE_SSE4_1>
+		$<${is_double_precision}:JPH_DOUBLE_PRECISION>
 	COMPILE_DEFINITIONS_DEBUG
 		${dev_definitions}
 	COMPILE_DEFINITIONS_RELEASE
@@ -71,6 +74,7 @@ gdj_add_external_library(jolt "${configurations}"
 		-DUSE_SSE4_2=${GDJ_USE_SSE4_2}
 		-DUSE_SSE4_1=${GDJ_USE_SSE4_2}
 		-DUSE_STATIC_MSVC_RUNTIME_LIBRARY=${GDJ_STATIC_RUNTIME_LIBRARY}
+		-DDOUBLE_PRECISION=${GDJ_DOUBLE_PRECISION}
 		${override_cxx_flags_arg}
 	LIBRARY_CONFIG_DEBUG Debug
 	LIBRARY_CONFIG_DEVELOPMENT Release

--- a/cmake/GodotJoltOptions.cmake
+++ b/cmake/GodotJoltOptions.cmake
@@ -28,6 +28,11 @@ set(GDJ_PRECOMPILE_HEADERS TRUE
 	"Precompile header files that don't change often, like external ones."
 )
 
+set(GDJ_DOUBLE_PRECISION FALSE
+	CACHE BOOL
+	"Compile with 64-bit floating-point precision."
+)
+
 if(NOT APPLE AND NOT ANDROID)
 	set(GDJ_X86_INSTRUCTION_SET SSE2
 		CACHE STRING

--- a/docs/building.md
+++ b/docs/building.md
@@ -11,6 +11,7 @@ This document contains instructions for how to build Godot Jolt from source.
 - [Building for macOS](#building-for-macos)
 - [Building for iOS](#building-for-ios)
 - [Building for Android](#building-for-android)
+- [Building for double-precision](#building-for-double-precision)
 
 ## Building for Windows
 
@@ -227,3 +228,23 @@ cmake --install build/windows-android-x86 --config EditorDistribution --prefix /
 [hck]: hacking.md
 [ccl]: https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild
 [cmd]: https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line
+
+## Building for double-precision
+
+Building for double-precision builds of Godot involves the same steps as what's shown above, but
+with the only difference that you add the `-DGDJ_DOUBLE_PRECISION=TRUE` argument when generating the
+build directory.
+
+So instead of doing this:
+
+```sh
+# Generate the build directory
+cmake --preset windows-msvc-x64
+```
+
+You would instead do this:
+
+```sh
+# Generate the build directory with double-precision enabled
+cmake --preset windows-msvc-x64 -DGDJ_DOUBLE_PRECISION=TRUE
+```

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -67,6 +67,10 @@ defaults by passing `-DGDJ_SOME_VARIABLE=VALUE` to CMake.
 - `GDJ_INSTALL_DEBUG_SYMBOLS`
   - Whether to install debug symbols along with the binaries
   - Default is `FALSE`.
+- `GDJ_DOUBLE_PRECISION`
+  - Whether to build with 64-bit floating-point precision.
+  - ⚠️ This only applies to positions, everything else will use 32-bit precision.
+  - Default is `FALSE`.
 
 ## Presets
 

--- a/examples/scenes/joints/joints.tscn
+++ b/examples/scenes/joints/joints.tscn
@@ -14,6 +14,7 @@
 size = Vector3(5, 1, 5)
 
 [node name="Joints" type="Node3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1e+06, 1e+06, 1e+06)
 
 [node name="Environment" type="WorldEnvironment" parent="."]
 environment = ExtResource("1_aom0t")

--- a/examples/scenes/shapes/entities/height_map/height_map.gd
+++ b/examples/scenes/shapes/entities/height_map/height_map.gd
@@ -65,7 +65,7 @@ func _generate() -> void:
 	noise_gen.noise_type = FastNoiseLite.TYPE_PERLIN
 	noise_gen.fractal_type = FastNoiseLite.FRACTAL_NONE
 
-	var heights := PackedFloat32Array()
+	var heights := PackedFloat64Array()
 	heights.resize(resolution * resolution)
 
 	for z in range(resolution):

--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -218,7 +218,7 @@ float JoltConeTwistJointImpl3D::get_applied_torque() const {
 		constraint->GetTotalLambdaSwingZ()
 	);
 
-	return rotation_lambda.length() / last_step;
+	return float(rotation_lambda.length() / last_step);
 }
 
 void JoltConeTwistJointImpl3D::rebuild() {
@@ -303,10 +303,10 @@ JPH::Constraint* JoltConeTwistJointImpl3D::_build_swing_twist(
 	}
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPosition1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mPosition1 = to_jolt_r(p_shifted_ref_a.origin);
 	constraint_settings.mTwistAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPosition2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPosition2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mTwistAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mSwingType = JPH::ESwingType::Pyramid;

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -506,10 +506,10 @@ JPH::Constraint* JoltGeneric6DOFJointImpl3D::_build_6dof(
 	}
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPosition1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mPosition1 = to_jolt_r(p_shifted_ref_a.origin);
 	constraint_settings.mAxisX1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Y));
-	constraint_settings.mPosition2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPosition2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mAxisX2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
 	constraint_settings.mSwingType = JPH::ESwingType::Pyramid;

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -316,10 +316,10 @@ JPH::Constraint* JoltHingeJointImpl3D::_build_hinge(
 	JPH::HingeConstraintSettings constraint_settings;
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mPoint1 = to_jolt_r(p_shifted_ref_a.origin);
 	constraint_settings.mHingeAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mNormalAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
-	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPoint2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mHingeAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mNormalAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mLimitsMin = -p_limit;
@@ -349,10 +349,10 @@ JPH::Constraint* JoltHingeJointImpl3D::_build_fixed(
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mPoint1 = to_jolt_r(p_shifted_ref_a.origin);
 	constraint_settings.mAxisX1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Y));
-	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPoint2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mAxisX2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
 

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -147,8 +147,8 @@ JPH::Constraint* JoltPinJointImpl3D::_build_pin(
 ) {
 	JPH::PointConstraintSettings constraint_settings;
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
-	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
-	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPoint1 = to_jolt_r(p_shifted_ref_a.origin);
+	constraint_settings.mPoint2 = to_jolt_r(p_shifted_ref_b.origin);
 
 	if (p_jolt_body_a == nullptr) {
 		return constraint_settings.Create(JPH::Body::sFixedToWorld, *p_jolt_body_b);

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -519,10 +519,10 @@ JPH::Constraint* JoltSliderJointImpl3D::_build_slider(
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mPoint1 = to_jolt_r(p_shifted_ref_a.origin);
 	constraint_settings.mSliderAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mNormalAxis1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPoint2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mSliderAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mNormalAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
 	constraint_settings.mLimitsMin = -p_limit;
@@ -552,10 +552,10 @@ JPH::Constraint* JoltSliderJointImpl3D::_build_fixed(
 
 	constraint_settings.mSpace = JPH::EConstraintSpace::LocalToBodyCOM;
 	constraint_settings.mAutoDetectPoint = false;
-	constraint_settings.mPoint1 = to_jolt(p_shifted_ref_a.origin);
+	constraint_settings.mPoint1 = to_jolt_r(p_shifted_ref_a.origin);
 	constraint_settings.mAxisX1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY1 = to_jolt(p_shifted_ref_a.basis.get_column(Vector3::AXIS_Y));
-	constraint_settings.mPoint2 = to_jolt(p_shifted_ref_b.origin);
+	constraint_settings.mPoint2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mAxisX2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mAxisY2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Y));
 

--- a/src/misc/type_conversions.hpp
+++ b/src/misc/type_conversions.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 _FORCE_INLINE_ Vector3 to_godot(const JPH::Vec3& p_vec) {
-	return {p_vec.GetX(), p_vec.GetY(), p_vec.GetZ()};
+	return {(real_t)p_vec.GetX(), (real_t)p_vec.GetY(), (real_t)p_vec.GetZ()};
+}
+
+_FORCE_INLINE_ Vector3 to_godot(const JPH::DVec3& p_vec) {
+	return {(real_t)p_vec.GetX(), (real_t)p_vec.GetY(), (real_t)p_vec.GetZ()};
 }
 
 _FORCE_INLINE_ Basis to_godot(const JPH::Quat& p_quat) {
@@ -38,12 +42,12 @@ _FORCE_INLINE_ AABB to_godot(const JPH::AABox& p_aabb) {
 }
 
 _FORCE_INLINE_ JPH::Vec3 to_jolt(const Vector3& p_vec) {
-	return {p_vec.x, p_vec.y, p_vec.z};
+	return {(float)p_vec.x, (float)p_vec.y, (float)p_vec.z};
 }
 
 _FORCE_INLINE_ JPH::Quat to_jolt(const Basis& p_basis) {
 	const Quaternion quat = p_basis.get_quaternion();
-	return {quat.x, quat.y, quat.z, quat.w};
+	return {(float)quat.x, (float)quat.y, (float)quat.z, (float)quat.w};
 }
 
 _FORCE_INLINE_ JPH::Mat44 to_jolt(const Transform3D& p_transform) {
@@ -54,7 +58,7 @@ _FORCE_INLINE_ JPH::Mat44 to_jolt(const Transform3D& p_transform) {
 		JPH::Vec4(b[0][0], b[1][0], b[2][0], 0.0f),
 		JPH::Vec4(b[0][1], b[1][1], b[2][1], 0.0f),
 		JPH::Vec4(b[0][2], b[1][2], b[2][2], 0.0f),
-		JPH::Vec4(o.x, o.y, o.z, 1.0f)};
+		JPH::Vec3(o.x, o.y, o.z)};
 }
 
 _FORCE_INLINE_ JPH::Color to_jolt(const Color& p_color) {
@@ -68,4 +72,19 @@ _FORCE_INLINE_ JPH::String to_jolt(const String& p_str) {
 
 _FORCE_INLINE_ JPH::AABox to_jolt(const AABB& p_aabb) {
 	return {to_jolt(p_aabb.position), to_jolt(p_aabb.position + p_aabb.size)};
+}
+
+_FORCE_INLINE_ JPH::RVec3 to_jolt_r(const Vector3& p_vec) {
+	return {p_vec.x, p_vec.y, p_vec.z};
+}
+
+_FORCE_INLINE_ JPH::RMat44 to_jolt_r(const Transform3D& p_transform) {
+	const Basis& b = p_transform.basis;
+	const Vector3& o = p_transform.origin;
+
+	return {
+		JPH::Vec4(b[0][0], b[1][0], b[2][0], 0.0f),
+		JPH::Vec4(b[0][1], b[1][1], b[2][1], 0.0f),
+		JPH::Vec4(b[0][2], b[1][2], b[2][2], 0.0f),
+		JPH::RVec3(o.x, o.y, o.z)};
 }

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -40,12 +40,12 @@ void JoltAreaImpl3D::set_transform(const Transform3D& p_transform) {
 	}
 
 	if (space == nullptr) {
-		jolt_settings->mPosition = to_jolt(new_transform.origin);
+		jolt_settings->mPosition = to_jolt_r(new_transform.origin);
 		jolt_settings->mRotation = to_jolt(new_transform.basis);
 	} else {
 		space->get_body_iface().SetPositionAndRotation(
 			jolt_id,
-			to_jolt(new_transform.origin),
+			to_jolt_r(new_transform.origin),
 			to_jolt(new_transform.basis),
 			JPH::EActivation::DontActivate
 		);
@@ -295,7 +295,7 @@ Vector3 JoltAreaImpl3D::compute_gravity(const Vector3& p_position) const {
 
 	const Vector3 point = get_transform_scaled().xform(gravity_vector);
 	const Vector3 to_point = point - p_position;
-	const float to_point_dist_sq = MAX(to_point.length_squared(), CMP_EPSILON);
+	const real_t to_point_dist_sq = MAX(to_point.length_squared(), (real_t)CMP_EPSILON);
 	const Vector3 to_point_dir = to_point / Math::sqrt(to_point_dist_sq);
 
 	if (point_gravity_distance == 0.0f) {

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -58,14 +58,14 @@ void JoltBodyImpl3D::set_transform(const Transform3D& p_transform) {
 	}
 
 	if (space == nullptr) {
-		jolt_settings->mPosition = to_jolt(new_transform.origin);
+		jolt_settings->mPosition = to_jolt_r(new_transform.origin);
 		jolt_settings->mRotation = to_jolt(new_transform.basis);
 	} else if (is_kinematic()) {
 		kinematic_transform = p_transform;
 	} else {
 		space->get_body_iface().SetPositionAndRotation(
 			jolt_id,
-			to_jolt(new_transform.origin),
+			to_jolt_r(new_transform.origin),
 			to_jolt(new_transform.basis),
 			JPH::EActivation::DontActivate
 		);
@@ -898,10 +898,10 @@ void JoltBodyImpl3D::move_kinematic(float p_step, JPH::Body& p_jolt_body) {
 	p_jolt_body.SetLinearVelocity(JPH::Vec3::sZero());
 	p_jolt_body.SetAngularVelocity(JPH::Vec3::sZero());
 
-	const JPH::Vec3 current_position = p_jolt_body.GetPosition();
+	const JPH::RVec3 current_position = p_jolt_body.GetPosition();
 	const JPH::Quat current_rotation = p_jolt_body.GetRotation();
 
-	const JPH::Vec3 new_position = to_jolt(kinematic_transform.origin);
+	const JPH::RVec3 new_position = to_jolt_r(kinematic_transform.origin);
 	const JPH::Quat new_rotation = to_jolt(kinematic_transform.basis);
 
 	if (new_position == current_position && new_rotation == current_rotation) {
@@ -1332,9 +1332,9 @@ JPH::MassProperties JoltBodyImpl3D::_calculate_mass_properties(const JPH::Shape&
 		mass_properties.ScaleToMass(mass);
 	} else {
 		mass_properties.mMass = mass;
-		mass_properties.mInertia(0, 0) = inertia.x;
-		mass_properties.mInertia(1, 1) = inertia.y;
-		mass_properties.mInertia(2, 2) = inertia.z;
+		mass_properties.mInertia(0, 0) = (float)inertia.x;
+		mass_properties.mInertia(1, 1) = (float)inertia.y;
+		mass_properties.mInertia(2, 2) = (float)inertia.z;
 	}
 
 	mass_properties.mInertia(3, 3) = 1.0f;

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -341,7 +341,8 @@ void JoltSoftBodyImpl3D::set_vertex_position(int32_t p_index, const Vector3& p_p
 	JPH::Array<JPH::SoftBodyVertex>& physics_vertices = motion_properties.GetVertices();
 	JPH::SoftBodyVertex& physics_vertex = physics_vertices[(size_t)physics_index];
 
-	const JPH::Vec3 local_position = to_jolt(p_position) - body->GetCenterOfMassPosition();
+	const JPH::RVec3 center_of_mass = body->GetCenterOfMassPosition();
+	const JPH::Vec3 local_position = JPH::Vec3(to_jolt_r(p_position) - center_of_mass);
 	const JPH::Vec3 displacement = local_position - physics_vertex.mPosition;
 	const JPH::Vec3 velocity = displacement / last_step;
 
@@ -519,7 +520,12 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 				auto iter_physics_index = vertex_to_physics.find(vertex);
 
 				if (iter_physics_index == vertex_to_physics.end()) {
-					physics_vertices.emplace_back(JPH::Float3(vertex.x, vertex.y, vertex.z));
+					physics_vertices.emplace_back(
+						JPH::Float3((float)vertex.x, (float)vertex.y, (float)vertex.z),
+						JPH::Float3(0.0f, 0.0f, 0.0f),
+						1.0f
+					);
+
 					iter_physics_index = vertex_to_physics.insert(vertex, physics_index_count++);
 				}
 

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -39,7 +39,7 @@ String JoltBoxShapeImpl3D::to_string() const {
 }
 
 JPH::ShapeRefC JoltBoxShapeImpl3D::_build() const {
-	const float min_half_extent = half_extents[half_extents.min_axis_index()];
+	const auto min_half_extent = (float)half_extents[half_extents.min_axis_index()];
 	const float shrunk_margin = MIN(margin, min_half_extent * MARGIN_FACTOR);
 	const float actual_margin = JoltProjectSettings::use_shape_margins() ? shrunk_margin : 0.0f;
 

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -76,9 +76,9 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 		const Vector3* v2 = vertex + 2;
 
 		jolt_faces.emplace_back(
-			JPH::Float3(v2->x, v2->y, v2->z),
-			JPH::Float3(v1->x, v1->y, v1->z),
-			JPH::Float3(v0->x, v0->y, v0->z)
+			JPH::Float3((float)v2->x, (float)v2->y, (float)v2->z),
+			JPH::Float3((float)v1->x, (float)v1->y, (float)v1->z),
+			JPH::Float3((float)v0->x, (float)v0->y, (float)v0->z)
 		);
 	}
 

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -55,7 +55,7 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::_build() const {
 	const Vector3* vertices_end = vertices_begin + vertex_count;
 
 	for (const Vector3* vertex = vertices_begin; vertex != vertices_end; ++vertex) {
-		jolt_vertices.emplace_back(vertex->x, vertex->y, vertex->z);
+		jolt_vertices.emplace_back((float)vertex->x, (float)vertex->y, (float)vertex->z);
 	}
 
 	const float actual_margin = JoltProjectSettings::use_shape_margins() ? margin : 0.0f;

--- a/src/shapes/jolt_height_map_shape_impl_3d.hpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.hpp
@@ -27,7 +27,11 @@ private:
 
 	JPH::ShapeRefC _build_double_sided(const JPH::Shape* p_shape) const;
 
+#ifdef REAL_T_IS_DOUBLE
+	PackedFloat64Array heights;
+#else // REAL_T_IS_DOUBLE
 	PackedFloat32Array heights;
+#endif // REAL_T_IS_DOUBLE
 
 	int32_t width = 0;
 

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -133,9 +133,9 @@ bool JoltContactListener3D::_try_apply_surface_velocities(
 	const JPH::Vec3 linear_velocity2 = to_jolt(body2->get_linear_surface_velocity());
 	const JPH::Vec3 angular_velocity2 = to_jolt(body2->get_angular_surface_velocity());
 
-	const JPH::Vec3 com1 = p_jolt_body1.GetCenterOfMassPosition();
-	const JPH::Vec3 com2 = p_jolt_body2.GetCenterOfMassPosition();
-	const JPH::Vec3 rel_com2 = com2 - com1;
+	const JPH::RVec3 com1 = p_jolt_body1.GetCenterOfMassPosition();
+	const JPH::RVec3 com2 = p_jolt_body2.GetCenterOfMassPosition();
+	const auto rel_com2 = JPH::Vec3(com2 - com1);
 
 	const JPH::Vec3 angular_linear_velocity2 = rel_com2.Cross(angular_velocity2);
 	const JPH::Vec3 total_linear_velocity2 = linear_velocity2 + angular_linear_velocity2;
@@ -195,11 +195,11 @@ bool JoltContactListener3D::_try_add_contacts(
 		Contact& contact1 = manifold.contacts1.emplace_back();
 		Contact& contact2 = manifold.contacts2.emplace_back();
 
-		const JPH::Vec3& relative_point1 = p_manifold.mRelativeContactPointsOn1[i];
-		const JPH::Vec3& relative_point2 = p_manifold.mRelativeContactPointsOn2[i];
+		const auto relative_point1 = JPH::RVec3(p_manifold.mRelativeContactPointsOn1[i]);
+		const auto relative_point2 = JPH::RVec3(p_manifold.mRelativeContactPointsOn2[i]);
 
-		const JPH::Vec3 world_point1 = p_manifold.mBaseOffset + relative_point1;
-		const JPH::Vec3 world_point2 = p_manifold.mBaseOffset + relative_point2;
+		const JPH::RVec3 world_point1 = p_manifold.mBaseOffset + relative_point1;
+		const JPH::RVec3 world_point2 = p_manifold.mBaseOffset + relative_point2;
 
 		const JPH::Vec3 velocity1 = p_body1.GetPointVelocity(world_point1);
 		const JPH::Vec3 velocity2 = p_body2.GetPointVelocity(world_point2);
@@ -355,8 +355,8 @@ bool JoltContactListener3D::_try_add_debug_contacts(
 	for (int32_t i = 0; i < additional_pairs; ++i) {
 		const int32_t pair_index = current_count + i * 2;
 
-		const JPH::Vec3 point_on_1 = p_manifold.GetWorldSpaceContactPointOn1((JPH::uint)i);
-		const JPH::Vec3 point_on_2 = p_manifold.GetWorldSpaceContactPointOn2((JPH::uint)i);
+		const JPH::RVec3 point_on_1 = p_manifold.GetWorldSpaceContactPointOn1((JPH::uint)i);
+		const JPH::RVec3 point_on_2 = p_manifold.GetWorldSpaceContactPointOn2((JPH::uint)i);
 
 		debug_contacts[pair_index + 0] = to_godot(point_on_1);
 		debug_contacts[pair_index + 1] = to_godot(point_on_2);

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -27,9 +27,9 @@ class JoltContactListener3D final : public JPH::ContactListener {
 	struct Contact {
 		JPH::Vec3 normal = {};
 
-		JPH::Vec3 point_self = {};
+		JPH::RVec3 point_self = {};
 
-		JPH::Vec3 point_other = {};
+		JPH::RVec3 point_other = {};
 
 		JPH::Vec3 velocity_self = {};
 

--- a/src/spaces/jolt_debug_renderer_3d.cpp
+++ b/src/spaces/jolt_debug_renderer_3d.cpp
@@ -6,7 +6,7 @@
 
 namespace {
 
-constexpr int64_t DEBUG_VERTEX_STRIDE = sizeof(Vector3);
+constexpr int64_t DEBUG_VERTEX_STRIDE = sizeof(float) * 3;
 constexpr int64_t DEBUG_ATTRIBUTE_STRIDE = sizeof(uint32_t);
 
 } // namespace
@@ -160,15 +160,15 @@ int32_t JoltDebugRenderer3D::submit(const RID& p_mesh) {
 	return surface_count;
 }
 
-void JoltDebugRenderer3D::DrawLine(JPH::Vec3 p_from, JPH::Vec3 p_to, JPH::Color p_color) {
+void JoltDebugRenderer3D::DrawLine(JPH::RVec3Arg p_from, JPH::RVec3Arg p_to, JPH::Color p_color) {
 	_reserve_lines(1);
 	_add_line(to_godot(p_from), to_godot(p_to), to_godot(p_color).to_abgr32());
 }
 
 void JoltDebugRenderer3D::DrawTriangle(
-	JPH::Vec3 p_vertex1,
-	JPH::Vec3 p_vertex2,
-	JPH::Vec3 p_vertex3,
+	JPH::RVec3Arg p_vertex1,
+	JPH::RVec3Arg p_vertex2,
+	JPH::RVec3Arg p_vertex3,
 	JPH::Color p_color,
 	[[maybe_unused]] ECastShadow p_cast_shadow
 ) {
@@ -226,7 +226,7 @@ JPH::DebugRenderer::Batch JoltDebugRenderer3D::CreateTriangleBatch(
 }
 
 void JoltDebugRenderer3D::DrawGeometry(
-	const JPH::Mat44& p_model_matrix,
+	JPH::RMat44Arg p_model_matrix,
 	const JPH::AABox& p_world_space_bounds,
 	float p_lod_scale_sq,
 	JPH::Color p_model_color,
@@ -304,7 +304,7 @@ void JoltDebugRenderer3D::DrawGeometry(
 }
 
 void JoltDebugRenderer3D::DrawText3D(
-	[[maybe_unused]] const JPH::Vec3 p_position,
+	[[maybe_unused]] JPH::RVec3Arg p_position,
 	[[maybe_unused]] const JPH::string_view& p_string,
 	[[maybe_unused]] JPH::Color p_color,
 	[[maybe_unused]] float p_height
@@ -344,12 +344,23 @@ void JoltDebugRenderer3D::_add_triangle(
 ) {
 	const int32_t vertex_count = triangle_count * 3;
 
-	auto* vertices_ptr = reinterpret_cast<Vector3*>(triangle_vertices.ptrw()) + vertex_count;
-	auto* attributes_ptr = reinterpret_cast<uint32_t*>(triangle_attributes.ptrw()) + vertex_count;
+	auto* vertices_ptr = reinterpret_cast<float*>(triangle_vertices.ptrw()) +
+		ptrdiff_t(vertex_count * 3);
 
-	*vertices_ptr++ = p_vertex1;
-	*vertices_ptr++ = p_vertex2;
-	*vertices_ptr++ = p_vertex3;
+	auto* attributes_ptr = reinterpret_cast<uint32_t*>(triangle_attributes.ptrw()) +
+		ptrdiff_t(vertex_count);
+
+	*vertices_ptr++ = (float)p_vertex1.x;
+	*vertices_ptr++ = (float)p_vertex1.y;
+	*vertices_ptr++ = (float)p_vertex1.z;
+
+	*vertices_ptr++ = (float)p_vertex2.x;
+	*vertices_ptr++ = (float)p_vertex2.y;
+	*vertices_ptr++ = (float)p_vertex2.z;
+
+	*vertices_ptr++ = (float)p_vertex3.x;
+	*vertices_ptr++ = (float)p_vertex3.y;
+	*vertices_ptr++ = (float)p_vertex3.z;
 
 	*attributes_ptr++ = p_color_abgr;
 	*attributes_ptr++ = p_color_abgr;
@@ -369,11 +380,19 @@ void JoltDebugRenderer3D::_add_line(
 ) {
 	const int32_t vertex_count = line_count * 2;
 
-	auto* vertices_ptr = reinterpret_cast<Vector3*>(line_vertices.ptrw()) + vertex_count;
-	auto* attributes_ptr = reinterpret_cast<uint32_t*>(line_attributes.ptrw()) + vertex_count;
+	auto* vertices_ptr = reinterpret_cast<float*>(line_vertices.ptrw()) +
+		ptrdiff_t(vertex_count * 3);
 
-	*vertices_ptr++ = p_from;
-	*vertices_ptr++ = p_to;
+	auto* attributes_ptr = reinterpret_cast<uint32_t*>(line_attributes.ptrw()) +
+		ptrdiff_t(vertex_count);
+
+	*vertices_ptr++ = (float)p_from.x;
+	*vertices_ptr++ = (float)p_from.y;
+	*vertices_ptr++ = (float)p_from.z;
+
+	*vertices_ptr++ = (float)p_to.x;
+	*vertices_ptr++ = (float)p_to.y;
+	*vertices_ptr++ = (float)p_to.z;
 
 	*attributes_ptr++ = p_color_abgr;
 	*attributes_ptr++ = p_color_abgr;

--- a/src/spaces/jolt_debug_renderer_3d.hpp
+++ b/src/spaces/jolt_debug_renderer_3d.hpp
@@ -49,12 +49,12 @@ public:
 private:
 	JoltDebugRenderer3D() { Initialize(); }
 
-	void DrawLine(JPH::Vec3 p_from, JPH::Vec3 p_to, JPH::Color p_color) override;
+	void DrawLine(JPH::RVec3Arg p_from, JPH::RVec3Arg p_to, JPH::Color p_color) override;
 
 	void DrawTriangle(
-		JPH::Vec3 p_vertex1,
-		JPH::Vec3 p_vertex2,
-		JPH::Vec3 p_vertex3,
+		JPH::RVec3Arg p_vertex1,
+		JPH::RVec3Arg p_vertex2,
+		JPH::RVec3Arg p_vertex3,
 		JPH::Color p_color,
 		ECastShadow p_cast_shadow
 	) override;
@@ -72,7 +72,7 @@ private:
 	) override;
 
 	void DrawGeometry(
-		const JPH::Mat44& p_model_matrix,
+		JPH::RMat44Arg p_model_matrix,
 		const JPH::AABox& p_world_space_bounds,
 		float p_lod_scale_sq,
 		JPH::Color p_model_color,
@@ -83,7 +83,7 @@ private:
 	) override;
 
 	void DrawText3D(
-		JPH::Vec3 p_position,
+		JPH::RVec3Arg p_position,
 		const JPH::string_view& p_string,
 		JPH::Color p_color = JPH::Color::sWhite,
 		float p_height = 0.5f


### PR DESCRIPTION
Fixes #355.

This adds support for building binaries that are compatible with double-precision builds of Godot, which is done by passing `-DGDJ_DOUBLE_PRECISION=TRUE` when generating the build directory.