### PR TITLE
Added dedicated broad phase layer for big static objects

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1079,7 +1079,9 @@ bool JoltBodyImpl3D::can_interact_with(const JoltAreaImpl3D& p_other) const {
 JPH::BroadPhaseLayer JoltBodyImpl3D::_get_broad_phase_layer() const {
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {
-			return JoltBroadPhaseLayer::BODY_STATIC;
+			return _is_big()
+				? JoltBroadPhaseLayer::BODY_STATIC_BIG
+				: JoltBroadPhaseLayer::BODY_STATIC;
 		}
 		case PhysicsServer3D::BODY_MODE_KINEMATIC:
 		case PhysicsServer3D::BODY_MODE_RIGID:

--- a/src/objects/jolt_shaped_object_impl_3d.hpp
+++ b/src/objects/jolt_shaped_object_impl_3d.hpp
@@ -26,6 +26,8 @@ public:
 
 	Vector3 get_angular_velocity() const;
 
+	AABB get_aabb() const;
+
 	virtual bool has_custom_center_of_mass() const = 0;
 
 	virtual Vector3 get_center_of_mass_custom() const = 0;
@@ -80,6 +82,8 @@ protected:
 	friend class JoltShapeImpl3D;
 
 	virtual JPH::EMotionType _get_motion_type() const = 0;
+
+	bool _is_big() const;
 
 	JPH::ShapeRefC _try_build_single_shape();
 

--- a/src/shapes/jolt_box_shape_impl_3d.cpp
+++ b/src/shapes/jolt_box_shape_impl_3d.cpp
@@ -36,6 +36,10 @@ String JoltBoxShapeImpl3D::to_string() const {
 	return vformat("{half_extents=%v margin=%f}", half_extents, margin);
 }
 
+AABB JoltBoxShapeImpl3D::get_aabb() const {
+	return {-half_extents, half_extents * 2.0f};
+}
+
 JPH::ShapeRefC JoltBoxShapeImpl3D::_build() const {
 	const auto min_half_extent = (float)half_extents[half_extents.min_axis_index()];
 	const float shrunk_margin = MIN(margin, min_half_extent * MARGIN_FACTOR);

--- a/src/shapes/jolt_box_shape_impl_3d.hpp
+++ b/src/shapes/jolt_box_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin(float p_margin) override;
 
+	AABB get_aabb() const override;
+
 	String to_string() const;
 
 private:

--- a/src/shapes/jolt_capsule_shape_impl_3d.cpp
+++ b/src/shapes/jolt_capsule_shape_impl_3d.cpp
@@ -29,6 +29,11 @@ void JoltCapsuleShapeImpl3D::set_data(const Variant& p_data) {
 	destroy();
 }
 
+AABB JoltCapsuleShapeImpl3D::get_aabb() const {
+	const Vector3 half_extents(radius, height / 2.0f, radius);
+	return {-half_extents, half_extents * 2.0f};
+}
+
 String JoltCapsuleShapeImpl3D::to_string() const {
 	return vformat("{height=%f radius=%f}", height, radius);
 }

--- a/src/shapes/jolt_capsule_shape_impl_3d.hpp
+++ b/src/shapes/jolt_capsule_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
+	AABB get_aabb() const override;
+
 	String to_string() const;
 
 private:

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -23,6 +23,8 @@ void JoltConcavePolygonShapeImpl3D::set_data(const Variant& p_data) {
 	faces = maybe_faces;
 	backface_collision = maybe_backface_collision;
 
+	aabb = _calculate_aabb();
+
 	destroy();
 }
 
@@ -101,4 +103,20 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 	}
 
 	return shape;
+}
+
+AABB JoltConcavePolygonShapeImpl3D::_calculate_aabb() const {
+	AABB result;
+
+	for (int i = 0; i < faces.size(); ++i) {
+		const Vector3& vertex = faces[i];
+
+		if (i == 0) {
+			result.position = vertex;
+		} else {
+			result.expand_to(vertex);
+		}
+	}
+
+	return result;
 }

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
@@ -16,10 +16,16 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
+	AABB get_aabb() const override { return aabb; }
+
 	String to_string() const;
 
 private:
 	JPH::ShapeRefC _build() const override;
+
+	AABB _calculate_aabb() const;
+
+	AABB aabb;
 
 	PackedVector3Array faces;
 

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.cpp
@@ -11,6 +11,8 @@ void JoltConvexPolygonShapeImpl3D::set_data(const Variant& p_data) {
 
 	vertices = p_data;
 
+	aabb = _calculate_aabb();
+
 	destroy();
 }
 
@@ -71,4 +73,20 @@ JPH::ShapeRefC JoltConvexPolygonShapeImpl3D::_build() const {
 	);
 
 	return shape_result.Get();
+}
+
+AABB JoltConvexPolygonShapeImpl3D::_calculate_aabb() const {
+	AABB result;
+
+	for (int i = 0; i < vertices.size(); ++i) {
+		const Vector3& vertex = vertices[i];
+
+		if (i == 0) {
+			result.position = vertex;
+		} else {
+			result.expand_to(vertex);
+		}
+	}
+
+	return result;
 }

