### PR TITLE
Added `CFBundleSupportedPlatforms` to `Info.plist`

### DIFF
--- a/cmake/templates/info_ios.plist.in
+++ b/cmake/templates/info_ios.plist.in
@@ -22,6 +22,10 @@
 	<string>${PROJECT_VERSION}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>DTPlatformName</key>

--- a/cmake/templates/info_macos.plist.in
+++ b/cmake/templates/info_macos.plist.in
@@ -22,6 +22,10 @@
 	<string>${PROJECT_VERSION}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>DTPlatformName</key>


### PR DESCRIPTION
When exporting macOS builds in Godot 4.3 you'll be met with a warning message saying "Info.plist missing or invalid, new Info.plist generated", which seems to be because of godotengine/godot#87908, which checks to make sure that there are a certain set of `CF*` keys in the extension framework's `Info.plist`.

Godot Jolt was missing one of these keys, namely `CFBundleSupportedPlatforms`, and as such its `Info.plist` was considered invalid.

This fixes that.