### PR TITLE
Changed editor-specific classes to register as internal

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -42,18 +42,23 @@ void on_initialize(ModuleInitializationLevel p_level) {
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
 			JoltProjectSettings::register_settings();
 
-			ClassDB::register_class<JoltDebugGeometry3D>();
 			ClassDB::register_class<JoltJoint3D>(true);
 			ClassDB::register_class<JoltPinJoint3D>();
 			ClassDB::register_class<JoltHingeJoint3D>();
 			ClassDB::register_class<JoltSliderJoint3D>();
 			ClassDB::register_class<JoltConeTwistJoint3D>();
 			ClassDB::register_class<JoltGeneric6DOFJoint3D>();
+
+#ifdef GDJ_CONFIG_DISTRIBUTION
+			ClassDB::register_internal_class<JoltDebugGeometry3D>();
+#else // GDJ_CONFIG_DISTRIBUTION
+			ClassDB::register_class<JoltDebugGeometry3D>();
+#endif // GDJ_CONFIG_DISTRIBUTION
 		} break;
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 #ifdef GDJ_CONFIG_EDITOR
-			ClassDB::register_class<JoltJointGizmoPlugin3D>();
-			ClassDB::register_class<JoltEditorPlugin>();
+			ClassDB::register_internal_class<JoltJointGizmoPlugin3D>();
+			ClassDB::register_internal_class<JoltEditorPlugin>();
 			EditorPlugins::add_by_type<JoltEditorPlugin>();
 #endif // GDJ_CONFIG_EDITOR
 		} break;


### PR DESCRIPTION
Currently internal editor-only classes like `JoltJointGizmoPlugin3D` and `JoltEditorPlugin` show up in the list of node types when you try to add a node, which they shouldn't.

This also hides `JoltDebugGeometry3D` in all distributed builds.