### PR TITLE
Fixed some issues with shapeless bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes are denoted with ⚠️.
 
 ### Changed
 
+- ⚠️ Changed the inertia of shapeless bodies to be `(1, 1, 1)`, to match Godot Physics.
 - Changed `SeparationRayShape3D` to not treat other convex shapes as solid, meaning it will now only
   ever collide with the hull of other convex shapes, which better matches Godot Physics.
 
@@ -38,6 +39,7 @@ Breaking changes are denoted with ⚠️.
   `area_attach_object_instance_id` and `area_get_object_instance_id`.
 - Fixed issue where the `inverse_inertia` property of `PhysicsDirectBodyState3D` would have some of
   its components swapped.
+- Fixed issue where shapeless bodies wouldn't have custom center-of-mass applied to them.
 
 ## [0.12.0] - 2024-01-07
 

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -153,7 +153,11 @@ JPH::ShapeRefC JoltShapedObjectImpl3D::build_shape() {
 	JPH::ShapeRefC new_shape = try_build_shape();
 
 	if (new_shape == nullptr) {
-		new_shape = new JoltCustomEmptyShape();
+		if (has_custom_center_of_mass()) {
+			new_shape = new JoltCustomEmptyShape(to_jolt(get_center_of_mass_custom()));
+		} else {
+			new_shape = new JoltCustomEmptyShape();
+		}
 	}
 
 	return new_shape;

--- a/src/shapes/jolt_custom_empty_shape.cpp
+++ b/src/shapes/jolt_custom_empty_shape.cpp
@@ -74,3 +74,22 @@ void JoltCustomEmptyShape::register_type() {
 		);
 	}
 }
+
+JPH::Vec3 JoltCustomEmptyShape::GetCenterOfMass() const {
+	// HACK(mihe): In Godot Physics you're able to provide a custom center-of-mass to a shapeless
+	// body without affecting its inertia. We can't emulate this behavior while relying on Jolt's
+	// `OffsetCenterOfMassShape` due to it translating its inner mass properties (and thus our
+	// inertia) by the center of mass provided to it. So instead we have this shape provide its own.
+	return center_of_mass;
+}
+
+JPH::MassProperties JoltCustomEmptyShape::GetMassProperties() const {
+	JPH::MassProperties mass_properties;
+
+	// HACK(mihe): Since this shape has no volume we can't really give it a correct set of mass
+	// properties, so instead we just give it some random/arbitrary ones.
+	mass_properties.mMass = 1.0f;
+	mass_properties.mInertia = JPH::Mat44::sIdentity();
+
+	return mass_properties;
+}

--- a/src/shapes/jolt_custom_empty_shape.hpp
+++ b/src/shapes/jolt_custom_empty_shape.hpp
@@ -6,7 +6,12 @@ class JoltCustomEmptyShapeSettings final : public JPH::ShapeSettings {
 public:
 	JoltCustomEmptyShapeSettings() = default;
 
+	explicit JoltCustomEmptyShapeSettings(JPH::Vec3Arg p_center_of_mass)
+		: center_of_mass(p_center_of_mass) { }
+
 	ShapeResult Create() const override;
+
+	JPH::Vec3 center_of_mass = JPH::Vec3::sZero();
 };
 
 class JoltCustomEmptyShape final : public JPH::Shape {
@@ -16,12 +21,19 @@ public:
 	JoltCustomEmptyShape()
 		: Shape(JoltCustomShapeType::EMPTY, JoltCustomShapeSubType::EMPTY) { }
 
+	explicit JoltCustomEmptyShape(JPH::Vec3Arg p_center_of_mass)
+		: Shape(JoltCustomShapeType::EMPTY, JoltCustomShapeSubType::EMPTY)
+		, center_of_mass(p_center_of_mass) { }
+
 	JoltCustomEmptyShape(const JoltCustomEmptyShapeSettings& p_settings, ShapeResult& p_result)
-		: Shape(JoltCustomShapeType::EMPTY, JoltCustomShapeSubType::EMPTY, p_settings, p_result) {
+		: Shape(JoltCustomShapeType::EMPTY, JoltCustomShapeSubType::EMPTY, p_settings, p_result)
+		, center_of_mass(p_settings.center_of_mass) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);
 		}
 	}
+
+	JPH::Vec3 GetCenterOfMass() const override;
 
 	JPH::AABox GetLocalBounds() const override { return {JPH::Vec3::sZero(), JPH::Vec3::sZero()}; }
 
@@ -29,13 +41,7 @@ public:
 
 	float GetInnerRadius() const override { return 0.0f; }
 
-	JPH::MassProperties GetMassProperties() const override {
-		// HACK(mihe): We need to give the shape a mass, otherwise we'll get an assert when we use
-		// this in dynamic or kinematic bodies.
-		JPH::MassProperties mass_properties;
-		mass_properties.mMass = 1.0f;
-		return mass_properties;
-	}
+	JPH::MassProperties GetMassProperties() const override;
 
 	const JPH::PhysicsMaterial* GetMaterial([[maybe_unused]] const JPH::SubShapeID& p_sub_shape_id
 	) const override {
@@ -135,4 +141,7 @@ public:
 	float GetVolume() const override { return 0.0f; }
 
 	bool IsValidScale([[maybe_unused]] JPH::Vec3Arg p_scale) const override { return true; }
+
+private:
+	JPH::Vec3 center_of_mass = JPH::Vec3::sZero();
 };


### PR DESCRIPTION
This fixes an issue where if you had a body without any shapes (or simply no enabled/valid shapes) it wouldn't apply any custom center-of-mass that might be set on the body.

This also changes the default inertia for shapeless bodies to be the same as in Godot Physics, meaning `(1, 1, 1)`.

Godot Physics seems to (perhaps unintentionally) support this use-case of simply not having any shapes while still overriding the center-of-mass and inertia to more predictably control its behavior when force/torque is applied to it.

This PR should hopefully get us closer to some kind of parity in that regard.