### PR TITLE
Simplified `JoltBodyImpl3D::get_principal_inertia_axes`

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -301,13 +301,10 @@ Basis JoltBodyImpl3D::get_principal_inertia_axes() const {
 	const JoltReadableBody3D body = space->read_body(jolt_id);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	// TODO(mihe): See if there's some way of getting this directly from Jolt
-
-	Basis inertia_tensor = to_godot(jolt_shape->GetMassProperties().mInertia).basis;
-	const Basis principal_inertia_axes_local = inertia_tensor.diagonalize().transposed();
-	const Basis principal_inertia_axes = get_basis() * principal_inertia_axes_local;
-
-	return principal_inertia_axes;
+	return to_godot(JPH::Mat44::sRotation(
+						body->GetRotation() * body->GetMotionProperties()->GetInertiaRotation()
+					))
+		.basis;
 }
 
 Vector3 JoltBodyImpl3D::get_inverse_inertia() const {

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -301,10 +301,7 @@ Basis JoltBodyImpl3D::get_principal_inertia_axes() const {
 	const JoltReadableBody3D body = space->read_body(jolt_id);
 	ERR_FAIL_COND_D(body.is_invalid());
 
-	return to_godot(JPH::Mat44::sRotation(
-						body->GetRotation() * body->GetMotionProperties()->GetInertiaRotation()
-					))
-		.basis;
+	return to_godot(body->GetRotation() * body->GetMotionProperties()->GetInertiaRotation());
 }
 
 Vector3 JoltBodyImpl3D::get_inverse_inertia() const {


### PR DESCRIPTION
I was going through the `TODO(mihe)` tags and noticed this one. The calculation that's there currently is quite expensive (`GetMassProperties` does quite a lot of things) and I think the calculation is quite trivial since Jolt also splits the inertia in a diagonal matrix and a rotation matrix.

Note: Code is totally untested as I don't know how to test it!