### PR TITLE
Changed `Area3D` to always collide with back-faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue with certain `generic_6dof_joint_*` methods on `JoltPhysicsServer3D` not having the
   correct parameter names.
 - Fixed issue where sleep timer would not reset when applying force/torque to a `RigidBody3D`.
+- Fixed issue where `Area3D` would fail to report overlap with certain `ConcavePolygonShape3D`.
 
 ## [0.12.0] - 2024-01-07
 

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -1,5 +1,6 @@
 #include "jolt_shaped_object_impl_3d.hpp"
 
+#include "shapes/jolt_custom_double_sided_shape.hpp"
 #include "shapes/jolt_custom_empty_shape.hpp"
 #include "shapes/jolt_shape_impl_3d.hpp"
 #include "spaces/jolt_space_3d.hpp"
@@ -145,6 +146,10 @@ JPH::ShapeRefC JoltShapedObjectImpl3D::try_build_shape() {
 #endif // GDJ_CONFIG_EDITOR
 
 		result = JoltShapeImpl3D::with_scale(result, scale);
+	}
+
+	if (is_area()) {
+		result = JoltShapeImpl3D::with_double_sided(result);
 	}
 
 	return result;

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -1,7 +1,6 @@
 #include "jolt_concave_polygon_shape_impl_3d.hpp"
 
 #include "servers/jolt_project_settings.hpp"
-#include "shapes/jolt_custom_double_sided_shape.hpp"
 
 Variant JoltConcavePolygonShapeImpl3D::get_data() const {
 	Dictionary data;
@@ -98,26 +97,8 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 	JPH::ShapeRefC shape = shape_result.Get();
 
 	if (backface_collision) {
-		return _build_double_sided(shape);
+		return JoltShapeImpl3D::with_double_sided(shape);
 	}
 
 	return shape;
-}
-
-JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build_double_sided(const JPH::Shape* p_shape) const {
-	ERR_FAIL_NULL_D(p_shape);
-
-	const JoltCustomDoubleSidedShapeSettings shape_settings(p_shape);
-	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-
-	ERR_FAIL_COND_D_MSG(
-		shape_result.HasError(),
-		vformat(
-			"Failed to make shape double-sided. "
-			"It returned the following error: '%s'.",
-			to_godot(shape_result.GetError())
-		)
-	);
-
-	return shape_result.Get();
 }

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
@@ -21,8 +21,6 @@ public:
 private:
 	JPH::ShapeRefC _build() const override;
 
-	JPH::ShapeRefC _build_double_sided(const JPH::Shape* p_shape) const;
-
 	PackedVector3Array faces;
 
 	bool backface_collision = false;

--- a/src/shapes/jolt_custom_double_sided_shape.cpp
+++ b/src/shapes/jolt_custom_double_sided_shape.cpp
@@ -97,10 +97,22 @@ void JoltCustomDoubleSidedShape::register_type() {
 			collide_shape_vs_double_sided
 		);
 
+		JPH::CollisionDispatch::sRegisterCollideShape(
+			JoltCustomShapeSubType::DOUBLE_SIDED,
+			sub_type,
+			JPH::CollisionDispatch::sReversedCollideShape
+		);
+
 		JPH::CollisionDispatch::sRegisterCastShape(
 			sub_type,
 			JoltCustomShapeSubType::DOUBLE_SIDED,
 			cast_shape_vs_double_sided
+		);
+
+		JPH::CollisionDispatch::sRegisterCastShape(
+			JoltCustomShapeSubType::DOUBLE_SIDED,
+			sub_type,
+			JPH::CollisionDispatch::sReversedCastShape
 		);
 	}
 }

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -1,7 +1,6 @@
 #include "jolt_height_map_shape_impl_3d.hpp"
 
 #include "servers/jolt_project_settings.hpp"
