### PR TITLE
Changed in-space check to also consider Jolt ID

### DIFF
--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -39,7 +39,7 @@ void JoltAreaImpl3D::set_transform(const Transform3D& p_transform) {
 		_shapes_changed();
 	}
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mPosition = to_jolt_r(new_transform.origin);
 		jolt_settings->mRotation = to_jolt(new_transform.basis);
 	} else {
@@ -613,7 +613,7 @@ void JoltAreaImpl3D::_force_areas_exited(bool p_remove) {
 }
 
 void JoltAreaImpl3D::_update_group_filter() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -62,7 +62,7 @@ void JoltBodyImpl3D::set_transform(Transform3D p_transform) {
 		_shapes_changed();
 	}
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mPosition = to_jolt_r(p_transform.origin);
 		jolt_settings->mRotation = to_jolt(p_transform.basis);
 	} else if (is_kinematic()) {
@@ -212,7 +212,7 @@ void JoltBodyImpl3D::set_custom_integrator(bool p_enabled) {
 
 	custom_integrator = p_enabled;
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 
@@ -224,7 +224,7 @@ void JoltBodyImpl3D::set_custom_integrator(bool p_enabled) {
 }
 
 bool JoltBodyImpl3D::is_sleeping() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or
 		// less impossible to have a body be sleeping when created, so we simply report this as not
 		// sleeping.
@@ -238,7 +238,7 @@ bool JoltBodyImpl3D::is_sleeping() const {
 }
 
 void JoltBodyImpl3D::set_is_sleeping(bool p_enabled) {
-	if (space == nullptr) {
+	if (!in_space()) {
 		// HACK(mihe): Since `BODY_STATE_TRANSFORM` will be set right after creation it's more or
 		// less impossible to have a body be sleeping when created, so we don't bother storing this.
 		return;
@@ -254,7 +254,7 @@ void JoltBodyImpl3D::set_is_sleeping(bool p_enabled) {
 }
 
 bool JoltBodyImpl3D::can_sleep() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return jolt_settings->mAllowSleeping;
 	}
 
@@ -265,7 +265,7 @@ bool JoltBodyImpl3D::can_sleep() const {
 }
 
 void JoltBodyImpl3D::set_can_sleep(bool p_enabled) {
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mAllowSleeping = p_enabled;
 		return;
 	}
@@ -351,7 +351,7 @@ void JoltBodyImpl3D::set_linear_velocity(const Vector3& p_velocity) {
 		return;
 	}
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mLinearVelocity = to_jolt(p_velocity);
 		return;
 	}
@@ -372,7 +372,7 @@ void JoltBodyImpl3D::set_angular_velocity(const Vector3& p_velocity) {
 		return;
 	}
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mAngularVelocity = to_jolt(p_velocity);
 		return;
 	}
@@ -390,7 +390,7 @@ void JoltBodyImpl3D::set_axis_velocity(const Vector3& p_axis_velocity) {
 
 	const Vector3 axis = p_axis_velocity.normalized();
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		Vector3 linear_velocity = to_godot(jolt_settings->mLinearVelocity);
 		linear_velocity -= axis * axis.dot(linear_velocity);
 		linear_velocity += p_axis_velocity;
@@ -407,7 +407,7 @@ void JoltBodyImpl3D::set_axis_velocity(const Vector3& p_axis_velocity) {
 }
 
 Vector3 JoltBodyImpl3D::get_velocity_at_position(const Vector3& p_position) const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return {};
 	}
 
@@ -451,7 +451,7 @@ void JoltBodyImpl3D::set_max_contacts_reported(int32_t p_count) {
 
 	const bool use_manifold_reduction = !reports_contacts();
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mUseManifoldReduction = use_manifold_reduction;
 		return;
 	}
@@ -880,7 +880,7 @@ void JoltBodyImpl3D::set_mode(PhysicsServer3D::BodyMode p_mode) {
 
 	mode = p_mode;
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 
@@ -909,7 +909,7 @@ void JoltBodyImpl3D::set_mode(PhysicsServer3D::BodyMode p_mode) {
 }
 
 bool JoltBodyImpl3D::is_ccd_enabled() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return jolt_settings->mMotionQuality == JPH::EMotionQuality::LinearCast;
 	}
 
@@ -923,7 +923,7 @@ void JoltBodyImpl3D::set_ccd_enabled(bool p_enabled) {
 		? JPH::EMotionQuality::LinearCast
 		: JPH::EMotionQuality::Discrete;
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mMotionQuality = motion_quality;
 		return;
 	}
@@ -948,7 +948,7 @@ void JoltBodyImpl3D::set_inertia(const Vector3& p_inertia) {
 }
 
 float JoltBodyImpl3D::get_bounce() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return jolt_settings->mRestitution;
 	}
 
@@ -959,7 +959,7 @@ float JoltBodyImpl3D::get_bounce() const {
 }
 
 void JoltBodyImpl3D::set_bounce(float p_bounce) {
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mRestitution = p_bounce;
 		return;
 	}
@@ -971,7 +971,7 @@ void JoltBodyImpl3D::set_bounce(float p_bounce) {
 }
 
 float JoltBodyImpl3D::get_friction() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return jolt_settings->mFriction;
 	}
 
@@ -982,7 +982,7 @@ float JoltBodyImpl3D::get_friction() const {
 }
 
 void JoltBodyImpl3D::set_friction(float p_friction) {
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mFriction = p_friction;
 		return;
 	}
