### PR TITLE
Fixed stack overflow when two double-sided shapes collide

### DIFF
--- a/src/shapes/jolt_custom_double_sided_shape.cpp
+++ b/src/shapes/jolt_custom_double_sided_shape.cpp
@@ -6,6 +6,41 @@ JPH::Shape* construct_double_sided() {
 	return new JoltCustomDoubleSidedShape();
 }
 
+void collide_double_sided_vs_shape(
+	const JPH::Shape* p_shape1,
+	const JPH::Shape* p_shape2,
+	JPH::Vec3Arg p_scale1,
+	JPH::Vec3Arg p_scale2,
+	JPH::Mat44Arg p_center_of_mass_transform1,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	const JPH::CollideShapeSettings& p_collide_shape_settings,
+	JPH::CollideShapeCollector& p_collector,
+	const JPH::ShapeFilter& p_shape_filter
+) {
+	ERR_FAIL_COND(p_shape1->GetSubType() != JoltCustomShapeSubType::DOUBLE_SIDED);
+
+	const auto* shape1 = static_cast<const JoltCustomDoubleSidedShape*>(p_shape1);
+
+	JPH::CollideShapeSettings new_collide_shape_settings = p_collide_shape_settings;
+	new_collide_shape_settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+
+	JPH::CollisionDispatch::sCollideShapeVsShape(
+		shape1->GetInnerShape(),
+		p_shape2,
+		p_scale1,
+		p_scale2,
+		p_center_of_mass_transform1,
+		p_center_of_mass_transform2,
+		p_sub_shape_id_creator1,
+		p_sub_shape_id_creator2,
+		new_collide_shape_settings,
+		p_collector,
+		p_shape_filter
+	);
+}
+
 void collide_shape_vs_double_sided(
 	const JPH::Shape* p_shape1,
 	const JPH::Shape* p_shape2,
@@ -41,37 +76,6 @@ void collide_shape_vs_double_sided(
 	);
 }
 
-void cast_shape_vs_double_sided(
-	const JPH::ShapeCast& p_shape_cast,
-	const JPH::ShapeCastSettings& p_shape_cast_settings,
-	const JPH::Shape* p_shape,
-	JPH::Vec3Arg p_scale,
-	const JPH::ShapeFilter& p_shape_filter,
-	JPH::Mat44Arg p_center_of_mass_transform2,
-	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
-	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
-	JPH::CastShapeCollector& p_collector
-) {
-	ERR_FAIL_COND(p_shape->GetSubType() != JoltCustomShapeSubType::DOUBLE_SIDED);
-
-	const auto* shape = static_cast<const JoltCustomDoubleSidedShape*>(p_shape);
-
-	JPH::ShapeCastSettings new_shape_cast_settings = p_shape_cast_settings;
-	new_shape_cast_settings.mBackFaceModeTriangles = JPH::EBackFaceMode::CollideWithBackFaces;
-
-	JPH::CollisionDispatch::sCastShapeVsShapeLocalSpace(
-		p_shape_cast,
-		new_shape_cast_settings,
-		shape->GetInnerShape(),
-		p_scale,
-		p_shape_filter,
-		p_center_of_mass_transform2,
-		p_sub_shape_id_creator1,
-		p_sub_shape_id_creator2,
-		p_collector
-	);
-}
-
 } // namespace
 
 JPH::ShapeSettings::ShapeResult JoltCustomDoubleSidedShapeSettings::Create() const {
@@ -92,27 +96,15 @@ void JoltCustomDoubleSidedShape::register_type() {
 
 	for (const JPH::EShapeSubType sub_type : JPH::sAllSubShapeTypes) {
 		JPH::CollisionDispatch::sRegisterCollideShape(
-			sub_type,
 			JoltCustomShapeSubType::DOUBLE_SIDED,
-			collide_shape_vs_double_sided
+			sub_type,
+			collide_double_sided_vs_shape
 		);
 
 		JPH::CollisionDispatch::sRegisterCollideShape(
-			JoltCustomShapeSubType::DOUBLE_SIDED,
-			sub_type,
-			JPH::CollisionDispatch::sReversedCollideShape
-		);
-
-		JPH::CollisionDispatch::sRegisterCastShape(
 			sub_type,
 			JoltCustomShapeSubType::DOUBLE_SIDED,
-			cast_shape_vs_double_sided
-		);
-
-		JPH::CollisionDispatch::sRegisterCastShape(
-			JoltCustomShapeSubType::DOUBLE_SIDED,
-			sub_type,
-			JPH::CollisionDispatch::sReversedCastShape
+			collide_shape_vs_double_sided
 		);
 	}
 }


### PR DESCRIPTION
With #899 having made it possible for two shapes decorated with `JoltCustomDoubleSidedShape` to collide with eachother, and me having used `JPH::CollisionDispatch::sReversedCollideShape` for part of the collision dispatch, you could end up endlessly reversing the reversal of the reversal of the reversal, etc. which led to a stack overflow.

This fixes that by not relying on `JPH::CollisionDispatch::sReversedCollideShape` and instead implementing the dispatch functions for both the scenario where the double-sided shape is shape 1 as well as shape 2.

I also removed the cast dispatch functions, since `JoltCustomDoubleSidedShape` will never be used in the context of a shape-cast anyway.