### PR TITLE
Fixed broken axis-locking

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1146,6 +1146,7 @@ void JoltBodyImpl3D::_add_to_space() {
 	jolt_settings->mObjectLayer = _get_object_layer();
 	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
 	jolt_settings->mMotionType = _get_motion_type();
+	jolt_settings->mAllowedDOFs = _calculate_allowed_dofs();
 	jolt_settings->mAllowDynamicOrKinematic = true;
 	jolt_settings->mCollideKinematicVsNonDynamic = reports_all_kinematic_contacts();
 	jolt_settings->mUseManifoldReduction = !reports_contacts();


### PR DESCRIPTION
It seems that #879 broke axis-locking completely, as we now never actually properly initialize `JPH::BodyCreationSettings::mAllowedDOFs`. This fixes that.