### PR TITLE
Updated Jolt to e60de1aa54

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 91272baecbc274941186db6f1e3be118af856ce3
+	GIT_COMMIT e60de1aa544dbdb77916b5ef410f2563e2b313bd
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -581,6 +581,12 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 			);
 		}
 
+		// HACK(mihe): Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt
+		// uses actual stiffness for its edge constraints, we crudely map one to the other with an
+		// arbitrary constant.
+		const float stiffness = MAX(Math::pow(stiffness_coefficient, 3.0f) * 1000000.0f, 0.000001f);
+		const float inverse_stiffness = 1.0f / stiffness;
+
 		SymmetricBitTable marked_edges((int32_t)physics_vertices.size());
 
 		auto try_add_edge = [&](int32_t p_physics_index_a, int32_t p_physics_index_b) {
@@ -588,7 +594,7 @@ bool JoltSoftBodyImpl3D::_ref_shared_data() {
 				physics_edges.emplace_back(
 					(JPH::uint32)p_physics_index_a,
 					(JPH::uint32)p_physics_index_b,
-					stiffness_coefficient
+					inverse_stiffness
 				);
 
 				marked_edges.set(p_physics_index_a, p_physics_index_b);


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@91272baecbc274941186db6f1e3be118af856ce3 to godot-jolt/jolt@e60de1aa544dbdb77916b5ef410f2563e2b313bd (see diff [here](https://github.com/godot-jolt/jolt/compare/91272baecbc274941186db6f1e3be118af856ce3...e60de1aa544dbdb77916b5ef410f2563e2b313bd)).

This brings in the following relevant changes:

- Changed soft-body edge constraints to use a compliance (inverse stiffness) rather than a stiffness coefficient