### PR TITLE
Changed point velocity to default to zero instead of error

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -416,15 +416,9 @@ void JoltBodyImpl3D::set_axis_velocity(const Vector3& p_axis_velocity) {
 }
 
 Vector3 JoltBodyImpl3D::get_velocity_at_position(const Vector3& p_position) const {
-	ERR_FAIL_NULL_D_MSG(
-		space,
-		vformat(
-			"Failed to retrieve point velocity for '%s'. "
-			"Doing so without a physics space is not supported by Godot Jolt. "
-			"If this relates to a node, try adding the node to a scene tree first.",
-			to_string()
-		)
-	);
+	if (space == nullptr) {
+		return {};
+	}
 
 	const JoltReadableBody3D body = space->read_body(jolt_id);
 	ERR_FAIL_COND_D(body.is_invalid());


### PR DESCRIPTION
It doesn't make a whole lot of sense to have `PhysicsDirectBodyState3D.get_velocity_at_local_position` emit an error if you tried calling it without a physics space. It makes more sense to just return a zero vector instead, which is what this PR does.