### PR TITLE
Added broad-phase optimization to physics queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where shapeless bodies wouldn't have custom center-of-mass applied to them.
 - Fixed issue with high (>1) damping values producing different results across different update
   frequencies.
+- Fixed issue where physics queries performed within the editor (e.g. editor plugins or tool
+  scripts) would end up ignoring potentially large swathes of bodies in scenes with many physics
+  bodies.
 
 ## [0.12.0] - 2024-01-07
 

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -415,23 +415,10 @@ void JoltAreaImpl3D::_add_to_space() {
 
 	jolt_settings->SetShape(build_shape());
 
-	JPH::BodyInterface& body_iface = space->get_body_iface();
-	JPH::Body* body = body_iface.CreateBody(*jolt_settings);
+	const JPH::BodyID new_jolt_id = space->add_rigid_body(*this, *jolt_settings);
+	QUIET_FAIL_COND(new_jolt_id.IsInvalid());
 
-	ERR_FAIL_NULL_MSG(
-		body,
-		vformat(
-			"Failed to create underlying Jolt body for '%s'. "
-			"Consider increasing maximum number of bodies in project settings. "
-			"Maximum number of bodies is currently set to %d.",
-			to_string(),
-			JoltProjectSettings::get_max_bodies()
-		)
-	);
-
-	jolt_id = body->GetID();
-
-	body_iface.AddBody(jolt_id, JPH::EActivation::Activate);
+	jolt_id = new_jolt_id;
 }
 
 void JoltAreaImpl3D::_add_shape_pair(

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1191,26 +1191,10 @@ void JoltBodyImpl3D::_add_to_space() {
 
 	jolt_settings->SetShape(jolt_shape);
 
-	JPH::BodyInterface& body_iface = space->get_body_iface();
-	JPH::Body* body = body_iface.CreateBody(*jolt_settings);
+	const JPH::BodyID new_jolt_id = space->add_rigid_body(*this, *jolt_settings);
+	QUIET_FAIL_COND(new_jolt_id.IsInvalid());
 
-	ERR_FAIL_NULL_MSG(
-		body,
-		vformat(
-			"Failed to create underlying Jolt body for '%s'. "
-			"Consider increasing maximum number of bodies in project settings. "
-			"Maximum number of bodies is currently set to %d.",
-			to_string(),
-			JoltProjectSettings::get_max_bodies()
-		)
-	);
-
-	jolt_id = body->GetID();
-
-	// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or less
-	// impossible to have a body be sleeping when created, so we default to always starting out as
-	// awake/active.
-	body_iface.AddBody(jolt_id, JPH::EActivation::Activate);
+	jolt_id = new_jolt_id;
 }
 
 void JoltBodyImpl3D::_integrate_forces(float p_step, JPH::Body& p_jolt_body) {

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -71,8 +71,7 @@ void JoltObjectImpl3D::set_collision_mask(uint32_t p_mask) {
 void JoltObjectImpl3D::_remove_from_space() {
 	QUIET_FAIL_COND(jolt_id.IsInvalid());
 
-	space->get_body_iface().RemoveBody(jolt_id);
-	space->get_body_iface().DestroyBody(jolt_id);
+	space->remove_body(jolt_id);
 
 	jolt_id = {};
 }

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -469,24 +469,10 @@ void JoltSoftBodyImpl3D::_add_to_space() {
 	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
 	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
 
-	JPH::BodyInterface& body_iface = space->get_body_iface();
+	const JPH::BodyID new_jolt_id = space->add_soft_body(*this, *jolt_settings);
+	QUIET_FAIL_COND(new_jolt_id.IsInvalid());
 
-	JPH::Body* body = body_iface.CreateSoftBody(*jolt_settings);
-
-	ERR_FAIL_NULL_MSG(
-		body,
-		vformat(
-			"Failed to create Jolt body for '%s'. "
-			"Consider increasing maximum number of bodies in project settings. "
-			"Maximum number of bodies is currently set to %d.",
-			to_string(),
-			JoltProjectSettings::get_max_bodies()
-		)
-	);
-
-	jolt_id = body->GetID();
-
-	body_iface.AddBody(jolt_id, JPH::EActivation::Activate);
+	jolt_id = new_jolt_id;
 }
 
 bool JoltSoftBodyImpl3D::_ref_shared_data() {

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -273,8 +273,10 @@ void JoltPhysicsServer3D::_space_set_active(const RID& p_space, bool p_active) {
 	ERR_FAIL_NULL(space);
 
 	if (p_active) {
+		space->set_active(true);
 		active_spaces.insert(space);
 	} else {
+		space->set_active(false);
 		active_spaces.erase(space);
 	}
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -616,6 +616,8 @@ public:
 
 	int32_t _get_process_info(PhysicsServer3D::ProcessInfo p_process_info) override;
 
+	bool is_active() const { return active; }
+
 	void free_space(JoltSpace3D* p_space);
 
 	void free_area(JoltAreaImpl3D* p_area);

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -26,6 +26,8 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	bool p_pick_ray,
 	PhysicsServer3DExtensionRayResult* p_result
 ) {
+	space->try_optimize();
+
 	const JoltQueryFilter3D query_filter(
 		*this,
 		p_collision_mask,
@@ -104,6 +106,8 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_point(
 		return 0;
 	}
 
+	space->try_optimize();
+
 	const JoltQueryFilter3D
 		query_filter(*this, p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
 
@@ -161,6 +165,8 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 		"This is likely caused by one or more axes having a scale of zero."
 	);
 #endif // DEBUG_ENABLED
+
+	space->try_optimize();
 
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
@@ -267,6 +273,8 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	);
 #endif // DEBUG_ENABLED
 
+	space->try_optimize();
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
@@ -346,6 +354,8 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 		"This is likely caused by one or more axes having a scale of zero."
 	);
 #endif // DEBUG_ENABLED
+
+	space->try_optimize();
 
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
@@ -462,6 +472,8 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	);
 #endif // DEBUG_ENABLED
 
+	space->try_optimize();
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltShapeImpl3D* shape = physics_server->get_shape(p_shape_rid);
@@ -545,6 +557,8 @@ Vector3 JoltPhysicsDirectSpaceState3D::_get_closest_point_to_object_volume(
 	const RID& p_object,
 	const Vector3& p_point
 ) const {
+	space->try_optimize();
+
 	auto* physics_server = static_cast<JoltPhysicsServer3D*>(PhysicsServer3D::get_singleton());
 
 	JoltObjectImpl3D* object = physics_server->get_area(p_object);
@@ -671,6 +685,8 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 		)
 	);
 #endif // DEBUG_ENABLED
+
+	space->try_optimize();
 
 	Vector3 recovery;
 	const bool recovered = _body_motion_recover(p_body, transform, p_margin, recovery);

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -9,7 +9,7 @@ class JoltLayerMapper;
 class JoltObjectImpl3D;
 class JoltPhysicsDirectSpaceState3D;
 
-class JoltSpace3D final {
+class JoltSpace3D {
 public:
 	explicit JoltSpace3D(JPH::JobSystem* p_job_system);
 
@@ -22,6 +22,10 @@ public:
 	RID get_rid() const { return rid; }
 
 	void set_rid(const RID& p_rid) { rid = p_rid; }
+
+	bool is_active() const { return active; }
+
+	void set_active(bool p_active) { active = p_active; }
 
 	double get_param(PhysicsServer3D::SpaceParameter p_param) const;
 
@@ -72,6 +76,20 @@ public:
 
 	float get_last_step() const { return last_step; }
 
+	JPH::BodyID add_rigid_body(
+		const JoltObjectImpl3D& p_object,
+		const JPH::BodyCreationSettings& p_settings
+	);
+
+	JPH::BodyID add_soft_body(
+		const JoltObjectImpl3D& p_object,
+		const JPH::SoftBodyCreationSettings& p_settings
+	);
+
+	void remove_body(const JPH::BodyID& p_body_id);
+
+	void try_optimize();
+
 	void add_joint(JPH::Constraint* p_jolt_ref);
 
 	void add_joint(JoltJointImpl3D* p_joint);
@@ -116,6 +134,10 @@ private:
 	JoltAreaImpl3D* default_area = nullptr;
 
 	float last_step = 0.0f;
+
+	int32_t bodies_added_since_optimizing = 0;
+
+	bool active = false;
 
 	bool has_stepped = false;
 };


### PR DESCRIPTION
Fixes #833.

This adds a call to `JPH::PhysicsSystem::OptimizeBroadPhase()` when performing any physics query after having added 128 bodies or more to that particular physics space, without having actually stepped it first. This is largely only applicable to editor viewport physics spaces.

Without this optimization pass you could end up with a broad-phase structure such that any physics query would max out the fixed-size stack that's used while traversing the broad-phase, leading to incomplete/incorrect results.

To help achieve this I've moved/refactored the responsibility of creation/destruction of Jolt bodies to the space itself.