### PR TITLE
Fixed sleep timer not resetting when applying force/torque

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -259,6 +259,7 @@ void JoltBodyImpl3D::set_is_sleeping(bool p_enabled) {
 		body_iface.DeactivateBody(jolt_id);
 	} else {
 		body_iface.ActivateBody(jolt_id);
+		body_iface.ResetSleepTimer(jolt_id);
 	}
 }
 


### PR DESCRIPTION
Fixes #866.

This makes sure that the sleep timer for `RigidBody3D` is reset whenever it's woken up.