### PR TITLE
Updated Jolt to fda5b4aa5a

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 343687a61493b1f0642b97b4b7fd05484acc3048
+	GIT_COMMIT fda5b4aa5a9f6651efc8bc1fda5be9e927a14e92
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@343687a61493b1f0642b97b4b7fd05484acc3048 to godot-jolt/jolt@fda5b4aa5a9f6651efc8bc1fda5be9e927a14e92 (see diff [here](https://github.com/godot-jolt/jolt/compare/343687a61493b1f0642b97b4b7fd05484acc3048...fda5b4aa5a9f6651efc8bc1fda5be9e927a14e92)).

This brings in the following relevant changes:

- Fixes SIMD not being enabled for 32-bit x86 builds on non-Windows platforms
- Fixes bug in ray-casting against soft bodies
- Improves enhanced internal edge detection

Fixes #587 (for real this time).