### PR TITLE
Fixed negative scaling

### DIFF
--- a/src/misc/math.cpp
+++ b/src/misc/math.cpp
@@ -1,0 +1,30 @@
+#include "math.hpp"
+
+namespace godot::Math {
+
+void decompose(Basis& p_basis, Vector3& p_scale) {
+	const real_t sign = SIGN(p_basis.determinant());
+
+	Vector3 x = p_basis.get_column(Vector3::AXIS_X);
+	Vector3 y = p_basis.get_column(Vector3::AXIS_Y);
+	Vector3 z = p_basis.get_column(Vector3::AXIS_Z);
+
+	const real_t x_dot_x = x.dot(x);
+
+	y -= x * (y.dot(x) / x_dot_x);
+	z -= x * (z.dot(x) / x_dot_x);
+
+	const real_t y_dot_y = y.dot(y);
+
+	z -= y * (z.dot(y) / y_dot_y);
+
+	const real_t z_dot_z = z.dot(z);
+
+	p_scale = sign * Vector3(Math::sqrt(x_dot_x), Math::sqrt(y_dot_y), Math::sqrt(z_dot_z));
+
+	p_basis.set_column(Vector3::AXIS_X, x / p_scale.x);
+	p_basis.set_column(Vector3::AXIS_Y, y / p_scale.y);
+	p_basis.set_column(Vector3::AXIS_Z, z / p_scale.z);
+}
+
+} // namespace godot::Math

--- a/src/misc/math.hpp
+++ b/src/misc/math.hpp
@@ -18,22 +18,24 @@
 namespace godot::Math {
 
 _FORCE_INLINE_ void decompose(Basis& p_basis, Vector3& p_scale) {
+	const real_t sign = SIGN(p_basis.determinant());
+
 	Vector3 x = p_basis.get_column(Vector3::AXIS_X);
 	Vector3 y = p_basis.get_column(Vector3::AXIS_Y);
 	Vector3 z = p_basis.get_column(Vector3::AXIS_Z);
 
-	const float x_dot_x = x.dot(x);
+	const real_t x_dot_x = x.dot(x);
 
 	y -= x * (y.dot(x) / x_dot_x);
 	z -= x * (z.dot(x) / x_dot_x);
 
-	const float y_dot_y = y.dot(y);
+	const real_t y_dot_y = y.dot(y);
 
 	z -= y * (z.dot(y) / y_dot_y);
 
-	const float z_dot_z = z.dot(z);
+	const real_t z_dot_z = z.dot(z);
 
-	p_scale = Vector3(Math::sqrt(x_dot_x), Math::sqrt(y_dot_y), Math::sqrt(z_dot_z));
+	p_scale = sign * Vector3(Math::sqrt(x_dot_x), Math::sqrt(y_dot_y), Math::sqrt(z_dot_z));
 
 	p_basis.set_column(Vector3::AXIS_X, x / p_scale.x);
 	p_basis.set_column(Vector3::AXIS_Y, y / p_scale.y);

--- a/src/misc/math.hpp
+++ b/src/misc/math.hpp
@@ -17,30 +17,7 @@
 
 namespace godot::Math {
 
-_FORCE_INLINE_ void decompose(Basis& p_basis, Vector3& p_scale) {
-	const real_t sign = SIGN(p_basis.determinant());
-
-	Vector3 x = p_basis.get_column(Vector3::AXIS_X);
-	Vector3 y = p_basis.get_column(Vector3::AXIS_Y);
-	Vector3 z = p_basis.get_column(Vector3::AXIS_Z);
-
-	const real_t x_dot_x = x.dot(x);
-
-	y -= x * (y.dot(x) / x_dot_x);
-	z -= x * (z.dot(x) / x_dot_x);
-
-	const real_t y_dot_y = y.dot(y);
-
-	z -= y * (z.dot(y) / y_dot_y);
-
-	const real_t z_dot_z = z.dot(z);
-
-	p_scale = sign * Vector3(Math::sqrt(x_dot_x), Math::sqrt(y_dot_y), Math::sqrt(z_dot_z));
-
-	p_basis.set_column(Vector3::AXIS_X, x / p_scale.x);
-	p_basis.set_column(Vector3::AXIS_Y, y / p_scale.y);
-	p_basis.set_column(Vector3::AXIS_Z, z / p_scale.z);
-}
+void decompose(Basis& p_basis, Vector3& p_scale);
 
 _FORCE_INLINE_ void decompose(Transform3D& p_transform, Vector3& p_scale) {
 	decompose(p_transform.basis, p_scale);


### PR DESCRIPTION
Apparently #808 broke negative scaling, due to me replacing the usage of `Basis::get_scale` in `Math::decompose` with some "manual" calculations, but in the process forgetting to actually incorporate the sign of the determinant like `Basis::get_scale` does.

This PR fixes this issue by doing exactly that.

I also moved `Math::decompose` into an actual `*.cpp` file, since it really has no business being force-inlined anymore.