### PR TITLE
Added more explicit message to errors that shouldn't happen

### DIFF
--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -239,7 +239,7 @@ void JoltConeTwistJoint3D::_update_param(Param p_param) {
 			value = &twist_limit_span;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 
@@ -271,7 +271,7 @@ void JoltConeTwistJoint3D::_update_jolt_param(Param p_param) {
 			value = &twist_motor_max_torque;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 
@@ -300,7 +300,7 @@ void JoltConeTwistJoint3D::_update_jolt_flag(Flag p_flag) {
 			value = &twist_motor_enabled;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 
@@ -321,7 +321,7 @@ void JoltConeTwistJoint3D::_param_changed(Param p_param) {
 			_update_jolt_param(p_param);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -335,7 +335,7 @@ void JoltConeTwistJoint3D::_flag_changed(Flag p_flag) {
 			_update_jolt_flag(p_flag);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -40,7 +40,7 @@ double JoltConeTwistJointImpl3D::get_param(PhysicsServer3D::ConeTwistJointParam 
 			return DEFAULT_RELAXATION;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled cone twist joint parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled cone twist joint parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -89,7 +89,7 @@ void JoltConeTwistJointImpl3D::set_param(
 			}
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled cone twist joint parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled cone twist joint parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -112,7 +112,7 @@ double JoltConeTwistJointImpl3D::get_jolt_param(JoltParameter p_param) const {
 			return twist_motor_max_torque;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -140,7 +140,7 @@ void JoltConeTwistJointImpl3D::set_jolt_param(JoltParameter p_param, double p_va
 			_twist_motor_limit_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -160,7 +160,7 @@ bool JoltConeTwistJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
 			return twist_motor_enabled;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -184,7 +184,7 @@ void JoltConeTwistJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled) {
 			_twist_motor_state_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_generic_6dof_joint.cpp
+++ b/src/joints/jolt_generic_6dof_joint.cpp
@@ -539,7 +539,7 @@ double* JoltGeneric6DOFJoint3D::_get_param_ptr(Axis p_axis, Param p_param) {
 			return &angular_spring_equilibrium_point[p_axis];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -573,7 +573,7 @@ bool* JoltGeneric6DOFJoint3D::_get_flag_ptr(Axis p_axis, Flag p_flag) {
 			return &angular_spring_enabled[p_axis];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -667,7 +667,7 @@ void JoltGeneric6DOFJoint3D::_param_changed(Axis p_axis, Param p_param) {
 		} break;
 
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -688,7 +688,7 @@ void JoltGeneric6DOFJoint3D::_flag_changed(Axis p_axis, Flag p_flag) {
 		} break;
 
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -100,7 +100,7 @@ double JoltGeneric6DOFJointImpl3D::get_param(Axis p_axis, Param p_param) const {
 			return spring_equilibrium[axis_ang];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -247,7 +247,7 @@ void JoltGeneric6DOFJointImpl3D::set_param(Axis p_axis, Param p_param, double p_
 			_spring_equilibrium_changed(axis_ang);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -276,7 +276,7 @@ bool JoltGeneric6DOFJointImpl3D::get_flag(Axis p_axis, Flag p_flag) const {
 			return motor_enabled[axis_lin];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -311,7 +311,7 @@ void JoltGeneric6DOFJointImpl3D::set_flag(Axis p_axis, Flag p_flag, bool p_enabl
 			_motor_state_changed(axis_lin);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }
@@ -334,7 +334,7 @@ double JoltGeneric6DOFJointImpl3D::get_jolt_param(Axis p_axis, JoltParam p_param
 			return spring_frequency[axis_ang];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -361,7 +361,7 @@ void JoltGeneric6DOFJointImpl3D::set_jolt_param(Axis p_axis, JoltParam p_param, 
 			_spring_parameters_changed(axis_ang);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -381,7 +381,7 @@ bool JoltGeneric6DOFJointImpl3D::get_jolt_flag(Axis p_axis, JoltFlag p_flag) con
 			return spring_use_frequency[axis_ang];
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -404,7 +404,7 @@ void JoltGeneric6DOFJointImpl3D::set_jolt_flag(Axis p_axis, JoltFlag p_flag, boo
 			_spring_parameters_changed(axis_ang);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -211,7 +211,7 @@ void JoltHingeJoint3D::_update_param(Param p_param) {
 			value = &motor_target_velocity;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 
@@ -237,7 +237,7 @@ void JoltHingeJoint3D::_update_jolt_param(Param p_param) {
 			value = &motor_max_torque;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 
@@ -260,7 +260,7 @@ void JoltHingeJoint3D::_update_flag(Flag p_flag) {
 			value = &motor_enabled;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 
@@ -280,7 +280,7 @@ void JoltHingeJoint3D::_update_jolt_flag(Flag p_flag) {
 			value = &limit_spring_enabled;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 
@@ -300,7 +300,7 @@ void JoltHingeJoint3D::_param_changed(Param p_param) {
 			_update_jolt_param(p_param);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -315,7 +315,7 @@ void JoltHingeJoint3D::_flag_changed(Flag p_flag) {
 			_update_jolt_flag(p_flag);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -52,7 +52,7 @@ double JoltHingeJointImpl3D::get_param(Parameter p_param) const {
 			return motor_max_torque * estimate_physics_step();
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -118,7 +118,7 @@ void JoltHingeJointImpl3D::set_param(Parameter p_param, double p_value) {
 			_motor_limit_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -135,7 +135,7 @@ double JoltHingeJointImpl3D::get_jolt_param(JoltParameter p_param) const {
 			return motor_max_torque;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -155,8 +155,8 @@ void JoltHingeJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value)
 			_motor_limit_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
-		}
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
+		} break;
 	}
 }
 
@@ -169,7 +169,7 @@ bool JoltHingeJointImpl3D::get_flag(Flag p_flag) const {
 			return motor_enabled;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -185,7 +185,7 @@ void JoltHingeJointImpl3D::set_flag(Flag p_flag, bool p_enabled) {
 			_motor_state_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }
@@ -197,7 +197,7 @@ bool JoltHingeJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
 			return limit_spring_enabled;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -210,7 +210,7 @@ void JoltHingeJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled) {
 			_limit_spring_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -331,12 +331,10 @@ void JoltJointGizmoPlugin3D::_create_redraw_timer(const Ref<EditorNode3DGizmo>& 
 
 	Node* editor_node = ancestor;
 
-	ERR_FAIL_NULL_MSG(
+	ERR_FAIL_NULL_REPORT(
 		editor_node,
 		"JoltJointGizmoPlugin3D was unable to find EditorNode. "
-		"Gizmos for Jolt joints won't be visible in any editor viewport. "
-		"This should not happen under normal circumstances. "
-		"Consider reporting this issue."
+		"Gizmos for Jolt joints won't be visible in any editor viewport."
 	);
 
 	Timer* timer = memnew(Timer);

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -50,7 +50,7 @@ double JoltPinJointImpl3D::get_param(PhysicsServer3D::PinJointParam p_param) con
 			return DEFAULT_IMPULSE_CLAMP;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled pin joint parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled pin joint parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -88,7 +88,7 @@ void JoltPinJointImpl3D::set_param(PhysicsServer3D::PinJointParam p_param, doubl
 			}
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled pin joint parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled pin joint parameter: '%d'.", p_param));
 		} break;
 	}
 }

--- a/src/joints/jolt_slider_joint_3d.cpp
+++ b/src/joints/jolt_slider_joint_3d.cpp
@@ -209,7 +209,7 @@ void JoltSliderJoint3D::_update_param(Param p_param) {
 			value = &motor_target_velocity;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 
@@ -238,7 +238,7 @@ void JoltSliderJoint3D::_update_jolt_param(Param p_param) {
 			value = &motor_max_force;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 
@@ -264,7 +264,7 @@ void JoltSliderJoint3D::_update_jolt_flag(Flag p_flag) {
 			value = &motor_enabled;
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 
@@ -284,7 +284,7 @@ void JoltSliderJoint3D::_param_changed(Param p_param) {
 			_update_jolt_param(p_param);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -297,7 +297,7 @@ void JoltSliderJoint3D::_flag_changed(Flag p_flag) {
 			_update_jolt_flag(p_flag);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -113,7 +113,7 @@ double JoltSliderJointImpl3D::get_param(PhysicsServer3D::SliderJointParam p_para
 			return DEFAULT_ANGULAR_ORTHO_DAMPING;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled slider joint parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled slider joint parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -331,7 +331,7 @@ void JoltSliderJointImpl3D::set_param(PhysicsServer3D::SliderJointParam p_param,
 			}
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled slider joint parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled slider joint parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -351,7 +351,7 @@ double JoltSliderJointImpl3D::get_jolt_param(JoltParameter p_param) const {
 			return motor_max_force;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -375,8 +375,8 @@ void JoltSliderJointImpl3D::set_jolt_param(JoltParameter p_param, double p_value
 			_motor_limit_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled parameter: '%d'", p_param));
-		}
+			ERR_FAIL_REPORT(vformat("Unhandled parameter: '%d'.", p_param));
+		} break;
 	}
 }
 
@@ -392,7 +392,7 @@ bool JoltSliderJointImpl3D::get_jolt_flag(JoltFlag p_flag) const {
 			return motor_enabled;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_D_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		}
 	}
 }
@@ -412,7 +412,7 @@ void JoltSliderJointImpl3D::set_jolt_flag(JoltFlag p_flag, bool p_enabled) {
 			_motor_state_changed();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled flag: '%d'", p_flag));
+			ERR_FAIL_REPORT(vformat("Unhandled flag: '%d'.", p_flag));
 		} break;
 	}
 }

--- a/src/misc/error_macros.hpp
+++ b/src/misc/error_macros.hpp
@@ -20,6 +20,29 @@
 #define ERR_BREAK_NOT_IMPL(m_cond) ERR_BREAK_MSG(m_cond, GDJ_MSG_NOT_IMPL)
 #define ERR_CONTINUE_NOT_IMPL(m_cond) ERR_CONTINUE_MSG(m_cond, GDJ_MSG_NOT_IMPL)
 
+#define GDJ_FMT_REPORT(m_msg) vformat("%s This should not happen under normal circumstances. Consider reporting this issue in the Godot Jolt repository on GitHub.", m_msg)
+#define ERR_FAIL_INDEX_REPORT(m_index, m_size, m_msg) ERR_FAIL_INDEX_MSG(m_index, m_size, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_INDEX_D_REPORT(m_index, m_size, m_msg) ERR_FAIL_INDEX_D_MSG(m_index, m_size, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_INDEX_V_REPORT(m_index, m_size, m_retval, m_msg) ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_UNSIGNED_INDEX_REPORT(m_index, m_size, m_msg) ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_UNSIGNED_INDEX_D_REPORT(m_index, m_size, m_msg) ERR_FAIL_UNSIGNED_INDEX_D_MSG(m_index, m_size, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_UNSIGNED_INDEX_V_REPORT(m_index, m_size, m_retval, m_msg) ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, GDJ_FMT_REPORT(m_msg))
+#define ERR_BREAK_REPORT(m_cond, m_msg) ERR_BREAK_MSG(m_cond, GDJ_FMT_REPORT(m_msg))
+#define ERR_CONTINUE_REPORT(m_cond, m_msg) ERR_CONTINUE_MSG(m_cond, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_REPORT(m_msg) ERR_FAIL_MSG(GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_COND_REPORT(m_cond, m_msg) ERR_FAIL_COND_MSG(m_cond, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_COND_D_REPORT(m_cond, m_msg) ERR_FAIL_COND_D_MSG(m_cond, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_COND_V_REPORT(m_cond, m_retval, m_msg) ERR_FAIL_COND_V_MSG(m_cond, m_retval, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_D_REPORT(m_msg) ERR_FAIL_D_MSG(GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_NULL_REPORT(m_param, m_msg) ERR_FAIL_NULL_MSG(m_param, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_NULL_D_REPORT(m_param, m_msg) ERR_FAIL_NULL_D_MSG(m_param, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_NULL_V_REPORT(m_param, m_retval, m_msg) ERR_FAIL_NULL_V_MSG(m_param, m_retval, GDJ_FMT_REPORT(m_msg))
+#define ERR_FAIL_V_REPORT(m_retval, m_msg) ERR_FAIL_V_MSG(m_retval, GDJ_FMT_REPORT(m_msg))
+#define CRASH_BAD_INDEX_REPORT(m_index, m_size, m_msg) CRASH_BAD_INDEX_MSG(m_index, m_size, GDJ_FMT_REPORT(m_msg))
+#define CRASH_BAD_UNSIGNED_INDEX_REPORT(m_index, m_size, m_msg) CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, GDJ_FMT_REPORT(m_msg))
+#define CRASH_COND_REPORT(m_cond, m_msg) CRASH_COND_MSG(m_cond, GDJ_FMT_REPORT(m_msg))
+#define CRASH_NOW_REPORT(m_msg) CRASH_NOW_MSG(GDJ_FMT_REPORT(m_msg))
+
 // clang-format on
 
 #define QUIET_FAIL_COND(m_cond) \

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -97,7 +97,7 @@ Variant JoltAreaImpl3D::get_param(PhysicsServer3D::AreaParameter p_param) const 
 			return DEFAULT_WIND_ATTENUATION_FACTOR;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled area parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled area parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -175,7 +175,7 @@ void JoltAreaImpl3D::set_param(PhysicsServer3D::AreaParameter p_param, const Var
 			}
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled area parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled area parameter: '%d'.", p_param));
 		} break;
 	}
 }

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -34,7 +34,7 @@ bool integrate(TValue& p_value, PhysicsServer3D::AreaSpaceOverrideMode p_mode, T
 			return false;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled override mode: '%d'", p_mode));
+			ERR_FAIL_D_REPORT(vformat("Unhandled override mode: '%d'.", p_mode));
 		}
 	}
 }
@@ -106,7 +106,7 @@ Variant JoltBodyImpl3D::get_state(PhysicsServer3D::BodyState p_state) const {
 			return can_sleep();
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled body state: '%d'", p_state));
+			ERR_FAIL_D_REPORT(vformat("Unhandled body state: '%d'.", p_state));
 		}
 	}
 }
@@ -129,7 +129,7 @@ void JoltBodyImpl3D::set_state(PhysicsServer3D::BodyState p_state, const Variant
 			set_can_sleep(p_value);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled body state: '%d'", p_state));
+			ERR_FAIL_REPORT(vformat("Unhandled body state: '%d'.", p_state));
 		} break;
 	}
 }
@@ -167,7 +167,7 @@ Variant JoltBodyImpl3D::get_param(PhysicsServer3D::BodyParameter p_param) const 
 			return get_angular_damp();
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled body parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled body parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -205,7 +205,7 @@ void JoltBodyImpl3D::set_param(PhysicsServer3D::BodyParameter p_param, const Var
 			set_angular_damp(p_value);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled body parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled body parameter: '%d'.", p_param));
 		} break;
 	}
 }
@@ -1096,7 +1096,7 @@ JPH::BroadPhaseLayer JoltBodyImpl3D::_get_broad_phase_layer() const {
 			return JoltBroadPhaseLayer::BODY_DYNAMIC;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled body mode: '%d'", mode));
+			ERR_FAIL_D_REPORT(vformat("Unhandled body mode: '%d'.", mode));
 		}
 	}
 }
@@ -1120,7 +1120,7 @@ JPH::EMotionType JoltBodyImpl3D::_get_motion_type() const {
 			return JPH::EMotionType::Dynamic;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled body mode: '%d'", mode));
+			ERR_FAIL_D_REPORT(vformat("Unhandled body mode: '%d'.", mode));
 		}
 	}
 }

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -97,7 +97,7 @@ bool JoltObjectImpl3D::can_interact_with(const JoltObjectImpl3D& p_other) const 
 	} else if (const JoltSoftBodyImpl3D* other_soft_body = p_other.as_soft_body()) {
 		return can_interact_with(*other_soft_body);
 	} else {
-		ERR_FAIL_D_MSG(vformat("Unhandled object type: '%d'", p_other.get_type()));
+		ERR_FAIL_D_REPORT(vformat("Unhandled object type: '%d'.", p_other.get_type()));
 	}
 }
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -165,7 +165,7 @@ Variant JoltSoftBodyImpl3D::get_state(PhysicsServer3D::BodyState p_state) const 
 			ERR_FAIL_D_NOT_IMPL();
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled body state: '%d'", p_state));
+			ERR_FAIL_D_REPORT(vformat("Unhandled body state: '%d'.", p_state));
 		}
 	}
 }