--- a/src/shapes/jolt_convex_polygon_shape_impl_3d.hpp
+++ b/src/shapes/jolt_convex_polygon_shape_impl_3d.hpp
@@ -16,10 +16,16 @@ public:
 
 	void set_margin(float p_margin) override;
 
+	AABB get_aabb() const override { return aabb; }
+
 	String to_string() const;
 
 private:
 	JPH::ShapeRefC _build() const override;
+
+	AABB _calculate_aabb() const;
+
+	AABB aabb;
 
 	PackedVector3Array vertices;
 

--- a/src/shapes/jolt_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.cpp
@@ -46,6 +46,11 @@ void JoltCylinderShapeImpl3D::set_margin(float p_margin) {
 	destroy();
 }
 
+AABB JoltCylinderShapeImpl3D::get_aabb() const {
+	const Vector3 half_extents(radius, height / 2.0f, radius);
+	return {-half_extents, half_extents * 2.0f};
+}
+
 String JoltCylinderShapeImpl3D::to_string() const {
 	return vformat("{height=%f radius=%f margin=%f}", height, radius, margin);
 }

--- a/src/shapes/jolt_cylinder_shape_impl_3d.hpp
+++ b/src/shapes/jolt_cylinder_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin(float p_margin) override;
 
+	AABB get_aabb() const override;
+
 	String to_string() const;
 
 private:

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -33,6 +33,8 @@ void JoltHeightMapShapeImpl3D::set_data(const Variant& p_data) {
 	width = maybe_width;
 	depth = maybe_depth;
 
+	aabb = _calculate_aabb();
+
 	destroy();
 }
 
@@ -217,4 +219,32 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_mesh() const {
 	);
 
 	return shape_result.Get();
+}
+
+AABB JoltHeightMapShapeImpl3D::_calculate_aabb() const {
+	AABB result;
+
+	const int32_t quad_count_x = width - 1;
+	const int32_t quad_count_z = depth - 1;
+
+	const float offset_x = (float)-quad_count_x / 2.0f;
+	const float offset_z = (float)-quad_count_z / 2.0f;
+
+	for (int32_t z = 0; z < depth; ++z) {
+		for (int32_t x = 0; x < width; ++x) {
+			const Vector3 vertex(
+				offset_x + (float)x,
+				(float)heights[z * width + x],
+				offset_z + (float)z
+			);
+
+			if (x == 0 && z == 0) {
+				result.position = vertex;
+			} else {
+				result.expand_to(vertex);
+			}
+		}
+	}
+
+	return result;
 }

--- a/src/shapes/jolt_height_map_shape_impl_3d.hpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
+	AABB get_aabb() const override { return aabb; }
+
 	String to_string() const;
 
 private:
@@ -24,6 +26,10 @@ private:
 	JPH::ShapeRefC _build_height_field() const;
 
 	JPH::ShapeRefC _build_mesh() const;
