### PR TITLE
Updated toolchains

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,13 @@
 ---
-# Requires LLVM 15.0
+# Requires LLVM 16.0
 
 # General
 Language: Cpp
 Standard: c++17
 TabWidth: 4
 UseTab: Always
-UseCRLF: false
+LineEnding: LF
+InsertNewlineAtEOF: true
 
 # Braces
 BreakBeforeBraces: Custom
@@ -48,6 +49,7 @@ IndentWrappedFunctionNames: false
 LambdaBodyIndentation: Signature
 NamespaceIndentation: None
 PPIndentWidth: -1
+RequiresExpressionIndentation: OuterScope
 
 # Spaces
 BitFieldColonSpacing: Both
@@ -94,8 +96,10 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
+BreakAfterAttributes: Always
 BreakBeforeBinaryOperators: None
 BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeComma
@@ -153,7 +157,8 @@ AlignConsecutiveDeclarations: None
 AlignConsecutiveMacros: None
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
-AlignTrailingComments: false
+AlignTrailingComments:
+  Kind: Never
 
 # Macros
 AttributeMacros: []
@@ -168,12 +173,18 @@ WhitespaceSensitiveMacros: []
 # Miscellaneous
 FixNamespaceComments: true
 InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  Decimal: 0
+  Hex: 0
 QualifierAlignment: Left
 RawStringFormats: []
+RemoveSemicolon: false
 SortUsingDeclarations: false
 
 # BasedOnStyle
 # BreakAfterJavaFieldAnnotations
+# BreakArrays
 # DisableFormat
 # IncludeIsMainRegex
 # IncludeIsMainSourceRegex

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-# Requires LLVM 15.0
+# Requires LLVM 16.0
 
 # The checks are split it into 4 groups:
 #
@@ -70,6 +70,7 @@ Checks: >
   bugprone-suspicious-memory-comparison,
   bugprone-suspicious-memset-usage,
   bugprone-suspicious-missing-comma,
+  bugprone-suspicious-realloc-usage,
   bugprone-suspicious-semicolon,
   bugprone-suspicious-string-compare,
   bugprone-swapped-arguments,
@@ -85,8 +86,11 @@ Checks: >
   -clang-diagnostic-pragma-once-outside-header,
   concurrency-mt-unsafe,
   -concurrency-thread-canceltype-asynchronous,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-do-while,
   cppcoreguidelines-avoid-goto,
   -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-avoid-reference-coroutine-parameters
   cppcoreguidelines-init-variables,
   cppcoreguidelines-interfaces-global-init,
   -cppcoreguidelines-macro-usage,
@@ -127,6 +131,7 @@ Checks: >
   misc-unused-alias-decls,
   misc-unused-parameters,
   misc-unused-using-decls,
+  misc-use-anonymous-namespace,
   modernize-concat-nested-namespaces,
   modernize-deprecated-headers,
   modernize-loop-convert,
@@ -196,6 +201,7 @@ Checks: >
   bugprone-inaccurate-erase,
   -bugprone-shared-ptr-array-mismatch,
   bugprone-sizeof-container,
+  -bugprone-standalone-empty,
   bugprone-string-constructor,
   bugprone-string-integer-assignment,
   -bugprone-stringview-nullptr,

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -4,9 +4,9 @@ inputs:
   toolchain:
     required: true
   version-gcc:
-    default: 11
+    default: 13
   version-llvm:
-    default: 15
+    default: 16
 
 runs:
   using: composite

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -2,7 +2,7 @@ name: Setup macOS
 
 inputs:
   version:
-    default: 14.3
+    default: 15.2
 
 runs:
   using: composite

--- a/docs/building.md
+++ b/docs/building.md
@@ -82,7 +82,7 @@ Prerequisites:
 - CMake 3.22 or newer
 - Python 3.8 or newer
 - GCC 11 or newer
-- (Optional) Clang 15.0.0 or newer
+- (Optional) Clang 16.0.0 or newer
   - If you wish to compile with LLVM/Clang instead of GCC
 
 ⚠️ These commands will build binaries for 64-bit systems. If you instead wish to build binaries for

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -199,7 +199,7 @@ Prerequisites:
 you to use clang-format from within the editor of your choosing, such as [the C++ extension][cpp]
 for Visual Studio Code, which can save you from the hassle of running the commands shown below.
 
-⚠️ The clang-format configuration that Godot Jolt uses is written for **LLVM 15.0** and won't work
+⚠️ The clang-format configuration that Godot Jolt uses is written for **LLVM 16.0** and won't work
 with earlier versions, possibly not newer ones either.
 
 There is a PowerShell script, `scripts/run_clang_format.ps1`, that runs clang-format on all source
@@ -227,7 +227,7 @@ Prerequisites:
 to use clang-tidy from within the editor of your choosing, such as [the C++ extension][cpp] for
 Visual Studio Code, which can save you from the hassle of running the commands shown below.
 
-⚠️ The clang-tidy configuration that Godot Jolt uses is written for **LLVM 15.0** and won't work
+⚠️ The clang-tidy configuration that Godot Jolt uses is written for **LLVM 16.0** and won't work
 with earlier versions, possibly not newer ones either.
 
 ⚠️ Because clang-tidy effectively compiles the code in order to analyze it, it's highly recommended

--- a/scripts/ci_setup_linux.ps1
+++ b/scripts/ci_setup_linux.ps1
@@ -42,6 +42,10 @@ Write-Output "Adding the ubuntu-toolchain-r repository..."
 
 add-apt-repository --yes --update ppa:ubuntu-toolchain-r/ppa
 
+Write-Output "Updating package lists..."
+
+apt update
+
 Write-Output "Installing GCC $VersionGcc..."
 
 apt install --quiet --yes `


### PR DESCRIPTION
This updates the minimum versions for the various toolchains, namely:

- Linux
    - GCC: 11 -> 13
    - Clang: 15 -> 16
- macOS
    - Xcode: 14.3 -> 15.2

The `clang-format` and `clang-tidy` configurations have been updated accordingly, which should work on Windows as well, as it should be on LLVM 17 by now.