### PR TITLE
Added ability to omit strict CMake warnings for CI builds

### DIFF
--- a/.github/actions/cmake-configure/action.yml
+++ b/.github/actions/cmake-configure/action.yml
@@ -7,6 +7,8 @@ inputs:
     default: null
   double:
     default: false
+  strict:
+    default: true
   args:
     default: ''
 
@@ -24,8 +26,8 @@ runs:
 
         cmake `
           --log-level=VERBOSE `
-          --warn-uninitialized `
-          -Werror=dev `
+          ${{ inputs.strict == 'true' && '--warn-uninitialized' || '' }} `
+          ${{ inputs.strict == 'true' && '-Werror=dev' || '' }} `
           --preset $ConfigurePreset `
           ${{ inputs.double == 'true' && '-DGDJ_DOUBLE_PRECISION=TRUE' || '' }} `
           ${{ inputs.args }}


### PR DESCRIPTION
Related to #902.

Due to the Emscripten toolchain file apparently using uninitialized variables the only realistic option is allow disabling the strict CMake warnings for those builds.

This PR allows for that by adding a new `strict` parameter to the `cmake-configure` action.