### PR TITLE
Added support for `WorldBoundaryShape3D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `WorldBoundaryShape3D`.
+
 ### Fixed
 
 - Fixed issue with `SoftBody3D` not waking up when doing things like changing its `total_mass`,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ should not be relied upon if determinism is a hard requirement.
 
 ## What's not supported?
 
-- `WorldBoundaryShape3D` is not supported
 - The physics server is not thread-safe (yet)
 - Memory usage is not reflected in Godot's performance monitors (yet)
 - Ray-casts do not support `face_index`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -400,6 +400,12 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Limits</td>
+      <td>World Boundary Shape Size</td>
+      <td>How wide/high/deep a <code>WorldBoundaryShape3D</code> will be.</td>
+      <td>Note that only half of this value will be used for its height.</td>
+    </tr>
+    <tr>
+      <td>Limits</td>
       <td>Max Linear Velocity</td>
       <td>The maximum linear velocity that a body can reach.</td>
       <td>Meant to prevent the simulation from exploding if something goes wrong.</td>

--- a/examples/scenes/shapes/shapes.tscn
+++ b/examples/scenes/shapes/shapes.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://bua2ujukcadgw"]
+[gd_scene load_steps=17 format=3 uid="uid://bua2ujukcadgw"]
 
 [ext_resource type="Environment" uid="uid://cgl5t5rlv6o6v" path="res://scenes/common/environments/default.tres" id="1_3khfi"]
 [ext_resource type="Script" path="res://scenes/common/scripts/free_look_camera.gd" id="1_uh1hw"]
@@ -10,6 +10,23 @@
 [ext_resource type="PackedScene" uid="uid://cqqkfrnystsat" path="res://scenes/shapes/entities/convex_polygon/convex_polygon.tscn" id="7_objwy"]
 [ext_resource type="PackedScene" uid="uid://cco8tutfmoey8" path="res://scenes/shapes/entities/height_map/height_map.tscn" id="8_8j6mc"]
 [ext_resource type="PackedScene" uid="uid://dosgsvakfplrm" path="res://scenes/shapes/entities/concave_polygon/concave_polygon.tscn" id="9_i15bi"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_714qv"]
+plane = Plane(1, 0, 0, 0)
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_gcpy5"]
+plane = Plane(-1, 0, 0, 0)
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_8sn1p"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_opywq"]
+plane = Plane(0, -1, 0, 0)
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_l2aow"]
+plane = Plane(0, 0, 1, 0)
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_54h13"]
+plane = Plane(0, 0, -1, 0)
 
 [node name="Shapes" type="Node3D"]
 
@@ -52,3 +69,29 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
 
 [node name="ConcavePolygon" parent="." instance=ExtResource("9_i15bi")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+
+[node name="WorldBoundaries" type="StaticBody3D" parent="."]
+
+[node name="Left" type="CollisionShape3D" parent="WorldBoundaries"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 0, 0)
+shape = SubResource("WorldBoundaryShape3D_714qv")
+
+[node name="Right" type="CollisionShape3D" parent="WorldBoundaries"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, 0)
+shape = SubResource("WorldBoundaryShape3D_gcpy5")
+
+[node name="Bottom" type="CollisionShape3D" parent="WorldBoundaries"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -20, 0)
+shape = SubResource("WorldBoundaryShape3D_8sn1p")
+
+[node name="Top" type="CollisionShape3D" parent="WorldBoundaries"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 20, 0)
+shape = SubResource("WorldBoundaryShape3D_opywq")
+
+[node name="Front" type="CollisionShape3D" parent="WorldBoundaries"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -20)
+shape = SubResource("WorldBoundaryShape3D_l2aow")
+
+[node name="Back" type="CollisionShape3D" parent="WorldBoundaries"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 20)
+shape = SubResource("WorldBoundaryShape3D_54h13")

--- a/src/misc/type_conversions.hpp
+++ b/src/misc/type_conversions.hpp
@@ -41,6 +41,10 @@ _FORCE_INLINE_ AABB to_godot(const JPH::AABox& p_aabb) {
 	return {to_godot(p_aabb.mMin), to_godot(p_aabb.mMax - p_aabb.mMin)};
 }
 
+_FORCE_INLINE_ Plane to_godot(const JPH::Plane& p_plane) {
+	return {to_godot(p_plane.GetNormal()), (real_t)p_plane.GetConstant()};
+}
+
 _FORCE_INLINE_ JPH::Vec3 to_jolt(const Vector3& p_vec) {
 	return {(float)p_vec.x, (float)p_vec.y, (float)p_vec.z};
 }
@@ -72,6 +76,10 @@ _FORCE_INLINE_ JPH::String to_jolt(const String& p_str) {
 
 _FORCE_INLINE_ JPH::AABox to_jolt(const AABB& p_aabb) {
 	return {to_jolt(p_aabb.position), to_jolt(p_aabb.position + p_aabb.size)};
+}
+
+_FORCE_INLINE_ JPH::Plane to_jolt(const Plane& p_plane) {
+	return {to_jolt(p_plane.normal), (float)p_plane.d};
 }
 
 _FORCE_INLINE_ JPH::RVec3 to_jolt_r(const Vector3& p_vec) {

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -6,6 +6,7 @@
 #include "objects/jolt_physics_direct_body_state_3d.hpp"
 #include "objects/jolt_soft_body_impl_3d.hpp"
 #include "servers/jolt_project_settings.hpp"
+#include "shapes/jolt_shape_impl_3d.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
 #include "spaces/jolt_space_3d.hpp"
 

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -366,7 +366,7 @@ void JoltShapedObjectImpl3D::post_step(float p_step, JPH::Body& p_jolt_body) {
 bool JoltShapedObjectImpl3D::_is_big() const {
 	// HACK(mihe): This number is completely arbitrary, and mostly just needs to capture any
 	// `WorldBoundaryShape3D`. There could be a better sweet spot to be found here.
-	return get_aabb().get_longest_axis_size() >= 900.0f;
+	return get_aabb().get_longest_axis_size() >= 1000.0f;
 }
 
 JPH::ShapeRefC JoltShapedObjectImpl3D::_try_build_single_shape() {

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -108,6 +108,7 @@
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/Collision/Shape/MutableCompoundShape.h>
 #include <Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h>
+#include <Jolt/Physics/Collision/Shape/PlaneShape.h>
 #include <Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h>
 #include <Jolt/Physics/Collision/Shape/ScaledShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -38,6 +38,7 @@ constexpr char BOUNCE_VELOCITY_THRESHOLD[] = "physics/jolt_3d/solver/bounce_velo
 constexpr char CONTACT_DISTANCE[] = "physics/jolt_3d/solver/contact_speculative_distance";
 constexpr char CONTACT_PENETRATION[] = "physics/jolt_3d/solver/contact_allowed_penetration";
 
+constexpr char WORLD_BOUNDARY_SIZE[] = "physics/jolt_3d/limits/world_boundary_shape_size";
 constexpr char MAX_LINEAR_VELOCITY[] = "physics/jolt_3d/limits/max_linear_velocity";
 constexpr char MAX_ANGULAR_VELOCITY[] = "physics/jolt_3d/limits/max_angular_velocity";
 constexpr char MAX_BODIES[] = "physics/jolt_3d/limits/max_bodies";
@@ -170,6 +171,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(PAIR_CACHE_DISTANCE, 0.001f, U"0,0.01,0.00001,or_greater,suffix:m");
 	register_setting_ranged(PAIR_CACHE_ANGLE, Math::deg_to_rad(2.0f), U"0,180,0.01,radians");
 
+	register_setting_ranged(WORLD_BOUNDARY_SIZE, 2000.0f, U"2,2000,0.1,or_greater,suffix:m");
 	register_setting_ranged(MAX_LINEAR_VELOCITY, 500.0f, U"0,500,0.01,or_greater,suffix:m/s");
 	register_setting_ranged(MAX_ANGULAR_VELOCITY, 2700.0f, U"0,2700,0.01,or_greater,suffix:°/s");
 	register_setting_ranged(MAX_BODIES, 10240, U"1,10240,or_greater", true);
@@ -293,6 +295,11 @@ float JoltProjectSettings::get_pair_cache_distance() {
 
 float JoltProjectSettings::get_pair_cache_angle() {
 	static const auto value = Math::cos(get_setting<float>(PAIR_CACHE_ANGLE) / 2.0f);
+	return value;
+}
+
+float JoltProjectSettings::get_world_boundary_shape_size() {
+	static const auto value = get_setting<float>(WORLD_BOUNDARY_SIZE);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -50,6 +50,8 @@ public:
 
 	static float get_pair_cache_angle();
 
+	static float get_world_boundary_shape_size();
+
 	static float get_max_linear_velocity();
 
 	static float get_max_angular_velocity();

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.cpp
@@ -1,5 +1,7 @@
 #include "jolt_world_boundary_shape_impl_3d.hpp"
 
+#include "servers/jolt_project_settings.hpp"
+
 Variant JoltWorldBoundaryShapeImpl3D::get_data() const {
 	return plane;
 }
@@ -15,11 +17,45 @@ void JoltWorldBoundaryShapeImpl3D::set_data(const Variant& p_data) {
 	destroy();
 }
 
+AABB JoltWorldBoundaryShapeImpl3D::get_aabb() const {
+	const float size = JoltProjectSettings::get_world_boundary_shape_size();
+	const float half_size = size / 2.0f;
+	return {Vector3(-half_size, -half_size, -half_size), Vector3(size, half_size, size)};
+}
+
+String JoltWorldBoundaryShapeImpl3D::to_string() const {
+	return vformat("{plane=%s}", plane);
+}
+
 JPH::ShapeRefC JoltWorldBoundaryShapeImpl3D::_build() const {
-	ERR_FAIL_D_MSG(vformat(
-		"WorldBoundaryShape3D is not supported by Godot Jolt. "
-		"Consider using one or more reasonably sized BoxShape3D instead. "
-		"This shape belongs to %s.",
-		_owners_to_string()
-	));
+	const Plane normalized_plane = plane.normalized();
+
+	ERR_FAIL_COND_D_MSG(
+		normalized_plane == Plane(),
+		vformat(
+			"Godot Jolt failed to build world boundary shape with %s. "
+			"The plane's normal must not be zero. "
+			"This shape belongs to %s.",
+			to_string(),
+			_owners_to_string()
+		)
+	);
+
+	const float half_size = JoltProjectSettings::get_world_boundary_shape_size() / 2.0f;
+	const JPH::PlaneShapeSettings shape_settings(to_jolt(normalized_plane), nullptr, half_size);
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+
+	ERR_FAIL_COND_D_MSG(
+		shape_result.HasError(),
+		vformat(
+			"Godot Jolt failed to build world boundary shape with %s. "
+			"It returned the following error: '%s'. "
+			"This shape belongs to %s.",
+			to_string(),
+			to_godot(shape_result.GetError()),
+			_owners_to_string()
+		)
+	);
+
+	return shape_result.Get();
 }

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.hpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.hpp
@@ -16,7 +16,9 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
-	AABB get_aabb() const override { return {}; }
+	AABB get_aabb() const override;
+
+	String to_string() const;
 
 private:
 	JPH::ShapeRefC _build() const override;


### PR DESCRIPTION
Fixes #104.

This implements `WorldBoundaryShape3D` using the newly introduced `JPH::PlaneShape` as the underlying Jolt shape.

This also brings with it a project setting for setting the effective size of this plane, which by default is set to 2000 meters.