@@ -1314,7 +1314,7 @@ JPH::MassProperties JoltBodyImpl3D::_calculate_mass_properties() const {
 }
 
 void JoltBodyImpl3D::_update_mass_properties() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 
@@ -1352,7 +1352,7 @@ void JoltBodyImpl3D::_update_gravity(JPH::Body& p_jolt_body) {
 }
 
 void JoltBodyImpl3D::_update_damp() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 
@@ -1426,7 +1426,7 @@ void JoltBodyImpl3D::_update_joint_constraints() {
 void JoltBodyImpl3D::_update_possible_kinematic_contacts() {
 	const bool value = reports_all_kinematic_contacts();
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mCollideKinematicVsNonDynamic = value;
 	} else {
 		const JoltWritableBody3D body = space->write_body(jolt_id);
@@ -1453,7 +1453,7 @@ void JoltBodyImpl3D::_exit_all_areas() {
 void JoltBodyImpl3D::_update_group_filter() {
 	JPH::GroupFilter* group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mCollisionGroup.SetGroupFilter(group_filter);
 		return;
 	}

--- a/src/objects/jolt_object_impl_3d.cpp
+++ b/src/objects/jolt_object_impl_3d.cpp
@@ -117,7 +117,7 @@ String JoltObjectImpl3D::to_string() const {
 }
 
 void JoltObjectImpl3D::_update_object_layer() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 

--- a/src/objects/jolt_object_impl_3d.hpp
+++ b/src/objects/jolt_object_impl_3d.hpp
@@ -84,6 +84,8 @@ public:
 
 	void set_space(JoltSpace3D* p_space);
 
+	bool in_space() const { return space != nullptr && !jolt_id.IsInvalid(); }
+
 	uint32_t get_collision_layer() const { return collision_layer; }
 
 	void set_collision_layer(uint32_t p_layer);

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -20,7 +20,7 @@ JoltShapedObjectImpl3D::~JoltShapedObjectImpl3D() {
 }
 
 Transform3D JoltShapedObjectImpl3D::get_transform_unscaled() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return {to_godot(jolt_settings->mRotation), to_godot(jolt_settings->mPosition)};
 	}
 
@@ -35,7 +35,7 @@ Transform3D JoltShapedObjectImpl3D::get_transform_scaled() const {
 }
 
 Basis JoltShapedObjectImpl3D::get_basis() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return to_godot(jolt_settings->mRotation);
 	}
 
@@ -46,7 +46,7 @@ Basis JoltShapedObjectImpl3D::get_basis() const {
 }
 
 Vector3 JoltShapedObjectImpl3D::get_position() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return to_godot(jolt_settings->mPosition);
 	}
 
@@ -88,7 +88,7 @@ Vector3 JoltShapedObjectImpl3D::get_center_of_mass_local() const {
 }
 
 Vector3 JoltShapedObjectImpl3D::get_linear_velocity() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return to_godot(jolt_settings->mLinearVelocity);
 	}
 
@@ -99,7 +99,7 @@ Vector3 JoltShapedObjectImpl3D::get_linear_velocity() const {
 }
 
 Vector3 JoltShapedObjectImpl3D::get_angular_velocity() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return to_godot(jolt_settings->mAngularVelocity);
 	}
 
@@ -164,7 +164,7 @@ JPH::ShapeRefC JoltShapedObjectImpl3D::build_shape() {
 }
 
 void JoltShapedObjectImpl3D::update_shape() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		_shapes_built();
 		return;
 	}

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -74,7 +74,7 @@ void JoltSoftBodyImpl3D::set_mesh(const RID& p_mesh) {
 }
 
 bool JoltSoftBodyImpl3D::is_sleeping() const {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return false;
 	}
 
@@ -85,7 +85,7 @@ bool JoltSoftBodyImpl3D::is_sleeping() const {
 }
 
 void JoltSoftBodyImpl3D::set_is_sleeping(bool p_enabled) {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 
@@ -646,7 +646,7 @@ void JoltSoftBodyImpl3D::_update_mass() {
 }
 
 void JoltSoftBodyImpl3D::_update_pressure() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mPressure = pressure;
 		return;
 	}
@@ -664,7 +664,7 @@ void JoltSoftBodyImpl3D::_update_pressure() {
 }
 
 void JoltSoftBodyImpl3D::_update_damping() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mLinearDamping = linear_damping;
 		return;
 	}
@@ -682,7 +682,7 @@ void JoltSoftBodyImpl3D::_update_damping() {
 }
 
 void JoltSoftBodyImpl3D::_update_simulation_precision() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mNumIterations = (JPH::uint32)simulation_precision;
 		return;
 	}
@@ -702,7 +702,7 @@ void JoltSoftBodyImpl3D::_update_simulation_precision() {
 void JoltSoftBodyImpl3D::_update_group_filter() {
 	JPH::GroupFilter* group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
 
-	if (space == nullptr) {
+	if (!in_space()) {
 		jolt_settings->mCollisionGroup.SetGroupFilter(group_filter);
 		return;
 	}


### PR DESCRIPTION
The current way of checking whether the object (body/area) is actually inside a space, by checking to see whether `space` is null, is somewhat incomplete, as there is technically a limbo state where `space` is set but `jolt_id` isn't, resulting in errors being emitted.

This PR adds a new `in_space()` method to also check that the `jolt_id` is valid.