### PR TITLE
Updated Jolt to eef0d0be7c

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 7cb5d1d627b134c63dc594cec89c4ba47a3e975c
+	GIT_COMMIT eef0d0be7cdee82602eca4607b94eae44e0de478
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -381,18 +381,15 @@ void JoltBodyImpl3D::set_angular_velocity(const Vector3& p_velocity) {
 		return;
 	}
 
-	// We need to clear locked angular axes since Jolt currently only clears linear axes
-	const Vector3 locked_velocity = _stop_locked_angular_axes(p_velocity);
-
 	if (space == nullptr) {
-		jolt_settings->mAngularVelocity = to_jolt(locked_velocity);
+		jolt_settings->mAngularVelocity = to_jolt(p_velocity);
 		return;
 	}
 
 	const JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
-	body->GetMotionPropertiesUnchecked()->SetAngularVelocityClamped(to_jolt(locked_velocity));
+	body->GetMotionPropertiesUnchecked()->SetAngularVelocityClamped(to_jolt(p_velocity));
 }
 
 void JoltBodyImpl3D::set_axis_velocity(const Vector3& p_axis_velocity) {
@@ -567,17 +564,7 @@ void JoltBodyImpl3D::apply_force(const Vector3& p_force, const Vector3& p_positi
 	const JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
-	// We need to manually apply any induced torque despite there being an overload of `AddForce`
-	// that does this for us, since Jolt doesn't currently clear locked angular axes.
-
-	const Vector3 body_pos = to_godot(body->GetPosition());
-	const Vector3 body_com = to_godot(body->GetCenterOfMassPosition());
-	const Vector3 torque = (body_pos + p_position - body_com).cross(p_force);
-
-	const Vector3 locked_torque = _stop_locked_angular_axes(torque);
-
-	body->AddForce(to_jolt(p_force));
-	body->AddTorque(to_jolt(locked_torque));
+	body->AddForce(to_jolt(p_force), body->GetPosition() + to_jolt(p_position));
 
 	_motion_changed();
 }
@@ -629,8 +616,6 @@ void JoltBodyImpl3D::apply_impulse(const Vector3& p_impulse, const Vector3& p_po
 
 	body->AddImpulse(to_jolt(p_impulse), body->GetPosition() + to_jolt(p_position));
 
-	_stop_locked_axes(*body);
-
 	_motion_changed();
 }
 
@@ -655,8 +640,6 @@ void JoltBodyImpl3D::apply_central_impulse(const Vector3& p_impulse) {
 	ERR_FAIL_COND(body.is_invalid());
 
 	body->AddImpulse(to_jolt(p_impulse));
-
-	_stop_locked_axes(*body);
 
 	_motion_changed();
 }
@@ -909,8 +892,6 @@ void JoltBodyImpl3D::move_kinematic(float p_step, JPH::Body& p_jolt_body) {
 	}
 
 	p_jolt_body.MoveKinematic(new_position, new_rotation, p_step);
-
-	_stop_locked_axes(p_jolt_body);
 
 	sync_state = true;
 }
