### PR TITLE
Updated godot-cpp to 550f91b2dc (4.2-stable)

### DIFF
--- a/cmake/GodotJoltExternalGodotCpp.cmake
+++ b/cmake/GodotJoltExternalGodotCpp.cmake
@@ -20,7 +20,7 @@ set(editor_definitions
 
 gdj_add_external_library(godot-cpp "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/godot-cpp.git
-	GIT_COMMIT caec7a1feecd56a1db3c4dfd1aa6b4e68c81d010
+	GIT_COMMIT 550f91b2dc38ccf200d7ff1435910f5e2a60f1d6
 	LANGUAGE CXX
 	OUTPUT_NAME godot-cpp
 	INCLUDE_DIRECTORIES

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -226,17 +226,10 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	uint32_t p_collision_mask,
 	bool p_collide_with_bodies,
 	bool p_collide_with_areas,
-	float* p_closest_safe,
-	float* p_closest_unsafe,
+	real_t* p_closest_safe,
+	real_t* p_closest_unsafe,
 	PhysicsServer3DExtensionShapeRestInfo* p_info
 ) {
-	// HACK(mihe): These two fractions are unfortunately bound with `real_t` from the Godot side of
-	// things, which means that they get emitted as `float` in `extension_api.json` but will then be
-	// passed in as `double` in double-precision builds of Godot, which means we have to reinterpret
-	// them to their correct type first.
-	auto* p_closest_safe_r = reinterpret_cast<real_t*>(p_closest_safe);
-	auto* p_closest_unsafe_r = reinterpret_cast<real_t*>(p_closest_unsafe);
-
 	// HACK(mihe): This rest info parameter doesn't seem to be used anywhere within Godot, and isn't
 	// exposed in the bindings, so this will be unsupported until anyone actually needs it.
 	ERR_FAIL_COND_D_MSG(
@@ -278,8 +271,8 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 		query_filter,
 		query_filter,
 		JPH::ShapeFilter(),
-		*p_closest_safe_r,
-		*p_closest_unsafe_r
+		*p_closest_safe,
+		*p_closest_unsafe
 	);
 
 	return true;

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -56,8 +56,8 @@ public:
 		uint32_t p_collision_mask,
 		bool p_collide_with_bodies,
 		bool p_collide_with_areas,
-		float* p_closest_safe,
-		float* p_closest_unsafe,
+		real_t* p_closest_safe,
+		real_t* p_closest_unsafe,
 		PhysicsServer3DExtensionShapeRestInfo* p_info
 	) override;
 


### PR DESCRIPTION
This bumps godot-cpp from godot-jolt/godot-cpp@caec7a1feecd56a1db3c4dfd1aa6b4e68c81d010 aka 4.2-stable to godot-jolt/godot-cpp@550f91b2dc38ccf200d7ff1435910f5e2a60f1d6 aka 4.2-stable (see diff [here](https://github.com/godot-jolt/godot-cpp/compare/caec7a1feecd56a1db3c4dfd1aa6b4e68c81d010...550f91b2dc38ccf200d7ff1435910f5e2a60f1d6)).

This changes double-precision builds to use a separate/dedicated `extension_api.json`, which more appropriately reflects the API exposed by double-precision builds of Godot.

This also removes the need for the hack introduced in #782.