### PR TITLE
Fixed some issues with inertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Breaking changes are denoted with ⚠️.
 
 - Fixed issue with not being able to pass a physics space `RID` to `area_get_param`,
   `area_attach_object_instance_id` and `area_get_object_instance_id`.
+- Fixed issue where the `inverse_inertia` property of `PhysicsDirectBodyState3D` would have some of
+  its components swapped.
 
 ## [0.12.0] - 2024-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Breaking changes are denoted with ⚠️.
   collisions with internal edges of `ConcavePolygonShape3D` and `HeightMapShape3D` shapes, also
   known as ghost collisions. This setting is enabled by default and may change the behavior of
   character controllers relying things like `move_and_slide`.
+- Added support for partial custom inertia, where leaving one or two components at zero will use the
+  automatically calculated values for those specific components.
 
 ### Fixed
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1312,8 +1312,17 @@ JPH::MassProperties JoltBodyImpl3D::_calculate_mass_properties(const JPH::Shape&
 		mass_properties.ScaleToMass(mass);
 	} else {
 		mass_properties.mMass = mass;
+	}
+
+	if (inertia.x > 0) {
 		mass_properties.mInertia(0, 0) = (float)inertia.x;
+	}
+
+	if (inertia.y > 0) {
 		mass_properties.mInertia(1, 1) = (float)inertia.y;
+	}
+
+	if (inertia.z > 0) {
 		mass_properties.mInertia(2, 2) = (float)inertia.z;
 	}
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -326,7 +326,9 @@ Vector3 JoltBodyImpl3D::get_inverse_inertia() const {
 	const JoltReadableBody3D body = space->read_body(jolt_id);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	return to_godot(body->GetMotionPropertiesUnchecked()->GetInverseInertiaDiagonal());
+	const JPH::MotionProperties& motion_properties = *body->GetMotionPropertiesUnchecked();
+
+	return to_godot(motion_properties.GetLocalSpaceInverseInertia().GetDiagonal3());
 }
 
 Basis JoltBodyImpl3D::get_inverse_inertia_tensor() const {


### PR DESCRIPTION
Fixes #798.

This fixes two issues with inertia.

The first issue being that `JoltBodyImpl3D::get_inverse_inertia()` (and thus `PhysicsDirectBodyState3D.inverse_inertia`) was not correctly implemented, as `JPH::MotionProperties::GetInverseInertiaDiagonal()` did not in fact return the local-space inverse inertia diagonal as reported by Godot. Now instead we use `JPH::MotionProperties::GetLocalSpaceInverseInertia()`.

The second issue being that this extension did not support partial custom inertia like Godot Physics does, where you can leave one or two components at zero and have it use the automatically calculated value for those specific components.