### PR TITLE
Removed redundant override of `JPH::Shape::IsValidScale`

### DIFF
--- a/src/shapes/jolt_custom_decorated_shape.hpp
+++ b/src/shapes/jolt_custom_decorated_shape.hpp
@@ -226,8 +226,4 @@ public:
 	Stats GetStats() const override { return {sizeof(*this), 0}; }
 
 	float GetVolume() const override { return mInnerShape->GetVolume(); }
-
-	bool IsValidScale(JPH::Vec3Arg p_scale) const override {
-		return mInnerShape->IsValidScale(p_scale);
-	}
 };


### PR DESCRIPTION
With `JPH::DecoratedShape` now overriding `IsValidScale` there's no longer any need for `JoltCustomDecoratedShape` to do so.