### PR TITLE
Improved enhanced internal edge removal for shape queries

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -203,6 +203,7 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -316,6 +317,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -527,6 +529,7 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 	settings.mMaxSeparationDistance = (float)p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -927,6 +930,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_recover(
 	settings.mMaxSeparationDistance = p_margin;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 
@@ -1036,6 +1040,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 	JPH::CollideShapeSettings settings;
 
 	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+		settings.mActiveEdgeMode = JPH::EActiveEdgeMode::CollideWithAll;
 		settings.mCollectFacesMode = JPH::ECollectFacesMode::CollectFaces;
 	}
 


### PR DESCRIPTION
As discussed in jrouwe/JoltPhysics#1155, Jolt's active edge detection seems to interfere with `JPH::InternalEdgeRemovingCollector`, causing the latter to not filter out certain internal edge collisions.

This PR does for the physics queries what jrouwe/JoltPhysics#1162 did for the actual simulation, which is to disable the active edge detection when using `JPH::InternalEdgeRemovingCollector`.