@@ -188,7 +188,7 @@ void JoltSoftBodyImpl3D::set_state(PhysicsServer3D::BodyState p_state, const Var
 			ERR_FAIL_NOT_IMPL();
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled body state: '%d'", p_state));
+			ERR_FAIL_REPORT(vformat("Unhandled body state: '%d'.", p_state));
 		} break;
 	}
 }

--- a/src/spaces/jolt_layer_mapper.cpp
+++ b/src/spaces/jolt_layer_mapper.cpp
@@ -110,13 +110,11 @@ JPH::ObjectLayer JoltLayerMapper::to_object_layer(
 	} else {
 		constexpr uint16_t object_layer_count = 1U << 13U;
 
-		ERR_FAIL_COND_D_MSG(
+		ERR_FAIL_COND_D_REPORT(
 			next_object_layer == object_layer_count,
 			vformat(
 				"Maximum number of object layers (%d) reached. "
-				"This means there are %d combinations of collision layers and masks. "
-				"This should not happen under normal circumstances. "
-				"Consider reporting this issue.",
+				"This means there are %d combinations of collision layers and masks.",
 				object_layer_count,
 				object_layer_count
 			)

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -28,7 +28,7 @@ bool JoltMotionFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer)
 			return false;
 		} break;
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled broad phase layer: '%d'", broad_phase_layer));
+			ERR_FAIL_D_REPORT(vformat("Unhandled broad phase layer: '%d'.", broad_phase_layer));
 		}
 	}
 }

