### PR TITLE
Fixed broken `cast_motion` in double-precision builds

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -113,8 +113,8 @@ private:
 		const JPH::ObjectLayerFilter& p_object_layer_filter,
 		const JPH::BodyFilter& p_body_filter,
 		const JPH::ShapeFilter& p_shape_filter,
-		float& p_closest_safe,
-		float& p_closest_unsafe
+		real_t& p_closest_safe,
+		real_t& p_closest_unsafe
 	) const;
 
 	bool _body_motion_recover(
@@ -130,8 +130,8 @@ private:
 		const Vector3& p_scale,
 		const Vector3& p_motion,
 		bool p_collide_separation_ray,
-		float& p_safe_fraction,
-		float& p_unsafe_fraction
+		real_t& p_safe_fraction,
+		real_t& p_unsafe_fraction
 	) const;
 
 	bool _body_motion_collide(


### PR DESCRIPTION
Fixes #355.

This fixes an issue where `cast_motion` (and thus `ShapeCast3D`) would write `float` fractions to what was actually `real_t` pointers on the Godot side of things, resulting in largely nonsense fractions being returned in double-precision builds.