### PR TITLE
Updated Jolt to 3ae9520be6

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 3e13b2c097905c8ca77d98813389b56cc200932e
+	GIT_COMMIT 3ae9520be65c60d0524692be01c0b35d7648d150
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -14,6 +14,10 @@ void* jolt_alloc(size_t p_size) {
 	return mi_malloc(p_size);
 }
 
+void* jolt_realloc(void* p_mem, size_t p_size) {
+	return mi_realloc(p_mem, p_size);
+}
+
 void jolt_free(void* p_mem) {
 	mi_free(p_mem);
 }
@@ -57,6 +61,7 @@ bool jolt_assert(const char* p_expr, const char* p_msg, const char* p_file, uint
 void jolt_initialize() {
 #ifdef GDJ_USE_MIMALLOC
 	JPH::Allocate = &jolt_alloc;
+	JPH::Reallocate = &jolt_realloc;
 	JPH::Free = &jolt_free;
 	JPH::AlignedAllocate = &jolt_aligned_alloc;
 	JPH::AlignedFree = &jolt_aligned_free;


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@3e13b2c097905c8ca77d98813389b56cc200932e to godot-jolt/jolt@3ae9520be65c60d0524692be01c0b35d7648d150 (see diff [here](https://github.com/godot-jolt/jolt/compare/3e13b2c097905c8ca77d98813389b56cc200932e...3ae9520be65c60d0524692be01c0b35d7648d150)).