### PR TITLE
Fixed failing Linux CI builds

### DIFF
--- a/scripts/ci_setup_linux.ps1
+++ b/scripts/ci_setup_linux.ps1
@@ -40,7 +40,7 @@ function Set-DefaultCommand($Name, $Path) {
 
 Write-Output "Adding the ubuntu-toolchain-r repository..."
 
-add-apt-repository --yes --update ppa:ubuntu-toolchain-r/ppa
+add-apt-repository --yes --update ppa:ubuntu-toolchain-r/test
 
 Write-Output "Updating package lists..."
 


### PR DESCRIPTION
Apparently the APT repository that I've been manually adding to get access to later GCC versions (and equivalent `*-multilib`) in the Linux setup script was not the appropriate one for the packages I was hoping to install from it, and instead this just happened to work thanks to GitHub providing this repository in its runner already.

GitHub has now pulled this repository from their runners and as a result all the Linux CI builds are failing one way or another.

This PR (hopefully) fixes that by adding the correct repository.