### PR TITLE
Added early-out when setting shape data with same value

### DIFF
--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -13,25 +13,23 @@ Variant JoltBoxShapeImpl3D::get_data() const {
 }
 
 void JoltBoxShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::VECTOR3);
 
-	half_extents = p_data;
+	const Vector3 new_half_extents = p_data;
+	QUIET_FAIL_COND(new_half_extents == half_extents);
+
+	half_extents = new_half_extents;
+
+	destroy();
 }
 
 void JoltBoxShapeImpl3D::set_margin(float p_margin) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
+	QUIET_FAIL_COND(margin == p_margin);
+	QUIET_FAIL_COND(!JoltProjectSettings::use_shape_margins());
 
 	margin = p_margin;
+
+	destroy();
 }
 
 String JoltBoxShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_capsule_shape_impl_3d.cpp
+++ b/src/shapes/jolt_capsule_shape_impl_3d.cpp
@@ -8,12 +8,6 @@ Variant JoltCapsuleShapeImpl3D::get_data() const {
 }
 
 void JoltCapsuleShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
 
 	const Dictionary data = p_data;
@@ -24,8 +18,15 @@ void JoltCapsuleShapeImpl3D::set_data(const Variant& p_data) {
 	const Variant maybe_radius = data.get("radius", {});
 	ERR_FAIL_COND(maybe_radius.get_type() != Variant::FLOAT);
 
-	height = maybe_height;
-	radius = maybe_radius;
+	const float new_height = maybe_height;
+	const float new_radius = maybe_radius;
+
+	QUIET_FAIL_COND(new_height == height && new_radius == radius);
+
+	height = new_height;
+	radius = new_radius;
+
+	destroy();
 }
 
 String JoltCapsuleShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -11,12 +11,6 @@ Variant JoltConcavePolygonShapeImpl3D::get_data() const {
 }
 
 void JoltConcavePolygonShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
 
 	const Dictionary data = p_data;
@@ -29,6 +23,8 @@ void JoltConcavePolygonShapeImpl3D::set_data(const Variant& p_data) {
 
 	faces = maybe_faces;
 	backface_collision = maybe_backface_collision;
+
+	destroy();
 }
 
 String JoltConcavePolygonShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -7,25 +7,20 @@ Variant JoltConvexPolygonShapeImpl3D::get_data() const {
 }
 
 void JoltConvexPolygonShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::PACKED_VECTOR3_ARRAY);
 
 	vertices = p_data;
+
+	destroy();
 }
 
 void JoltConvexPolygonShapeImpl3D::set_margin(float p_margin) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
+	QUIET_FAIL_COND(margin == p_margin);
+	QUIET_FAIL_COND(!JoltProjectSettings::use_shape_margins());
 
 	margin = p_margin;
+
+	destroy();
 }
 
 String JoltConvexPolygonShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -16,12 +16,6 @@ Variant JoltCylinderShapeImpl3D::get_data() const {
 }
 
 void JoltCylinderShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
 
 	const Dictionary data = p_data;
@@ -32,18 +26,24 @@ void JoltCylinderShapeImpl3D::set_data(const Variant& p_data) {
 	const Variant maybe_radius = data.get("radius", {});
 	ERR_FAIL_COND(maybe_radius.get_type() != Variant::FLOAT);
 
-	height = maybe_height;
-	radius = maybe_radius;
+	const float new_height = maybe_height;
+	const float new_radius = maybe_radius;
+
+	QUIET_FAIL_COND(new_height == height && new_radius == radius);
+
+	height = new_height;
+	radius = new_radius;
+
+	destroy();
 }
 
 void JoltCylinderShapeImpl3D::set_margin(float p_margin) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
+	QUIET_FAIL_COND(margin == p_margin);
+	QUIET_FAIL_COND(!JoltProjectSettings::use_shape_margins());
 
 	margin = p_margin;
+
+	destroy();
 }
 
 String JoltCylinderShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -12,12 +12,6 @@ Variant JoltHeightMapShapeImpl3D::get_data() const {
 }
 
 void JoltHeightMapShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
 
 	const Dictionary data = p_data;
