### PR TITLE
Updated Jolt to 4084c13b67

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT d50bee9d983303d77c1a8ae6b2380a77203cfc52
+	GIT_COMMIT 4084c13b676a2e7ebf9662b47dcb949179b8c4a1
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/servers/jolt_globals.cpp
+++ b/src/servers/jolt_globals.cpp
@@ -14,8 +14,8 @@ void* jolt_alloc(size_t p_size) {
 	return mi_malloc(p_size);
 }
 
-void* jolt_realloc(void* p_mem, size_t p_size) {
-	return mi_realloc(p_mem, p_size);
+void* jolt_realloc(void* p_mem, [[maybe_unused]] size_t p_old_size, size_t p_new_size) {
+	return mi_realloc(p_mem, p_new_size);
 }
 
 void jolt_free(void* p_mem) {


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@d50bee9d983303d77c1a8ae6b2380a77203cfc52 to godot-jolt/jolt@4084c13b676a2e7ebf9662b47dcb949179b8c4a1 (see diff [here](https://github.com/godot-jolt/jolt/compare/d50bee9d983303d77c1a8ae6b2380a77203cfc52...4084c13b676a2e7ebf9662b47dcb949179b8c4a1)).

This brings in the following relevant changes:

- Adds default overrides for `IsValidScale` and `MakeValidScale` to `JPH::DecoratedShape`
- Fixes `ScaledShape::MakeScaleValid`