### PR TITLE
Fixed use-after-free when reusing bodies that overlapped areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where `Area3D` would fail to report overlap with certain `ConcavePolygonShape3D`.
 - Fixed crash when re-enabling the node processing of a disabled body that's connected to a two-body
   joint.
+- Fixed issue where re-adding previously used physics bodies to the scene tree could result in many
+  "Unhandled override mode" errors in the Output log.
 
 ## [0.12.0] - 2024-01-07
 

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -374,6 +374,34 @@ bool JoltAreaImpl3D::shape_exited(
 		area_shape_exited(p_body_id, p_other_shape_id, p_self_shape_id);
 }
 
+void JoltAreaImpl3D::body_exited(const JPH::BodyID& p_body_id, bool p_notify) {
+	Overlap* overlap = bodies_by_id.getptr(p_body_id);
+	QUIET_FAIL_NULL(overlap);
+	QUIET_FAIL_COND(overlap->shape_pairs.is_empty());
+
+	for (auto& [id_pair, index_pair] : overlap->shape_pairs) {
+		overlap->pending_added.erase(index_pair);
+		overlap->pending_removed.push_back(index_pair);
+	}
+
+	overlap->shape_pairs.clear();
+
+	if (p_notify) {
+		_notify_body_exited(p_body_id);
+	}
+}
+
+void JoltAreaImpl3D::area_exited(const JPH::BodyID& p_body_id) {
+	Overlap* overlap = areas_by_id.getptr(p_body_id);
+	QUIET_FAIL_NULL(overlap);
+
+	for (const auto& [id_pair, index_pair] : overlap->shape_pairs) {
+		overlap->pending_removed.push_back(index_pair);
+	}
+
+	overlap->shape_pairs.clear();
+}
+
 void JoltAreaImpl3D::call_queries([[maybe_unused]] JPH::Body& p_jolt_body) {
 	_flush_events(bodies_by_id, body_monitor_callback);
 	_flush_events(areas_by_id, area_monitor_callback);
@@ -540,6 +568,7 @@ void JoltAreaImpl3D::_notify_body_exited(const JPH::BodyID& p_body_id) {
 void JoltAreaImpl3D::_force_bodies_entered() {
 	for (auto& [id, body] : bodies_by_id) {
 		for (const auto& [id_pair, index_pair] : body.shape_pairs) {
+			body.pending_removed.erase(index_pair);
 			body.pending_added.push_back(index_pair);
 		}
 	}
@@ -548,6 +577,7 @@ void JoltAreaImpl3D::_force_bodies_entered() {
 void JoltAreaImpl3D::_force_bodies_exited(bool p_remove) {
 	for (auto& [id, body] : bodies_by_id) {
 		for (const auto& [id_pair, index_pair] : body.shape_pairs) {
+			body.pending_added.erase(index_pair);
 			body.pending_removed.push_back(index_pair);
 		}
 
@@ -561,6 +591,7 @@ void JoltAreaImpl3D::_force_bodies_exited(bool p_remove) {
 void JoltAreaImpl3D::_force_areas_entered() {
 	for (auto& [id, area] : areas_by_id) {
 		for (const auto& [id_pair, index_pair] : area.shape_pairs) {
+			area.pending_removed.erase(index_pair);
 			area.pending_added.push_back(index_pair);
 		}
 	}
@@ -569,6 +600,7 @@ void JoltAreaImpl3D::_force_areas_entered() {
 void JoltAreaImpl3D::_force_areas_exited(bool p_remove) {
 	for (auto& [id, area] : areas_by_id) {
 		for (const auto& [id_pair, index_pair] : area.shape_pairs) {
+			area.pending_added.erase(index_pair);
 			area.pending_removed.push_back(index_pair);
 		}
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -33,6 +33,16 @@ class JoltAreaImpl3D final : public JoltShapedObjectImpl3D {
 	};
 
 	struct ShapeIndexPair {
+		ShapeIndexPair() = default;
+
+		ShapeIndexPair(int32_t p_other, int32_t p_self)
+			: other(p_other)
+			, self(p_self) { }
+
+		friend bool operator==(const ShapeIndexPair& p_lhs, const ShapeIndexPair& p_rhs) {
+			return std::tie(p_lhs.other, p_lhs.self) == std::tie(p_rhs.other, p_rhs.self);
+		}
+
 		int32_t other = -1;
 
 		int32_t self = -1;
@@ -166,6 +176,10 @@ public:
 		const JPH::SubShapeID& p_other_shape_id,
 		const JPH::SubShapeID& p_self_shape_id
 	);
+
+	void body_exited(const JPH::BodyID& p_body_id, bool p_notify = true);
+
+	void area_exited(const JPH::BodyID& p_body_id);
 
 	void call_queries(JPH::Body& p_jolt_body);
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1451,6 +1451,14 @@ void JoltBodyImpl3D::_destroy_joint_constraints() {
 	}
 }
 
+void JoltBodyImpl3D::_exit_all_areas() {
+	for (JoltAreaImpl3D* area : areas) {
+		area->body_exited(jolt_id, false);
+	}
+
+	areas.clear();
+}
+
 void JoltBodyImpl3D::_update_group_filter() {
 	JPH::GroupFilter* group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
 
@@ -1484,6 +1492,7 @@ void JoltBodyImpl3D::_space_changing() {
 	JoltShapedObjectImpl3D::_space_changing();
 
 	_destroy_joint_constraints();
+	_exit_all_areas();
 }
 
 void JoltBodyImpl3D::_space_changed() {

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -292,6 +292,8 @@ private:
 
 	void _destroy_joint_constraints();
 
+	void _exit_all_areas();
+
 	void _mode_changed();
 
 	void _shapes_built() override;


### PR DESCRIPTION
Fixes #773 (finally).

When reusing a `RigidBody3D`, `CharacterBody3D` or `AnimatableBody3D` inbetween scene changes, or when moving them between different `World3D`, and said body was overlapping with an `Area3D`, you would end up getting a use-after-free because the bodies would never end up receiving the relevant overlap event and thus hang on to a bunch of stale pointers. This often manifested as an "Unhandled override mode" error with a bunch of random numbers, due to the body accessing random (freed) memory.

This PR fixes that by having bodies to go through their list of areas when changing physics space and forcing them to unregister the overlap, and then clearing the list of areas entirely.