@@ -39,6 +33,8 @@ void JoltHeightMapShapeImpl3D::set_data(const Variant& p_data) {
 	heights = maybe_heights;
 	width = maybe_width;
 	depth = maybe_depth;
+
+	destroy();
 }
 
 String JoltHeightMapShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
+++ b/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
@@ -10,12 +10,6 @@ Variant JoltSeparationRayShapeImpl3D::get_data() const {
 }
 
 void JoltSeparationRayShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
 
 	const Dictionary data = p_data;
@@ -26,8 +20,15 @@ void JoltSeparationRayShapeImpl3D::set_data(const Variant& p_data) {
 	const Variant maybe_slide_on_slope = data.get("slide_on_slope", {});
 	ERR_FAIL_COND(maybe_slide_on_slope.get_type() != Variant::BOOL);
 
-	length = maybe_length;
-	slide_on_slope = maybe_slide_on_slope;
+	const float new_length = maybe_length;
+	const bool new_slide_on_slope = maybe_slide_on_slope;
+
+	QUIET_FAIL_COND(new_length == length && new_slide_on_slope == slide_on_slope);
+
+	length = new_length;
+	slide_on_slope = new_slide_on_slope;
+
+	destroy();
 }
 
 String JoltSeparationRayShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -54,6 +54,14 @@ JPH::ShapeRefC JoltShapeImpl3D::try_build() {
 	return jolt_ref;
 }
 
+void JoltShapeImpl3D::destroy() {
+	jolt_ref = nullptr;
+
+	for (const auto& [owner, ref_count] : ref_counts_by_owner) {
+		owner->_shapes_changed();
+	}
+}
+
 JPH::ShapeRefC JoltShapeImpl3D::with_scale(const JPH::Shape* p_shape, const Vector3& p_scale) {
 	ERR_FAIL_NULL_D(p_shape);
 
@@ -277,12 +285,6 @@ JPH::ShapeRefC JoltShapeImpl3D::without_custom_shapes(const JPH::Shape* p_shape)
 		default: {
 			return p_shape;
 		}
-	}
-}
-
-void JoltShapeImpl3D::_invalidated() {
-	for (const auto& [owner, ref_count] : ref_counts_by_owner) {
-		owner->_shapes_changed();
 	}
 }
 

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -36,7 +36,7 @@ public:
 
 	JPH::ShapeRefC try_build();
 
-	void destroy() { jolt_ref = nullptr; }
+	void destroy();
 
 	const JPH::Shape* get_jolt_ref() const { return jolt_ref; }
 
@@ -64,8 +64,6 @@ public:
 
 protected:
 	virtual JPH::ShapeRefC _build() const = 0;
-
-	virtual void _invalidated();
 
 	String _owners_to_string() const;
 

--- a/src/shapes/jolt_sphere_shape_impl_3d.cpp
+++ b/src/shapes/jolt_sphere_shape_impl_3d.cpp
@@ -5,15 +5,14 @@ Variant JoltSphereShapeImpl3D::get_data() const {
 }
 
 void JoltSphereShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::FLOAT);
 
-	radius = p_data;
+	const float new_radius = p_data;
+	QUIET_FAIL_COND(new_radius == radius);
+
+	radius = new_radius;
+
+	destroy();
 }
 
 String JoltSphereShapeImpl3D::to_string() const {

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
@@ -5,15 +5,14 @@ Variant JoltWorldBoundaryShapeImpl3D::get_data() const {
 }
 
 void JoltWorldBoundaryShapeImpl3D::set_data(const Variant& p_data) {
-	ON_SCOPE_EXIT {
-		_invalidated();
-	};
-
-	destroy();
-
 	ERR_FAIL_COND(p_data.get_type() != Variant::PLANE);
 
+	const Plane new_plane = p_data;
+	QUIET_FAIL_COND(new_plane == plane);
+
 	plane = p_data;
+
+	destroy();
 }
 
 JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::_build() const {


### PR DESCRIPTION
This changes the setting of shape data (and margins) to not have any effect when setting the same value as what was previously set.

Until now this has always caused a rebuild of the entire compound shape, regardless of value, which can be somewhat wasteful, especially when there are complex compound shapes involved.