### PR TITLE
fix to axis dependent mismatch of jolt joint angular limit gizmo

### DIFF
--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -78,9 +78,10 @@ void draw_angular_limits(
 	const float limit_span = limit_valid ? p_limit_upper - p_limit_lower : Mathf_TAU;
 	const bool limit_bounded = limit_valid && limit_span < (Mathf_TAU - 0.0001f);
 	const float angle_step = limit_span / line_count;
+	const float angle_offset = (p_axis == Vector3::AXIS_X) ? - Mathf_PI / 2.0f : p_axis == Vector3::AXIS_Z ? + Mathf_PI / 2.0f : 0;
 
 	auto calculate_point = [&](int32_t p_index) {
-		const float angle = p_limit_lower + angle_step * (float)p_index;
+		const float angle = p_limit_lower + angle_step * (float)p_index + angle_offset;
 
 		const float x = GIZMO_RADIUS * cosf(-angle);
 		const float y = GIZMO_RADIUS * sinf(-angle);


### PR DESCRIPTION
this is my supposed fix to the jolt joing angular gizmos being wrong.

My initial idea worked only for the x axis, the other axes need to be treated differently.

You can just take this PR as an inspiration and create a cleaner solution, I wont mind. Or edit this one to suit your needs.