### PR TITLE
Fixed damping being inconsistent at different update frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where the `inverse_inertia` property of `PhysicsDirectBodyState3D` would have some of
   its components swapped.
 - Fixed issue where shapeless bodies wouldn't have custom center-of-mass applied to them.
+- Fixed issue with high (>1) damping values producing different results across different update
+  frequencies.
 
 ## [0.12.0] - 2024-01-07
 

--- a/src/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.cpp
@@ -255,10 +255,10 @@ void JoltPhysicsDirectBodyState3D::_integrate_forces() {
 	Vector3 linear_velocity = _get_linear_velocity();
 	Vector3 angular_velocity = _get_angular_velocity();
 
-	linear_velocity += _get_total_gravity() * step;
-
 	linear_velocity *= MAX(1.0f - (float)_get_total_linear_damp() * step, 0.0f);
 	angular_velocity *= MAX(1.0f - (float)_get_total_angular_damp() * step, 0.0f);
+
+	linear_velocity += _get_total_gravity() * step;
 
 	_set_linear_velocity(linear_velocity);
 	_set_angular_velocity(angular_velocity);


### PR DESCRIPTION
Fixes #827.

This disables Jolt's application of damping for `RigidBody3D` and replaces it with custom (but same) damping which is instead done _before_ any force integration, as opposed to after.

This way of doing it seems to yield more consistent results across different update frequencies when using high (>1) damping values.