-#include "shapes/jolt_custom_double_sided_shape.hpp"
 
 Variant JoltHeightMapShapeImpl3D::get_data() const {
 	Dictionary data;
@@ -69,17 +68,17 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build() const {
 	);
 
 	if (width != depth) {
-		return _build_double_sided(_build_mesh());
+		return JoltShapeImpl3D::with_double_sided(_build_mesh());
 	}
 
 	const int32_t block_size = 2; // Default of JPH::HeightFieldShapeSettings::mBlockSize
 	const int32_t block_count = width / block_size;
 
 	if (block_count < 2) {
-		return _build_double_sided(_build_mesh());
+		return JoltShapeImpl3D::with_double_sided(_build_mesh());
 	}
 
-	return _build_double_sided(_build_height_field());
+	return JoltShapeImpl3D::with_double_sided(_build_height_field());
 }
 
 JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_height_field() const {
@@ -214,24 +213,6 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_mesh() const {
 			to_string(),
 			to_godot(shape_result.GetError()),
 			_owners_to_string()
-		)
-	);
-
-	return shape_result.Get();
-}
-
-JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_double_sided(const JPH::Shape* p_shape) const {
-	ERR_FAIL_NULL_D(p_shape);
-
-	const JoltCustomDoubleSidedShapeSettings shape_settings(p_shape);
-	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
-
-	ERR_FAIL_COND_D_MSG(
-		shape_result.HasError(),
-		vformat(
-			"Failed to make shape double-sided. "
-			"It returned the following error: '%s'.",
-			to_godot(shape_result.GetError())
 		)
 	);
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.hpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.hpp
@@ -25,8 +25,6 @@ private:
 
 	JPH::ShapeRefC _build_mesh() const;
 
-	JPH::ShapeRefC _build_double_sided(const JPH::Shape* p_shape) const;
-
 #ifdef REAL_T_IS_DOUBLE
 	PackedFloat64Array heights;
 #else // REAL_T_IS_DOUBLE

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -1,6 +1,7 @@
 #include "jolt_shape_impl_3d.hpp"
 
 #include "objects/jolt_shaped_object_impl_3d.hpp"
+#include "shapes/jolt_custom_double_sided_shape.hpp"
 #include "shapes/jolt_custom_user_data_shape.hpp"
 
 namespace {
@@ -158,6 +159,24 @@ JPH::ShapeRefC JoltShapeImpl3D::with_user_data(const JPH::Shape* p_shape, uint64
 		shape_result.HasError(),
 		vformat(
 			"Failed to override user data. "
+			"It returned the following error: '%s'.",
+			to_godot(shape_result.GetError())
+		)
+	);
+
+	return shape_result.Get();
+}
+
+JPH::ShapeRefC JoltShapeImpl3D::with_double_sided(const JPH::Shape* p_shape) {
+	ERR_FAIL_NULL_D(p_shape);
+
+	const JoltCustomDoubleSidedShapeSettings shape_settings(p_shape);
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+
+	ERR_FAIL_COND_D_MSG(
+		shape_result.HasError(),
+		vformat(
+			"Failed to make shape double-sided. "
 			"It returned the following error: '%s'.",
 			to_godot(shape_result.GetError())
 		)

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -60,6 +60,8 @@ public:
 
 	static JPH::ShapeRefC with_user_data(const JPH::Shape* p_shape, uint64_t p_user_data);
 
+	static JPH::ShapeRefC with_double_sided(const JPH::Shape* p_shape);
+
 	static JPH::ShapeRefC without_custom_shapes(const JPH::Shape* p_shape);
 
 protected:


### PR DESCRIPTION
Fixes #897.

This fixes an issue where an `Area3D` would sometimes fail to detect an overlap with a `ConcavePolygonShape3D`.

The issue stemmed from the collision resulting in only back-face hits, which meant that the `ConcavePolygonShape3D` had to have the `backface_collision` property enabled for the overlap to be reigstered.

This PR fixes this by wrapping every `Area3D` in the `JoltCustomDoubleSidedShape` decorator shape, which forces every collision with said shape to respect back-face collisions, meaning it's no longer dependent on the `ConcavePolygonShape3D` having it enabled.