### PR TITLE
Updated Jolt to 343687a614

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT deeb4bca047308ddd48345c2d906ed1c9ae487ca
+	GIT_COMMIT 343687a61493b1f0642b97b4b7fd05484acc3048
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -259,7 +259,6 @@ void JoltBodyImpl3D::set_is_sleeping(bool p_enabled) {
 		body_iface.DeactivateBody(jolt_id);
 	} else {
 		body_iface.ActivateBody(jolt_id);
-		body_iface.ResetSleepTimer(jolt_id);
 	}
 }
 


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@deeb4bca047308ddd48345c2d906ed1c9ae487ca to godot-jolt/jolt@343687a61493b1f0642b97b4b7fd05484acc3048 (see diff [here](https://github.com/godot-jolt/jolt/compare/deeb4bca047308ddd48345c2d906ed1c9ae487ca...343687a61493b1f0642b97b4b7fd05484acc3048)).

This brings in the following relevant changes:

- Changes `JPH::BodyInterface::ActivateBody` to also reset sleep timer.