### PR TITLE
Updated Jolt to 045a87e230

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT eef0d0be7cdee82602eca4607b94eae44e0de478
+	GIT_COMMIT 045a87e23052a6d550619ac0e9e401d96e40e9e9
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@eef0d0be7cdee82602eca4607b94eae44e0de478 to godot-jolt/jolt@045a87e23052a6d550619ac0e9e401d96e40e9e9 (see diff [here](https://github.com/godot-jolt/jolt/compare/eef0d0be7cdee82602eca4607b94eae44e0de478...045a87e23052a6d550619ac0e9e401d96e40e9e9)).

This brings in the following relevant changes:

- Support for `JPH::SoftBodyContactListener`