### PR TITLE
Added error-handling for zero-scaled transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Breaking changes are denoted with ⚠️.
   character controllers relying things like `move_and_slide`.
 - Added support for partial custom inertia, where leaving one or two components at zero will use the
   automatically calculated values for those specific components.
+- Added error-handling for catching zero-scaled bodies/shapes, among other things.
 
 ### Fixed
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -49,6 +49,18 @@ JoltBodyImpl3D::~JoltBodyImpl3D() {
 }
 
 void JoltBodyImpl3D::set_transform(const Transform3D& p_transform) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		vformat(
+			"Failed to set transform for body '%s'. "
+			"The basis was found to be singular, which is not supported by Godot Jolt. "
+			"This is likely caused by one or more axes having a scale of zero.",
+			to_string()
+		)
+	);
+#endif // DEBUG_ENABLED
+
 	Vector3 new_scale;
 	const Transform3D new_transform = Math::decomposed(p_transform, new_scale);
 

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -287,6 +287,19 @@ Vector3 JoltShapedObjectImpl3D::get_shape_scale(int32_t p_index) const {
 void JoltShapedObjectImpl3D::set_shape_transform(int32_t p_index, Transform3D p_transform) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		vformat(
+			"Failed to set transform for shape at index %d of body '%s'. "
+			"The basis was found to be singular, which is not supported by Godot Jolt. "
+			"This is likely caused by one or more axes having a scale of zero.",
+			p_index,
+			to_string()
+		)
+	);
+#endif // DEBUG_ENABLED
+
 	Vector3 new_scale;
 	Math::decompose(p_transform, new_scale);
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -153,6 +153,15 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 		return 0;
 	}
 
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_D_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		"intersect_shape failed due to being passed an invalid transform. "
+		"The basis was found to be singular, which is not supported by Godot Jolt. "
+		"This is likely caused by one or more axes having a scale of zero."
+	);
+#endif // DEBUG_ENABLED
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
@@ -237,6 +246,15 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 		"Providing rest info as part of a shape-cast is not supported by Godot Jolt."
 	);
 
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_D_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		"cast_motion failed due to being passed an invalid transform. "
+		"The basis was found to be singular, which is not supported by Godot Jolt. "
+		"This is likely caused by one or more axes having a scale of zero."
+	);
+#endif // DEBUG_ENABLED
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
@@ -295,6 +313,15 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 	if (p_max_results == 0) {
 		return false;
 	}
+
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_D_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		"collide_shape failed due to being passed an invalid transform. "
+		"The basis was found to be singular, which is not supported by Godot Jolt. "
+		"This is likely caused by one or more axes having a scale of zero."
+	);
+#endif // DEBUG_ENABLED
 
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
@@ -390,6 +417,15 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	bool p_collide_with_areas,
 	PhysicsServer3DExtensionShapeRestInfo* p_info
 ) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_D_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		"rest_info failed due to being passed an invalid transform. "
+		"The basis was found to be singular, which is not supported by Godot Jolt. "
+		"This is likely caused by one or more axes having a scale of zero."
+	);
+#endif // DEBUG_ENABLED
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
@@ -564,6 +600,15 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 ) const {
 	p_margin = MAX(p_margin, 0.0001f);
 	p_max_collisions = MIN(p_max_collisions, 32);
+
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_D_MSG(
+		p_transform.basis.determinant() == 0.0f,
+		"body_test_motion failed due to being passed an invalid transform. "
+		"The basis was found to be singular, which is not supported by Godot Jolt. "
+		"This is likely caused by one or more axes having a scale of zero."
+	);
+#endif // DEBUG_ENABLED
 
 	Vector3 scale;
 	Transform3D transform = Math::decomposed(p_transform, scale);


### PR DESCRIPTION
This adds error-handling to the following methods:

- `PhysicsServer3D::body_set_state` (`BODY_STATE_TRANSFORM`)
- `PhysicsServer3D::body_set_shape_transform`
- `PhysicsServer3D::body_test_motion`
- `PhysicsDirectSpaceState3D::intersect_shape`
- `PhysicsDirectSpaceState3D::cast_motion`
- `PhysicsDirectSpaceState3D::collide_shape`
- `PhysicsDirectSpaceState3D::rest_info`

... to make sure that the transform passed in isn't singular, i.e. doesn't have a determinant of zero. This should catch errors such as passing a transform/basis with one or more zero-scaled axes, before they have a chance to propagate into the simulation, where they eventually cause the dreaded `instance_set_transform: Condition "!v.is_finite()" is true` error.