### PR TITLE
Flipped rotation for joint's angular limit gizmo again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ Breaking changes are denoted with ⚠️.
 - ⚠️ Changed the inertia of shapeless bodies to be `(1, 1, 1)`, to match Godot Physics.
 - Changed `SeparationRayShape3D` to not treat other convex shapes as solid, meaning it will now only
   ever collide with the hull of other convex shapes, which better matches Godot Physics.
-- Mirrored the way in which angular limits are visualized for `JoltHingeJoint3D`,
-  `JoltConeTwistJoint3D` and `JoltGeneric6DOFJoint`.
 
 ### Added
 

--- a/src/joints/jolt_joint_gizmo_plugin_3d.cpp
+++ b/src/joints/jolt_joint_gizmo_plugin_3d.cpp
@@ -82,8 +82,8 @@ void draw_angular_limits(
 	auto calculate_point = [&](int32_t p_index) {
 		const float angle = p_limit_lower + angle_step * (float)p_index;
 
-		const float x = GIZMO_RADIUS * cosf(-angle);
-		const float y = GIZMO_RADIUS * sinf(-angle);
+		const float x = GIZMO_RADIUS * Math::cos(angle);
+		const float y = GIZMO_RADIUS * Math::sin(angle);
 
 		return to_3d(p_axis, x, y);
 	};


### PR DESCRIPTION
This effectively reverts #862. In hindsight this change just made things weird in a different way (arguably worse), rather than fixing anything.

The actual problem of #855 is that the gizmo doesn't take the reference frames of the bodies into account when drawing, so will never really represent the true start and end point of the angular limits.

I'm not sure this can ever really be fixed to make every arrangement intuitive, but that's a problem for another day.