### PR TITLE
Updated Jolt to cf22ca9e16

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT d1936c8506f7b1d321e84a42e8bcdfd2f11bda5a
+	GIT_COMMIT cf22ca9e16c63805fa6285ae855522e82587469d
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/spaces/jolt_debug_geometry_3d.cpp
+++ b/src/spaces/jolt_debug_geometry_3d.cpp
@@ -413,6 +413,8 @@ void JoltDebugGeometry3D::set_material_depth_test([[maybe_unused]] bool p_enable
 #endif // JPH_DEBUG_RENDERER
 }
 
+#ifdef JPH_DEBUG_RENDERER
+
 static_assert(
 	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_INSTANCE ==
 	(int32_t)JPH::BodyManager::EShapeColor::InstanceColor
@@ -437,3 +439,5 @@ static_assert(
 	(int32_t)JoltDebugGeometry3D::COLOR_SCHEME_ISLAND ==
 	(int32_t)JPH::BodyManager::EShapeColor::IslandColor
 );
+
+#endif // JPH_DEBUG_RENDERER


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@d1936c8506f7b1d321e84a42e8bcdfd2f11bda5a to godot-jolt/jolt@cf22ca9e16c63805fa6285ae855522e82587469d (see diff [here](https://github.com/godot-jolt/jolt/compare/d1936c8506f7b1d321e84a42e8bcdfd2f11bda5a...cf22ca9e16c63805fa6285ae855522e82587469d)).

This brings in the following relevant changes:

- Optimizations for soft bodies