### PR TITLE
Changed `body_test_motion` to discard by angle rather than depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Breaking changes are denoted with ⚠️.
 
 ### Changed
 
+- ⚠️ Changed the way that the `body_test_motion` method of `PhysicsServer3D` discards contacts,
+  which should fix issues related to jitter/ping-ponging. Note that this can also result in *more*
+  ghost collisions under certain conditions. This affects `move_and_slide`, `move_and_collide` and
+  `test_move`.
 - ⚠️ Changed the inertia of shapeless bodies to be `(1, 1, 1)`, to match Godot Physics.
 - Changed `SeparationRayShape3D` to not treat other convex shapes as solid, meaning it will now only
   ever collide with the hull of other convex shapes, which better matches Godot Physics.

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -137,7 +137,7 @@ private:
 	bool _body_motion_collide(
 		const JoltBodyImpl3D& p_body,
 		const Transform3D& p_transform,
-		float p_distance,
+		const Vector3& p_motion,
 		float p_margin,
 		int32_t p_max_collisions,
 		PhysicsServer3DExtensionMotionResult* p_result


### PR DESCRIPTION
Fixes #626.
Fixes #643.

This applies the change to `PhysicsServer3D.body_test_motion` that was suggested by @yosoyfreeman in #812, which effectively reverts the hack introduced by #559 and replaces its depth-based contact discard with an angle-based one instead.

Note that this also impacts `PhysicsBody3D.move_and_collide` as well as `PhysicsBody3D.test_move` and of course `CharacterBody3D.move_and_slide`.

This will possibly lead to a regression in ghost collisions for some scenarios, like the one seen in #529, but the downsides of #559 have proved to be too great to keep it around.