### PR TITLE
Fixed center-of-mass not being a relative global position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed the `center_of_mass` property of `PhysicsDirectBodyState3D` to be a relative global
+  position rather than an absolute global position, to match Godot Physics.
+
 ### Added
 
 - Added support for `WorldBoundaryShape3D`.

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -697,12 +697,8 @@ void JoltBodyImpl3D::add_constant_force(const Vector3& p_force, const Vector3& p
 	const JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
-	const Vector3 center_of_mass = get_center_of_mass();
-	const Vector3 body_position = get_position();
-	const Vector3 center_of_mass_relative = center_of_mass - body_position;
-
 	constant_force += p_force;
-	constant_torque += (p_position - center_of_mass_relative).cross(p_force);
+	constant_torque += (p_position - get_center_of_mass_relative()).cross(p_force);
 
 	_motion_changed();
 }

--- a/src/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/src/objects/jolt_physics_direct_body_state_3d.cpp
@@ -24,7 +24,7 @@ double JoltPhysicsDirectBodyState3D::_get_total_linear_damp() const {
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass() const {
 	QUIET_FAIL_NULL_D_ED(body);
-	return body->get_center_of_mass();
+	return body->get_center_of_mass_relative();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::_get_center_of_mass_local() const {

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -73,6 +73,10 @@ Vector3 JoltShapedObjectImpl3D::get_center_of_mass() const {
 	return to_godot(body->GetCenterOfMassPosition());
 }
 
+Vector3 JoltShapedObjectImpl3D::get_center_of_mass_relative() const {
+	return get_center_of_mass() - get_position();
+}
+
 Vector3 JoltShapedObjectImpl3D::get_center_of_mass_local() const {
 	ERR_FAIL_NULL_D_MSG(
 		space,

--- a/src/objects/jolt_shaped_object_impl_3d.hpp
+++ b/src/objects/jolt_shaped_object_impl_3d.hpp
@@ -20,6 +20,8 @@ public:
 
 	Vector3 get_center_of_mass() const;
 
+	Vector3 get_center_of_mass_relative() const;
+
 	Vector3 get_center_of_mass_local() const;
 
 	Vector3 get_linear_velocity() const;


### PR DESCRIPTION
Fixes #947.

It seems that there's been a long-standing discrepancy with Godot Physics when it comes to the `center_of_mass` property of `PhysicsDirectBodyState3D`, where we've been reporting an absolute global-space position rather than a relative global-space one like Godot Physics does (and states in its documentation).

This PR changes this to instead match Godot Physics.