+
+	AABB _calculate_aabb() const;
+
+	AABB aabb;
 
 #ifdef REAL_T_IS_DOUBLE
 	PackedFloat64Array heights;

--- a/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
+++ b/src/shapes/jolt_separation_ray_shape_impl_3d.cpp
@@ -31,6 +31,12 @@ void JoltSeparationRayShapeImpl3D::set_data(const Variant& p_data) {
 	destroy();
 }
 
+AABB JoltSeparationRayShapeImpl3D::get_aabb() const {
+	constexpr float size_xy = 0.1f;
+	constexpr float half_size_xy = size_xy / 2.0f;
+	return {Vector3(-half_size_xy, -half_size_xy, 0.0f), Vector3(size_xy, size_xy, length)};
+}
+
 String JoltSeparationRayShapeImpl3D::to_string() const {
 	return vformat("{length=%f slide_on_slope=%s}", length, slide_on_slope);
 }

--- a/src/shapes/jolt_separation_ray_shape_impl_3d.hpp
+++ b/src/shapes/jolt_separation_ray_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
+	AABB get_aabb() const override;
+
 	String to_string() const;
 
 private:

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -30,6 +30,8 @@ public:
 
 	virtual void set_margin(float p_margin) = 0;
 
+	virtual AABB get_aabb() const = 0;
+
 	float get_solver_bias() const;
 
 	void set_solver_bias(float p_bias);

--- a/src/shapes/jolt_shape_instance_3d.cpp
+++ b/src/shapes/jolt_shape_instance_3d.cpp
@@ -32,6 +32,10 @@ JoltShapeInstance3D::~JoltShapeInstance3D() {
 	}
 }
 
