### PR TITLE
Fixed crash when setting a negative `max_contacts_reported`

### DIFF
--- a/src/containers/local_vector.hpp
+++ b/src/containers/local_vector.hpp
@@ -73,11 +73,17 @@ public:
 
 	_FORCE_INLINE_ int32_t get_capacity() const { return (int32_t)impl.capacity(); }
 
-	_FORCE_INLINE_ void reserve(int32_t p_capacity) { impl.reserve((size_t)p_capacity); }
+	_FORCE_INLINE_ void reserve(int32_t p_capacity) {
+		ERR_FAIL_COND(p_capacity < 0);
+		impl.reserve((size_t)p_capacity);
+	}
 
 	_FORCE_INLINE_ int32_t size() const { return (int32_t)impl.size(); }
 
-	_FORCE_INLINE_ void resize(int32_t p_size) { impl.resize((size_t)p_size); }
+	_FORCE_INLINE_ void resize(int32_t p_size) {
+		ERR_FAIL_COND(p_size < 0);
+		impl.resize((size_t)p_size);
+	}
 
 	_FORCE_INLINE_ void insert(int32_t p_index, const TElement& p_value) {
 		emplace(p_index, p_value);

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -454,9 +454,8 @@ void JoltBodyImpl3D::set_center_of_mass_custom(const Vector3& p_center_of_mass) 
 }
 
 void JoltBodyImpl3D::set_max_contacts_reported(int32_t p_count) {
-	if (contacts.size() == p_count) {
-		return;
-	}
+	ERR_FAIL_COND(p_count < 0);
+	QUIET_FAIL_COND(contacts.size() == p_count);
 
 	ON_SCOPE_EXIT {
 		_contact_reporting_changed();


### PR DESCRIPTION
Fixes #868.

This adds error checks to `JoltBodyImpl3D::set_max_contacts_reported`, `LocalVector::resize` and `LocalVector::reserve` to make sure we don't try to cast a negative value to a `size_t`.