### PR TITLE
Updated Jolt to cf22ca9e16

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT cf22ca9e16c63805fa6285ae855522e82587469d
+	GIT_COMMIT 3e13b2c097905c8ca77d98813389b56cc200932e
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -137,14 +137,7 @@ bool JoltContactListener3D::_try_override_collision_response(
 		p_settings.mInvMassScale2 = 0.0f;
 		p_settings.mInvInertiaScale2 = 0.0f;
 	} else if (can_collide2 && !can_collide1) {
-		if (p_jolt_other_body.IsStatic() || p_jolt_other_body.IsKinematic()) {
-			// HACK(mihe): Using an inverse mass scale of 0 when colliding with static/kinematic
-			// bodies doesn't have the expected effect of just passing through it, so we rely on the
-			// ability to emulate a sensor for these cases.
-			p_settings.mIsSensor = true;
-		} else {
-			p_settings.mInvMassScale1 = 0.0f;
-		}
+		p_settings.mInvMassScale1 = 0.0f;
 	}
 
 	return true;


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@cf22ca9e16c63805fa6285ae855522e82587469d to godot-jolt/jolt@3e13b2c097905c8ca77d98813389b56cc200932e (see diff [here](https://github.com/godot-jolt/jolt/compare/cf22ca9e16c63805fa6285ae855522e82587469d...3e13b2c097905c8ca77d98813389b56cc200932e)).

This brings in the following relevant changes:

- Fix for issue where overriding a soft body's mass to be infinite within a collision with a kinematic/static body would still prompt a collision response.