### PR TITLE
Moved some of the newer project settings around a bit

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -249,11 +249,38 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       </td>
     </tr>
     <tr>
-      <td>Soft Bodies</td>
-      <td>Point Margin</td>
+      <td>Collisions</td>
+      <td>Soft Body Point Margin</td>
       <td>
         How much of a margin to add to the soft body points. This can keep soft bodies (like cloth)
         from laying perfectly flush against other surfaces, thereby preventing Z-fighting.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Collisions</td>
+      <td>Body Pair Cache Enabled</td>
+      <td>
+        Whether the body pair cache is enabled, which removes the need for potentially expensive
+        collision detection when the relative orientation between two bodies didn't change.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Collisions</td>
+      <td>Body Pair Cache Distance Threshold</td>
+      <td>
+        The maximum relative distance by which a body pair can move and still reuse the collision
+        results from the previous physics tick.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Collisions</td>
+      <td>Body Pair Cache Angle Threshold</td>
+      <td>
+        The maximum relative angle by which a body pair can move and still reuse the collision
+        results from the previous physics tick.
       </td>
       <td>-</td>
     </tr>
@@ -369,33 +396,6 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>Solver</td>
       <td>Contact Allowed Penetration</td>
       <td>How much bodies are allowed to penetrate eachother.</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Solver</td>
-      <td>Body Pair Cache Enabled</td>
-      <td>
-        Whether the body pair cache is enabled, which removes the need for potentially expensive
-        collision detection when the relative orientation between two bodies didn't change.
-      </td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Solver</td>
-      <td>Body Pair Cache Distance Threshold</td>
-      <td>
-        The maximum relative distance by which a body pair can move and still reuse the collision
-        results from the previous physics tick.
-      </td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>Solver</td>
-      <td>Body Pair Cache Angle Threshold</td>
-      <td>
-        The maximum relative angle by which a body pair can move and still reuse the collision
-        results from the previous physics tick.
-      </td>
       <td>-</td>
     </tr>
     <tr>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -7,6 +7,8 @@ enum JointWorldNode : int32_t {
 	JOINT_WORLD_NODE_B
 };
 
+// clang-format off
+
 constexpr char SLEEP_ENABLED[] = "physics/jolt_3d/sleep/enabled";
 constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_threshold";
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
@@ -15,8 +17,10 @@ constexpr char SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
 constexpr char EDGE_REMOVAL[] = "physics/jolt_3d/collisions/use_enhanced_internal_edge_removal";
 constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_3d/collisions/areas_detect_static_bodies";
 constexpr char KINEMATIC_CONTACTS[] = "physics/jolt_3d/collisions/report_all_kinematic_contacts";
-
-constexpr char SOFT_BODY_POINT_MARGIN[] = "physics/jolt_3d/soft_bodies/point_margin";
+constexpr char SOFT_BODY_POINT_MARGIN[] = "physics/jolt_3d/collisions/soft_body_point_margin";
+constexpr char PAIR_CACHE_ENABLED[] = "physics/jolt_3d/collisions/body_pair_cache_enabled";
+constexpr char PAIR_CACHE_DISTANCE[] = "physics/jolt_3d/collisions/body_pair_cache_distance_threshold";
+constexpr char PAIR_CACHE_ANGLE[] = "physics/jolt_3d/collisions/body_pair_cache_angle_threshold";
 
 constexpr char JOINT_WORLD_NODE[] = "physics/jolt_3d/joints/world_node";
 
@@ -33,9 +37,6 @@ constexpr char ACTIVE_EDGE_THRESHOLD[] = "physics/jolt_3d/solver/active_edge_thr
 constexpr char BOUNCE_VELOCITY_THRESHOLD[] = "physics/jolt_3d/solver/bounce_velocity_threshold";
 constexpr char CONTACT_DISTANCE[] = "physics/jolt_3d/solver/contact_speculative_distance";
 constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_penetration";
-constexpr char PAIR_CACHE_ENABLED[] = "physics/jolt_3d/solver/body_pair_cache_enabled";
-constexpr char PAIR_CACHE_DISTANCE[] = "physics/jolt_3d/solver/body_pair_cache_distance_threshold";
-constexpr char PAIR_CACHE_ANGLE[] = "physics/jolt_3d/solver/body_pair_cache_angle_threshold";
 
 constexpr char MAX_LINEAR_VELOCITY[] = "physics/jolt_3d/limits/max_linear_velocity";
 constexpr char MAX_ANGULAR_VELOCITY[] = "physics/jolt_3d/limits/max_angular_velocity";
@@ -46,6 +47,8 @@ constexpr char MAX_TEMP_MEMORY[] = "physics/jolt_3d/limits/max_temporary_memory"
 
 constexpr char RUN_ON_SEPARATE_THREAD[] = "physics/3d/run_on_separate_thread";
 constexpr char MAX_THREADS[] = "threading/worker_pool/max_threads";
+
+// clang-format on
 
 void register_setting(
 	const String& p_name,


### PR DESCRIPTION
Some of the project settings that have been added since the last release felt a bit out-of-place in terms of their categories.

It didn't seem necessary to have soft bodies be its own category, especially since regular bodies aren't grouped as such, so `soft_bodies/point_margin` is now `collisions/soft_body_point_margin` instead.

The `solver/body_pair_cache_*` settings that were added in #865 are now instead `collisions/body_pair_cache_*`, since I figured it has more to do with caching collision results rather than solving for them.

CC @MemoriesIn8bit (this will break stuff for you)