### PR TITLE
Fixed crash when re-enabling processing for joint bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Breaking changes are denoted with ⚠️.
   correct parameter names.
 - Fixed issue where sleep timer would not reset when applying force/torque to a `RigidBody3D`.
 - Fixed issue where `Area3D` would fail to report overlap with certain `ConcavePolygonShape3D`.
+- Fixed crash when re-enabling the node processing of a disabled body that's connected to a two-body
+  joint.
 
 ## [0.12.0] - 2024-01-07
 

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -56,28 +56,32 @@ JoltJointImpl3D::~JoltJointImpl3D() {
 }
 
 JoltSpace3D* JoltJointImpl3D::get_space() const {
-	JoltSpace3D* space_a = body_a != nullptr ? body_a->get_space() : nullptr;
-	JoltSpace3D* space_b = body_b != nullptr ? body_b->get_space() : nullptr;
+	if (body_a != nullptr && body_b != nullptr) {
+		JoltSpace3D* space_a = body_a->get_space();
+		JoltSpace3D* space_b = body_b->get_space();
 
-	if (space_b == nullptr) {
+		if (space_a == nullptr || space_b == nullptr) {
+			return nullptr;
+		}
+
+		ERR_FAIL_COND_D_MSG(
+			space_a != space_b,
+			vformat(
+				"Joint was found to connect bodies in different physics spaces. "
+				"This joint will effectively be disabled. "
+				"This joint connects %s.",
+				_bodies_to_string()
+			)
+		);
+
 		return space_a;
+	} else if (body_a != nullptr) {
+		return body_a->get_space();
+	} else if (body_b != nullptr) {
+		return body_b->get_space();
 	}
 
-	if (space_a == nullptr) {
-		return space_b;
-	}
-
-	ERR_FAIL_COND_D_MSG(
-		space_a != space_b,
-		vformat(
-			"Joint was found to connect bodies in different physics spaces. "
-			"This joint will effectively be disabled. "
-			"This joint connects %s.",
-			_bodies_to_string()
-		)
-	);
-
-	return space_a;
+	return nullptr;
 }
 
 void JoltJointImpl3D::set_enabled(bool p_enabled) {


### PR DESCRIPTION
Fixes #913.

This refactors `JoltJointImpl3D::get_space` to fix some broken logic in how it selects the space when dealing with two-body joints.

Previously the code assumed that if one of the spaces were invalid then it's a single-body joint and the other space would be fine to return. However, when we have a two-body joint where one of the bodies is disabled, then we'll end up in that same scenario, and we want this method to return `nullptr` in that case, to signify that we don't want to continue building this joint.

This PR fixes that by returning `nullptr` in the case where we have a two-body joint with only one valid space.