--- a/src/spaces/jolt_query_filter_3d.cpp
+++ b/src/spaces/jolt_query_filter_3d.cpp
@@ -32,7 +32,7 @@ bool JoltQueryFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) 
 			return collide_with_areas;
 		} break;
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled broad phase layer: '%d'", broad_phase_layer));
+			ERR_FAIL_D_REPORT(vformat("Unhandled broad phase layer: '%d'.", broad_phase_layer));
 		}
 	}
 }

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -212,7 +212,7 @@ double JoltSpace3D::get_param(PhysicsServer3D::SpaceParameter p_param) const {
 			return DEFAULT_SOLVER_ITERATIONS;
 		}
 		default: {
-			ERR_FAIL_D_MSG(vformat("Unhandled space parameter: '%d'", p_param));
+			ERR_FAIL_D_REPORT(vformat("Unhandled space parameter: '%d'.", p_param));
 		}
 	}
 }
@@ -271,7 +271,7 @@ void JoltSpace3D::set_param(
 			);
 		} break;
 		default: {
-			ERR_FAIL_MSG(vformat("Unhandled space parameter: '%d'", p_param));
+			ERR_FAIL_REPORT(vformat("Unhandled space parameter: '%d'.", p_param));
 		} break;
 	}
 }

--- a/src/spaces/jolt_temp_allocator.cpp
+++ b/src/spaces/jolt_temp_allocator.cpp
@@ -50,7 +50,7 @@ void JoltTempAllocator::Free(void* p_ptr, uint32_t p_size) {
 
 	if (top <= capacity) {
 		if (base + new_top != p_ptr) {
-			CRASH_NOW_MSG("Temporary memory was freed in the wrong order.");
+			CRASH_NOW_REPORT("Temporary memory was freed in the wrong order.");
 		}
 	} else {
 		JPH::Free(p_ptr);


### PR DESCRIPTION
All the "Unhandled ..." errors are currently a bit vague as to whether they're the user's fault or not, and it's also not super clear that it's originating from this extension.

This PR fixes that by making them all use some new macros that explicitly mentions that this is a bug that shouldn't happen and that it should be reported in this repo.