+AABB JoltShapeInstance3D::get_aabb() const {
+	return get_transform_scaled().xform(shape->get_aabb());
+}
+
 bool JoltShapeInstance3D::try_build() {
 	ERR_FAIL_COND_D(is_disabled());
 

--- a/src/shapes/jolt_shape_instance_3d.hpp
+++ b/src/shapes/jolt_shape_instance_3d.hpp
@@ -35,6 +35,8 @@ public:
 
 	void set_scale(const Vector3& p_scale) { scale = p_scale; }
 
+	AABB get_aabb() const;
+
 	bool is_built() const { return jolt_ref != nullptr; }
 
 	bool is_enabled() const { return !disabled; }

--- a/src/shapes/jolt_sphere_shape_impl_3d.cpp
+++ b/src/shapes/jolt_sphere_shape_impl_3d.cpp
@@ -15,6 +15,11 @@ void JoltSphereShapeImpl3D::set_data(const Variant& p_data) {
 	destroy();
 }
 
+AABB JoltSphereShapeImpl3D::get_aabb() const {
+	const Vector3 half_extents(radius, radius, radius);
+	return {-half_extents, half_extents * 2.0f};
+}
+
 String JoltSphereShapeImpl3D::to_string() const {
 	return vformat("{radius=%f}", radius);
 }

--- a/src/shapes/jolt_sphere_shape_impl_3d.hpp
+++ b/src/shapes/jolt_sphere_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
+	AABB get_aabb() const override;
+
 	String to_string() const;
 
 private:

--- a/src/shapes/jolt_world_boundary_shape_impl_3d.hpp
+++ b/src/shapes/jolt_world_boundary_shape_impl_3d.hpp
@@ -16,6 +16,8 @@ public:
 
 	void set_margin([[maybe_unused]] float p_margin) override { }
 
+	AABB get_aabb() const override { return {}; }
+
 private:
 	JPH::ShapeRefC _build() const override;
 

--- a/src/spaces/jolt_broad_phase_layer.hpp
+++ b/src/spaces/jolt_broad_phase_layer.hpp
@@ -4,11 +4,12 @@
 namespace JoltBroadPhaseLayer {
 
 constexpr JPH::BroadPhaseLayer BODY_STATIC(0);
-constexpr JPH::BroadPhaseLayer BODY_DYNAMIC(1);
-constexpr JPH::BroadPhaseLayer AREA_DETECTABLE(2);
-constexpr JPH::BroadPhaseLayer AREA_UNDETECTABLE(3);
+constexpr JPH::BroadPhaseLayer BODY_STATIC_BIG(1);
+constexpr JPH::BroadPhaseLayer BODY_DYNAMIC(2);
+constexpr JPH::BroadPhaseLayer AREA_DETECTABLE(3);
+constexpr JPH::BroadPhaseLayer AREA_UNDETECTABLE(4);
 
-constexpr uint32_t COUNT = 4;
+constexpr uint32_t COUNT = 5;
 
 static_assert(COUNT <= 8);
 

--- a/src/spaces/jolt_layer_mapper.cpp
+++ b/src/spaces/jolt_layer_mapper.cpp
@@ -15,24 +15,27 @@ public:
 		using namespace JoltBroadPhaseLayer;
 
 		allow_collision(BODY_STATIC, BODY_DYNAMIC);
-
+		allow_collision(BODY_STATIC_BIG, BODY_DYNAMIC);
 		allow_collision(BODY_DYNAMIC, BODY_STATIC);
+		allow_collision(BODY_DYNAMIC, BODY_STATIC_BIG);
 		allow_collision(BODY_DYNAMIC, BODY_DYNAMIC);
 		allow_collision(BODY_DYNAMIC, AREA_DETECTABLE);
 		allow_collision(BODY_DYNAMIC, AREA_UNDETECTABLE);
-
 		allow_collision(AREA_DETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_DETECTABLE, AREA_DETECTABLE);
 		allow_collision(AREA_DETECTABLE, AREA_UNDETECTABLE);
-
 		allow_collision(AREA_UNDETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_UNDETECTABLE, AREA_DETECTABLE);
 
 		if (JoltProjectSettings::areas_detect_static_bodies()) {
 			allow_collision(BODY_STATIC, AREA_DETECTABLE);
 			allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
+			allow_collision(BODY_STATIC_BIG, AREA_DETECTABLE);
+			allow_collision(BODY_STATIC_BIG, AREA_UNDETECTABLE);
 			allow_collision(AREA_DETECTABLE, BODY_STATIC);
+			allow_collision(AREA_DETECTABLE, BODY_STATIC_BIG);
 			allow_collision(AREA_UNDETECTABLE, BODY_STATIC);
+			allow_collision(AREA_UNDETECTABLE, BODY_STATIC_BIG);
 		}
 	}
 
@@ -158,6 +161,9 @@ const char* JoltLayerMapper::GetBroadPhaseLayerName(JPH::BroadPhaseLayer p_layer
 	switch ((JPH::BroadPhaseLayer::Type)p_layer) {
 		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC: {
 			return "BODY_STATIC";
+		}
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC_BIG: {
+			return "BODY_STATIC_BIG";
 		}
 		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_DYNAMIC: {
 			return "BODY_DYNAMIC";

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -20,6 +20,7 @@ bool JoltMotionFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer)
 
 	switch (broad_phase_layer) {
 		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC:
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC_BIG:
 		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_DYNAMIC: {
 			return true;
 		} break;

--- a/src/spaces/jolt_query_filter_3d.cpp
+++ b/src/spaces/jolt_query_filter_3d.cpp
@@ -24,6 +24,7 @@ bool JoltQueryFilter3D::ShouldCollide(JPH::BroadPhaseLayer p_broad_phase_layer) 
 
 	switch (broad_phase_layer) {
 		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC:
+		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_STATIC_BIG:
 		case (JPH::BroadPhaseLayer::Type)JoltBroadPhaseLayer::BODY_DYNAMIC: {
 			return collide_with_bodies;
 		} break;


### PR DESCRIPTION
Related to #941.

This adds a new broad phase layer called `BODY_STATIC_BIG`, which is meant to be for bodies whose AABB exceeds (the very arbitrary) 900 meters in size on any axis. This should hopefully help keep the spatial partitioning of the standard `BODY_STATIC` layer a bit more balanced/optimized, especially when adding the upcoming `WorldBoundaryShape3D` to a scene.