@@ -1234,9 +1215,6 @@ void JoltBodyImpl3D::_integrate_forces(float p_step, JPH::Body& p_jolt_body) {
 	_update_gravity(p_jolt_body);
 
 	if (!custom_integrator) {
-		// We need to clear locked angular axes since Jolt currently only clears linear axes
-		const Vector3 locked_constant_torque = _stop_locked_angular_axes(constant_torque);
-
 		JPH::MotionProperties& motion_properties = *p_jolt_body.GetMotionPropertiesUnchecked();
 
 		motion_properties.SetLinearVelocityClamped(
@@ -1244,7 +1222,7 @@ void JoltBodyImpl3D::_integrate_forces(float p_step, JPH::Body& p_jolt_body) {
 		);
 
 		p_jolt_body.AddForce(to_jolt(constant_force));
-		p_jolt_body.AddTorque(to_jolt(locked_constant_torque));
+		p_jolt_body.AddTorque(to_jolt(constant_torque));
 	}
 
 	sync_state = true;
@@ -1275,7 +1253,7 @@ void JoltBodyImpl3D::_pre_step_kinematic(float p_step, JPH::Body& p_jolt_body) {
 }
 
 JPH::EAllowedDOFs JoltBodyImpl3D::_calculate_allowed_dofs() const {
-	if (is_static() || is_kinematic()) {
+	if (is_static()) {
 		return JPH::EAllowedDOFs::All;
 	}
 
@@ -1346,51 +1324,6 @@ JPH::MassProperties JoltBodyImpl3D::_calculate_mass_properties() const {
 	return _calculate_mass_properties(*jolt_shape);
 }
 
-Vector3 JoltBodyImpl3D::_stop_locked_linear_axes(Vector3 p_vector) const {
-	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_LINEAR_X)) {
-		p_vector.x = 0.0f;
-	}
-
-	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_LINEAR_Y)) {
-		p_vector.y = 0.0f;
-	}
-
-	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_LINEAR_Z)) {
-		p_vector.z = 0.0f;
-	}
-
-	return p_vector;
-}
-
-Vector3 JoltBodyImpl3D::_stop_locked_angular_axes(Vector3 p_vector) const {
-	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_ANGULAR_X) || is_rigid_linear()) {
-		p_vector.x = 0.0f;
-	}
-
-	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_ANGULAR_Y) || is_rigid_linear()) {
-		p_vector.y = 0.0f;
-	}
-
-	if (is_axis_locked(PhysicsServer3D::BODY_AXIS_ANGULAR_Z) || is_rigid_linear()) {
-		p_vector.z = 0.0f;
-	}
-
-	return p_vector;
-}
-
-void JoltBodyImpl3D::_stop_locked_axes(JPH::Body& p_jolt_body) const {
-	JPH::MotionProperties& motion_properties = *p_jolt_body.GetMotionPropertiesUnchecked();
-
-	const Vector3 linear_velocity = to_godot(motion_properties.GetLinearVelocity());
-	const Vector3 angular_velocity = to_godot(motion_properties.GetAngularVelocity());
-
-	const Vector3 locked_linear_velocity = _stop_locked_linear_axes(linear_velocity);
-	const Vector3 locked_angular_velocity = _stop_locked_angular_axes(angular_velocity);
-
-	motion_properties.SetLinearVelocity(to_jolt(locked_linear_velocity));
-	motion_properties.SetAngularVelocity(to_jolt(locked_angular_velocity));
-}
-
 void JoltBodyImpl3D::_update_mass_properties() {
 	if (space == nullptr) {
 		return;
@@ -1399,43 +1332,10 @@ void JoltBodyImpl3D::_update_mass_properties() {
 	const JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
-	JPH::MotionProperties& motion_properties = *body->GetMotionPropertiesUnchecked();
-
-	const JPH::EAllowedDOFs allowed_dofs = _calculate_allowed_dofs();
-	JPH::MassProperties mass_properties = _calculate_mass_properties();
-
-	if (allowed_dofs != JPH::EAllowedDOFs::All) {
-		// HACK(mihe): We need to take the inertia into global space in order for any locked angular
-		// axes to actually be applied in global space. We then bring it back into local space once
-		// we've called `SetMassProperties`.
-
-		const JPH::Mat44& inertia_local = mass_properties.mInertia;
-		const JPH::Mat44 rotation_global = JPH::Mat44::sRotation(body->GetRotation());
-		const JPH::Mat44 rotation_global_inv = rotation_global.Transposed();
-		const JPH::Mat44 inertia_global = inertia_local.Multiply3x3(rotation_global_inv);
-		const JPH::Mat44 inertia_global_rotated = rotation_global.Multiply3x3(inertia_global);
-
-		mass_properties.mInertia = inertia_global_rotated;
-	}
-
-	motion_properties.SetMassProperties(allowed_dofs, mass_properties);
-
-	if (allowed_dofs != JPH::EAllowedDOFs::All) {
-		// HACK(mihe): We need to take the inertia back into local space since it's still in global
-		// space after our transformations above.
-
-		const JPH::Vec3 inertia_diagonal = motion_properties.GetInverseInertiaDiagonal();
-		const JPH::Quat inertia_rotation_global = motion_properties.GetInertiaRotation();
-		const JPH::Quat rotation_global_inv = body->GetRotation().Conjugated();
-		const JPH::Quat inertia_rotation_local = rotation_global_inv * inertia_rotation_global;
-
-		motion_properties.SetInverseInertia(inertia_diagonal, inertia_rotation_local);
-
-		// HACK(mihe): Because Jolt doesn't reset the velocities when first omitting the angular
-		// degrees-of-freedom we do it ourselves instead.
-
-		_stop_locked_axes(*body);
-	}
+	body->GetMotionPropertiesUnchecked()->SetMassProperties(
+		_calculate_allowed_dofs(),
+		_calculate_mass_properties()
+	);
 }
 
 void JoltBodyImpl3D::_update_gravity(JPH::Body& p_jolt_body) {

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -276,12 +276,6 @@ private:
 
 	JPH::MassProperties _calculate_mass_properties() const;
 
-	Vector3 _stop_locked_linear_axes(Vector3 p_vector) const;
-
-	Vector3 _stop_locked_angular_axes(Vector3 p_vector) const;
-
-	void _stop_locked_axes(JPH::Body& p_jolt_body) const;
-
 	void _update_mass_properties();
 
 	void _update_gravity(JPH::Body& p_jolt_body);


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@7cb5d1d627b134c63dc594cec89c4ba47a3e975c to godot-jolt/jolt@eef0d0be7cdee82602eca4607b94eae44e0de478 (see diff [here](https://github.com/godot-jolt/jolt/compare/7cb5d1d627b134c63dc594cec89c4ba47a3e975c...eef0d0be7cdee82602eca4607b94eae44e0de478)).

This brings in the following relevant changes:

- `JPH::EAllowedDOFs` now applies in global-space rather than local-space.