### PR TITLE
Improved error-handling for scaling

### DIFF
--- a/src/misc/math.hpp
+++ b/src/misc/math.hpp
@@ -15,6 +15,28 @@
 
 #define USEC_TO_SEC(m_usec) (double(m_usec) / 1000000.0)
 
+#ifdef GDJ_CONFIG_EDITOR
+
+#define ENSURE_SCALE_NOT_ZERO(m_transform, m_msg)                                             \
+	if (unlikely((m_transform).basis.determinant() == 0.0f)) {                                \
+		WARN_PRINT(vformat(                                                                   \
+			"%s "                                                                             \
+			"The basis of the transform was singular, which is not supported by Godot Jolt. " \
+			"This is likely caused by one or more axes having a scale of zero. "              \
+			"The basis (and thus its scale) will be treated as identity.",                    \
+			m_msg                                                                             \
+		));                                                                                   \
+                                                                                              \
+		(m_transform).basis = Basis();                                                        \
+	} else                                                                                    \
+		((void)0)
+
+#else // GDJ_CONFIG_EDITOR
+
+#define ENSURE_SCALE_NOT_ZERO(m_transform, m_msg)
+
+#endif // GDJ_CONFIG_EDITOR
+
 namespace godot::Math {
 
 void decompose(Basis& p_basis, Vector3& p_scale);

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -49,19 +49,10 @@ JoltBodyImpl3D::~JoltBodyImpl3D() {
 }
 
 void JoltBodyImpl3D::set_transform(Transform3D p_transform) {
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(p_transform.basis.determinant() == 0.0f)) {
-		ERR_PRINT(vformat(
-			"Failed to set transform for body '%s'. "
-			"Its basis was found to be singular, which is not supported by Godot Jolt. "
-			"This is likely caused by one or more axes having a scale of zero. "
-			"Its basis (and thus its scale) will be treated as identity.",
-			to_string()
-		));
-
-		p_transform.basis = Basis();
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_NOT_ZERO(
+		p_transform,
+		vformat("An invalid transform was passed to physics body '%s'.", to_string())
+	);
 
 	Vector3 new_scale;
 	Math::decompose(p_transform, new_scale);

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -307,6 +307,20 @@ JPH::ShapeRefC JoltShapeImpl3D::without_custom_shapes(const JPH::Shape* p_shape)
 	}
 }
 
+Vector3 JoltShapeImpl3D::make_scale_valid(const JPH::Shape* p_shape, const Vector3& p_scale) {
+	return to_godot(p_shape->MakeScaleValid(to_jolt(p_scale)));
+}
+
+bool JoltShapeImpl3D::is_scale_valid(
+	const Vector3& p_scale,
+	const Vector3& p_valid_scale,
+	real_t p_tolerance
+) {
+	return Math::is_equal_approx(p_scale.x, p_valid_scale.x, p_tolerance) &&
+		Math::is_equal_approx(p_scale.y, p_valid_scale.y, p_tolerance) &&
+		Math::is_equal_approx(p_scale.z, p_valid_scale.z, p_tolerance);
+}
+
 String JoltShapeImpl3D::_owners_to_string() const {
 	const int32_t owner_count = ref_counts_by_owner.size();
 

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -64,6 +64,14 @@ public:
 
 	static JPH::ShapeRefC without_custom_shapes(const JPH::Shape* p_shape);
 
+	static Vector3 make_scale_valid(const JPH::Shape* p_shape, const Vector3& p_scale);
+
+	static bool is_scale_valid(
+		const Vector3& p_scale,
+		const Vector3& p_valid_scale,
+		real_t p_tolerance = 0.01f
+	);
+
 protected:
 	virtual JPH::ShapeRefC _build() const = 0;
 
@@ -75,3 +83,32 @@ protected:
 
 	JPH::ShapeRefC jolt_ref;
 };
