### PR TITLE
Fixed quaternions not being normalized on rare occasions

### DIFF
--- a/src/misc/math.hpp
+++ b/src/misc/math.hpp
@@ -18,25 +18,26 @@
 namespace godot::Math {
 
 _FORCE_INLINE_ void decompose(Basis& p_basis, Vector3& p_scale) {
-	p_scale = p_basis.get_scale();
-
-	if (p_scale == Vector3(1.0f, 1.0f, 1.0f)) {
-		return;
-	}
-
 	Vector3 x = p_basis.get_column(Vector3::AXIS_X);
 	Vector3 y = p_basis.get_column(Vector3::AXIS_Y);
 	Vector3 z = p_basis.get_column(Vector3::AXIS_Z);
 
-	x /= p_scale.x;
-	y -= x * x.dot(y);
-	y /= p_scale.y;
-	z -= x * x.dot(z) - y * y.dot(z);
-	z /= p_scale.z;
+	const float x_dot_x = x.dot(x);
 
-	p_basis.set_column(Vector3::AXIS_X, x);
-	p_basis.set_column(Vector3::AXIS_Y, y);
-	p_basis.set_column(Vector3::AXIS_Z, z);
+	y -= x * (y.dot(x) / x_dot_x);
+	z -= x * (z.dot(x) / x_dot_x);
+
+	const float y_dot_y = y.dot(y);
+
+	z -= y * (z.dot(y) / y_dot_y);
+
+	const float z_dot_z = z.dot(z);
+
+	p_scale = Vector3(Math::sqrt(x_dot_x), Math::sqrt(y_dot_y), Math::sqrt(z_dot_z));
+
+	p_basis.set_column(Vector3::AXIS_X, x / p_scale.x);
+	p_basis.set_column(Vector3::AXIS_Y, y / p_scale.y);
+	p_basis.set_column(Vector3::AXIS_Z, z / p_scale.z);
 }
 
 _FORCE_INLINE_ void decompose(Transform3D& p_transform, Vector3& p_scale) {

--- a/src/misc/type_conversions.hpp
+++ b/src/misc/type_conversions.hpp
@@ -46,7 +46,7 @@ _FORCE_INLINE_ JPH::Vec3 to_jolt(const Vector3& p_vec) {
 }
 
 _FORCE_INLINE_ JPH::Quat to_jolt(const Basis& p_basis) {
-	const Quaternion quat = p_basis.get_quaternion();
+	const Quaternion quat = p_basis.get_quaternion().normalized();
 	return {(float)quat.x, (float)quat.y, (float)quat.z, (float)quat.w};
 }
 


### PR DESCRIPTION
I managed to somewhat reliably trigger a Jolt assertion about the quaternion passed into `JPH::Body::MoveKinematic` not being normalized in a particular project/scene.

As far as I can tell this was just the accumulation of numerical inaccuracies, but which turned out to be enough to trigger the `1.0e-5f` threshold Jolt uses for its `JPH::Quat::IsNormalized()`.

This PR addresses this by simply normalizing the result from `Basis::get_quaternion()`.

While looking into it I decided to also refactor the Gram-Schmidt decomposition that's used to separate the scale from the rest of the transform, as required by Jolt, as I'm pretty sure the previous implementation was not entirely correct, since it assumed that the scale of the basis vectors would remain the same even after orthogonalization, which might have exacerbated the above mentioned problem.