### PR TITLE
Fixed `SeparationRayShape3D` crash

### DIFF
--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -117,8 +117,14 @@ void collide_ray_vs_shape(
 	);
 
 	if (p_collide_shape_settings.mCollectFacesMode == JPH::ECollectFacesMode::CollectFaces) {
+		// Since `hit.mSubShapeID2` could represent a path not only from `p_shape2` but also any
+		// compound shape that it's contained within, we need to split this path into something that
+		// `p_shape2` can actually understand.
+		JPH::SubShapeID sub_shape_id2;
+		hit.mSubShapeID2.PopID(p_sub_shape_id_creator2.GetNumBitsWritten(), sub_shape_id2);
+
 		p_shape2->GetSupportingFace(
-			hit.mSubShapeID2,
+			sub_shape_id2,
 			ray_direction2,
 			p_scale2,
 			p_center_of_mass_transform2,


### PR DESCRIPTION
Fixes #893.

This fixes a crash related to `SeparationRayShape3D` (introduced in #837) where if a `SeparationRayShape3D` collided with something like a `ConcavePolygonShape3D` that was part of a compound shape (i.e. one of multiple shapes in a physics body) the `JPH::SubShapeID` that was generated by the ray-cast would not be a valid ID to pass into the second shape's `JPH::Shape::GetSupportingFace` of the collision pair. This would then lead to a Jolt assert in `JPH::MeshShape::DecodeSubShapeID` and eventually a crash in `JPH::TriangleCodecIndexed8BitPackSOA4Flags::DecodingContext::GetTriangle`.

See the change itself for more details.