+
+#ifdef GDJ_CONFIG_EDITOR
+
+#define ERR_PRINT_INVALID_SCALE_MSG(m_scale, m_valid_scale, m_msg)               \
+	if (unlikely(!JoltShapeImpl3D::is_scale_valid(m_scale, valid_scale))) {      \
+		ERR_PRINT(vformat(                                                       \
+			"%s "                                                                \
+			"A scale of %v is not supported by Godot Jolt for this shape/body. " \
+			"The scale will instead be treated as %v.",                          \
+			m_msg,                                                               \
+			m_scale,                                                             \
+			valid_scale                                                          \
+		));                                                                      \
+	} else                                                                       \
+		((void)0)
+
+#else // GDJ_CONFIG_EDITOR
+
+#define ERR_PRINT_INVALID_SCALE_MSG(m_scale, m_valid_scale, m_msg)
+
+#endif // GDJ_CONFIG_EDITOR
+
+#define ENSURE_SCALE_VALID(m_shape, m_scale, m_msg)                                      \
+	if (true) {                                                                          \
+		const Vector3 valid_scale = JoltShapeImpl3D::make_scale_valid(m_shape, m_scale); \
+		ERR_PRINT_INVALID_SCALE_MSG(m_scale, valid_scale, m_msg);                        \
+		(m_scale) = valid_scale;                                                         \
+	} else                                                                               \
+		((void)0)

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -167,34 +167,12 @@ int32_t JoltPhysicsDirectSpaceState3D::_intersect_shape(
 
 	Transform3D transform = p_transform;
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(transform.basis.determinant() == 0.0f)) {
-		ERR_PRINT(vformat(
-			"intersect_shape failed due to being passed an invalid transform. "
-			"Its basis was found to be singular, which is not supported by Godot Jolt. "
-			"This is likely caused by one or more axes having a scale of zero. "
-			"Its basis (and thus its scale) will be treated as identity."
-		));
-
-		transform.basis = Basis();
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_NOT_ZERO(transform, "intersect_shape was passed an invalid transform.");
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(!jolt_shape->IsValidScale(to_jolt(scale)))) {
-		ERR_PRINT(vformat(
-			"intersect_shape failed due to being passed an invalid transform. "
-			"A scale of %v is not supported by Godot Jolt for this shape type. "
-			"Its scale will instead be treated as (1, 1, 1).",
-			scale
-		));
-
-		scale = Vector3(1, 1, 1);
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_VALID(jolt_shape, scale, "intersect_shape was passed an invalid transform.");
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	const Transform3D transform_com = transform.translated_local(com_scaled);
@@ -281,34 +259,12 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 
 	Transform3D transform = p_transform;
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(transform.basis.determinant() == 0.0f)) {
-		ERR_PRINT(vformat(
-			"cast_motion failed due to being passed an invalid transform. "
-			"Its basis was found to be singular, which is not supported by Godot Jolt. "
-			"This is likely caused by one or more axes having a scale of zero. "
-			"Its basis (and thus its scale) will be treated as identity."
-		));
-
-		transform.basis = Basis();
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_NOT_ZERO(transform, "cast_motion was passed an invalid transform.");
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(!jolt_shape->IsValidScale(to_jolt(scale)))) {
-		ERR_PRINT(vformat(
-			"cast_motion failed due to being passed an invalid transform. "
-			"A scale of %v is not supported by Godot Jolt for this shape type. "
-			"Its scale will instead be treated as (1, 1, 1).",
-			scale
-		));
-
-		scale = Vector3(1, 1, 1);
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_VALID(jolt_shape, scale, "cast_motion was passed an invalid transform.");
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	Transform3D transform_com = transform.translated_local(com_scaled);
@@ -370,34 +326,12 @@ bool JoltPhysicsDirectSpaceState3D::_collide_shape(
 
 	Transform3D transform = p_transform;
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(transform.basis.determinant() == 0.0f)) {
-		ERR_PRINT(vformat(
-			"collide_shape failed due to being passed an invalid transform. "
-			"Its basis was found to be singular, which is not supported by Godot Jolt. "
-			"This is likely caused by one or more axes having a scale of zero. "
-			"Its basis (and thus its scale) will be treated as identity."
-		));
-
-		transform.basis = Basis();
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_NOT_ZERO(transform, "collide_shape was passed an invalid transform.");
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(!jolt_shape->IsValidScale(to_jolt(scale)))) {
-		ERR_PRINT(vformat(
-			"collide_shape failed due to being passed an invalid transform. "
-			"A scale of %v is not supported by Godot Jolt for this shape type. "
-			"Its scale will instead be treated as (1, 1, 1).",
-			scale
-		));
-
-		scale = Vector3(1, 1, 1);
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_VALID(jolt_shape, scale, "collide_shape was passed an invalid transform.");
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	const Transform3D transform_com = transform.translated_local(com_scaled);
@@ -493,34 +427,12 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 
 	Transform3D transform = p_transform;
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(transform.basis.determinant() == 0.0f)) {
-		ERR_PRINT(vformat(
-			"get_rest_info failed due to being passed an invalid transform. "
-			"Its basis was found to be singular, which is not supported by Godot Jolt. "
-			"This is likely caused by one or more axes having a scale of zero. "
-			"Its basis (and thus its scale) will be treated as identity."
-		));
-
-		transform.basis = Basis();
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_NOT_ZERO(transform, "get_rest_info was passed an invalid transform.");
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(!jolt_shape->IsValidScale(to_jolt(scale)))) {
-		ERR_PRINT(vformat(
-			"get_rest_info failed due to being passed an invalid transform. "
-			"A scale of %v is not supported by Godot Jolt for this shape type. "
-			"Its scale will instead be treated as (1, 1, 1).",
-			scale
-		));
-
-		scale = Vector3(1, 1, 1);
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_VALID(jolt_shape, scale, "get_rest_info was passed an invalid transform.");
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	const Transform3D transform_com = transform.translated_local(com_scaled);
@@ -691,34 +603,16 @@ bool JoltPhysicsDirectSpaceState3D::test_body_motion(
 
 	Transform3D transform = p_transform;
 
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(transform.basis.determinant() == 0.0f)) {
-		ERR_PRINT(vformat(
-			"body_test_motion failed due to being passed an invalid transform. "
-			"Its basis was found to be singular, which is not supported by Godot Jolt. "
-			"This is likely caused by one or more axes having a scale of zero. "
-			"Its basis (and thus its scale) will be treated as identity."
-		));
-
-		transform.basis = Basis();
-	}
-#endif // GDJ_CONFIG_EDITOR
+	ENSURE_SCALE_NOT_ZERO(
+		transform,
+		vformat(
+			"body_test_motion was passed an invalid transform along with body '%s'.",
+			p_body.to_string()
+		)
+	);
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
-
-#ifdef GDJ_CONFIG_EDITOR
-	if (unlikely(!p_body.get_jolt_shape()->IsValidScale(to_jolt(scale)))) {
-		ERR_PRINT(vformat(
-			"body_test_motion failed due to being passed an invalid transform. "
-			"A scale of %v is not supported by Godot Jolt for this shape type. "
-			"Its scale will instead be treated as (1, 1, 1).",
-			scale
-		));
-
-		scale = Vector3(1, 1, 1);
-	}
-#endif // GDJ_CONFIG_EDITOR
 
 	space->try_optimize();
 
@@ -1070,11 +964,16 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_cast(
 		const Transform3D transform_com = body_transform * transform_com_local;
 		const Transform3D transform_com_unscaled = Math::decomposed(transform_com, scale);
 
-#ifdef GDJ_CONFIG_EDITOR
-		if (!jolt_shape->IsValidScale(to_jolt(scale))) {
-			continue;
-		}
-#endif // GDJ_CONFIG_EDITOR
+		ENSURE_SCALE_VALID(
+			jolt_shape,
+			scale,
+			vformat(
+				"body_test_motion was passed an invalid transform along with body '%s'. "
+				"This results in invalid scaling for shape at index %d.",
+				i,
+				p_body.to_string()
+			)
+		);
 
 		real_t shape_safe_fraction = 1.0;
 		real_t shape_unsafe_fraction = 1.0;


### PR DESCRIPTION
Fixes #912.

This refactors the error-handling for scaling introduced in #810.

The current usage of `JPH::Shape::IsValidScale` poses some problems in the context of Godot, since the tolerance of `JPH::Shape::IsValidScale` is (understandably) quite small, and Godot doesn't do any sort of automatic orthonormalization of its transforms, which means that it doesn't take many frames for something like the rotation of a `CharacterBody3D` to start messing with the orthogonality of its transforms, thereby resulting in weird scaling and potentially causing `JPH::Shape::IsValidScale` to fail.

The technically correct resolution to this would of course be for the user to just orthonormalize its transforms, or for this extension to disregard scaling completely (like Godot Physics does), but given the friction involved with this, and the fact that some users have come to appreciate and rely on the (undocumented) support for scaling in this extension, a compromise has been reached instead.

This PR makes use of the newly introduced `JPH::Shape::MakeScaleValid`, which takes any arbitrary scaling and changes it just enough to be valid for the given shape. This means that we can make sure that Jolt always receives a correct scaling, but better yet we can also check to see how different this new valid scaling is from the one we put in, and emit an error based on a tolerance that we define ourselves.

So this effectively raises the tolerance from `0.0001`-ish to `0.01`. This will make sure that clearly incorrect scaling, such as deliberately scaling a capsule or sphere non-uniformly, will emit errors, but scaling as a result of accumulative precision errors are only reported if they're really bad.

Note that the correction of the scale (i.e. `JPH::Shape::MakeScaleValid`) happens regardless of build, whereas the error-reporting only happens in editor/debug builds.