### PR TITLE
Flipped rotation for joint's angular limit gizmo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Breaking changes are denoted with ⚠️.
 - ⚠️ Changed the inertia of shapeless bodies to be `(1, 1, 1)`, to match Godot Physics.
 - Changed `SeparationRayShape3D` to not treat other convex shapes as solid, meaning it will now only
   ever collide with the hull of other convex shapes, which better matches Godot Physics.
+- Mirrored the way in which angular limits are visualized for `JoltHingeJoint3D`,
+  `JoltConeTwistJoint3D` and `JoltGeneric6DOFJoint`.
 
 ### Added
 

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -82,8 +82,8 @@ void draw_angular_limits(
 	auto calculate_point = [&](int32_t p_index) {
 		const float angle = p_limit_lower + angle_step * (float)p_index;
 
-		const float x = GIZMO_RADIUS * cosf(angle);
-		const float y = GIZMO_RADIUS * sinf(angle);
+		const float x = GIZMO_RADIUS * cosf(-angle);
+		const float y = GIZMO_RADIUS * sinf(-angle);
 
 		return to_3d(p_axis, x, y);
 	};


### PR DESCRIPTION
Fixes #855.

This flips the rotation for the way angular limits are drawn for the substitute joint gizmos, meaning it now lines up with the way these limits actually behave.

This should ideally have been done as part of #725, as I had originally (and arguably incorrectly) made this gizmo to suit the way single-body joints worked previously, which has been changed as of #725.