### PR TITLE
Added waking of bodies when modifying joints

### DIFF
--- a/src/joints/jolt_cone_twist_joint_impl_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.cpp
@@ -365,24 +365,30 @@ void JoltConeTwistJointImpl3D::_update_twist_motor_limit() {
 
 void JoltConeTwistJointImpl3D::_limits_changed() {
 	rebuild();
+	_wake_up_bodies();
 }
 
 void JoltConeTwistJointImpl3D::_swing_motor_state_changed() {
 	_update_swing_motor_state();
+	_wake_up_bodies();
 }
 
 void JoltConeTwistJointImpl3D::_twist_motor_state_changed() {
 	_update_twist_motor_state();
+	_wake_up_bodies();
 }
 
 void JoltConeTwistJointImpl3D::_motor_velocity_changed() {
 	_update_motor_velocity();
+	_wake_up_bodies();
 }
 
 void JoltConeTwistJointImpl3D::_swing_motor_limit_changed() {
 	_update_swing_motor_limit();
+	_wake_up_bodies();
 }
 
 void JoltConeTwistJointImpl3D::_twist_motor_limit_changed() {
 	_update_twist_motor_limit();
+	_wake_up_bodies();
 }

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.cpp
@@ -635,33 +635,41 @@ void JoltGeneric6DOFJointImpl3D::_update_spring_equilibrium(int32_t p_axis) {
 
 void JoltGeneric6DOFJointImpl3D::_limits_changed() {
 	rebuild();
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_limit_spring_parameters_changed(int32_t p_axis) {
 	_update_limit_spring_parameters(p_axis);
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_motor_state_changed(int32_t p_axis) {
 	_update_motor_state(p_axis);
 	_update_motor_limit(p_axis);
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_motor_speed_changed(int32_t p_axis) {
 	_update_motor_velocity(p_axis);
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_motor_limit_changed(int32_t p_axis) {
 	_update_motor_limit(p_axis);
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_spring_state_changed(int32_t p_axis) {
 	_update_motor_state(p_axis);
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_spring_parameters_changed(int32_t p_axis) {
 	_update_spring_parameters(p_axis);
+	_wake_up_bodies();
 }
 
 void JoltGeneric6DOFJointImpl3D::_spring_equilibrium_changed(int32_t p_axis) {
 	_update_spring_equilibrium(p_axis);
+	_wake_up_bodies();
 }

--- a/src/joints/jolt_hinge_joint_impl_3d.cpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.cpp
@@ -396,20 +396,25 @@ void JoltHingeJointImpl3D::_update_motor_limit() {
 
 void JoltHingeJointImpl3D::_limits_changed() {
 	rebuild();
+	_wake_up_bodies();
 }
 
 void JoltHingeJointImpl3D::_limit_spring_changed() {
 	rebuild();
+	_wake_up_bodies();
 }
 
 void JoltHingeJointImpl3D::_motor_state_changed() {
 	_update_motor_state();
+	_wake_up_bodies();
 }
 
 void JoltHingeJointImpl3D::_motor_speed_changed() {
 	_update_motor_velocity();
+	_wake_up_bodies();
 }
 
 void JoltHingeJointImpl3D::_motor_limit_changed() {
 	_update_motor_limit();
+	_wake_up_bodies();
 }

--- a/src/joints/jolt_joint_impl_3d.cpp
+++ b/src/joints/jolt_joint_impl_3d.cpp
@@ -190,6 +190,16 @@ void JoltJointImpl3D::_shift_reference_frames(
 	p_shifted_ref_b = Transform3D(basis_b, origin_b);
 }
 
+void JoltJointImpl3D::_wake_up_bodies() {
+	if (body_a != nullptr) {
+		body_a->wake_up();
+	}
+
+	if (body_b != nullptr) {
+		body_b->wake_up();
+	}
+}
+
 void JoltJointImpl3D::_update_enabled() {
 	if (jolt_ref != nullptr) {
 		jolt_ref->SetEnabled(enabled);
@@ -205,10 +215,12 @@ void JoltJointImpl3D::_update_iterations() {
 
 void JoltJointImpl3D::_enabled_changed() {
 	_update_enabled();
+	_wake_up_bodies();
 }
 
 void JoltJointImpl3D::_iterations_changed() {
 	_update_iterations();
+	_wake_up_bodies();
 }
 
 String JoltJointImpl3D::_bodies_to_string() const {

--- a/src/joints/jolt_joint_impl_3d.hpp
+++ b/src/joints/jolt_joint_impl_3d.hpp
@@ -59,6 +59,8 @@ protected:
 		Transform3D& p_shifted_ref_b
 	);
 
+	void _wake_up_bodies();
+
 	void _update_enabled();
 
 	void _update_iterations();

--- a/src/joints/jolt_pin_joint_impl_3d.cpp
+++ b/src/joints/jolt_pin_joint_impl_3d.cpp
@@ -161,4 +161,5 @@ JPH::Constraint* JoltPinJointImpl3D::_build_pin(
 
 void JoltPinJointImpl3D::_points_changed() {
 	rebuild();
+	_wake_up_bodies();
 }

--- a/src/joints/jolt_slider_joint_impl_3d.cpp
+++ b/src/joints/jolt_slider_joint_impl_3d.cpp
@@ -598,20 +598,25 @@ void JoltSliderJointImpl3D::_update_motor_limit() {
 
 void JoltSliderJointImpl3D::_limits_changed() {
 	rebuild();
+	_wake_up_bodies();
 }
 
 void JoltSliderJointImpl3D::_limit_spring_changed() {
 	rebuild();
+	_wake_up_bodies();
 }
 
 void JoltSliderJointImpl3D::_motor_state_changed() {
 	_update_motor_state();
+	_wake_up_bodies();
 }
 
 void JoltSliderJointImpl3D::_motor_speed_changed() {
 	_update_motor_velocity();
+	_wake_up_bodies();
 }
 
 void JoltSliderJointImpl3D::_motor_limit_changed() {
 	_update_motor_limit();
+	_wake_up_bodies();
 }


### PR DESCRIPTION
Modifying a joint, like changing the equilibrium point of a sprung joint, while the bodies connected to it are sleeping, won't actually wake up to reflect its new value.

This PR fixes that by waking up both bodies when any modification is done to any joint.