### PR TITLE
Added support for `face_index` to ray-casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ Breaking changes are denoted with ⚠️.
 ### Added
 
 - Added support for `WorldBoundaryShape3D`.
+- Added support for `face_index` in ray-cast results.
 - Added project setting "World Boundary Shape Size", to allow changing the effective size of
   `WorldBoundaryShape3D`.
+- Added project setting "Enable Ray Cast Face Index", to allow opting in to the additional memory
+  needed to support `face_index`, which is roughly an additional 25% to every
+  `ConcavePolygonShape3D`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ should not be relied upon if determinism is a hard requirement.
 
 - The physics server is not thread-safe (yet)
 - Memory usage is not reflected in Godot's performance monitors (yet)
-- Ray-casts do not support `face_index`
 - `SoftBody3D` does not support any interactions with `Area3D`
 
 ## What else is different?
@@ -53,6 +52,7 @@ should not be relied upon if determinism is a hard requirement.
 - Springs and linear motors are actually implemented in `Generic6DOFJoint3D`
 - Single-body joints will make `node_a` be the "world node" rather than `node_b`
 - Ray-casts using `hit_back_faces` will hit the back/inside of all shapes, not only concave ones
+- Ray-casts returning `face_index` is opt-in, at a potentially [heavy memory cost][jst]
 - Ray-casts are not affected by the `backface_collision` property of `ConcavePolygonShape3D`
 - Shape-casts should be more accurate, but their cost also scale with the cast distance
 - Shape margins are used, but are treated as an upper bound and scale with the shape's extents

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -334,6 +334,20 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>-</td>
     </tr>
     <tr>
+      <td>Queries</td>
+      <td>Enable Ray Cast Face Index</td>
+      <td>
+        Whether to actually populate the <code>face_index</code> field in the result
+        <code>Dictionary</code> from <code>intersect_ray</code>, also known as
+        <code>get_collision_face_index()</code> in the <code>RayCast3D</code> node.
+      </td>
+      <td>
+        ⚠️ Enabling this can come at a fairly heavy memory cost if you have many (or complex)
+        <code>ConcavePolygonShape3D</code> in your scene, as this roughly adds an additional 25%
+        memory.
+      </td>
+    </tr>
+    <tr>
       <td>Solver</td>
       <td>Velocity Iterations</td>
       <td>The number of solver velocity iterations to run during a physics tick.</td>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -30,6 +30,8 @@ constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetr
 constexpr char RECOVERY_ITERATIONS[] = "physics/jolt_3d/kinematics/recovery_iterations";
 constexpr char RECOVERY_AMOUNT[] = "physics/jolt_3d/kinematics/recovery_amount";
 
+constexpr char RAY_FACE_INDEX[] = "physics/jolt_3d/queries/enable_ray_cast_face_index";
+
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
 constexpr char VELOCITY_ITERATIONS[] = "physics/jolt_3d/solver/velocity_iterations";
 constexpr char POSITION_CORRECTION[] = "physics/jolt_3d/solver/position_correction";
@@ -160,6 +162,8 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(RECOVERY_ITERATIONS, 4, U"1,8,or_greater");
 	register_setting_ranged(RECOVERY_AMOUNT, 40.0f, U"0,100,0.1,suffix:%");
 
+	register_setting_plain(RAY_FACE_INDEX, false);
+
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
 	register_setting_ranged(POSITION_CORRECTION, 20.0f, U"0,100,0.1,suffix:%");
@@ -247,6 +251,11 @@ float JoltProjectSettings::get_kinematic_recovery_amount() {
 
 int32_t JoltProjectSettings::get_velocity_iterations() {
 	static const auto value = get_setting<int32_t>(VELOCITY_ITERATIONS);
+	return value;
+}
+
+bool JoltProjectSettings::enable_ray_cast_face_index() {
+	static const auto value = get_setting<bool>(RAY_FACE_INDEX);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -30,6 +30,8 @@ public:
 
 	static float get_kinematic_recovery_amount();
 
+	static bool enable_ray_cast_face_index();
+
 	static int32_t get_velocity_iterations();
 
 	static int32_t get_position_iterations();

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -66,6 +66,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 
 	const Vector3* faces_begin = &faces[0];
 	const Vector3* faces_end = faces_begin + vertex_count;
+	JPH::uint32 triangle_index = 0;
 
 	for (const Vector3* vertex = faces_begin; vertex != faces_end; vertex += 3) {
 		const Vector3* v0 = vertex + 0;
@@ -75,12 +76,15 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 		jolt_faces.emplace_back(
 			JPH::Float3((float)v2->x, (float)v2->y, (float)v2->z),
 			JPH::Float3((float)v1->x, (float)v1->y, (float)v1->z),
-			JPH::Float3((float)v0->x, (float)v0->y, (float)v0->z)
+			JPH::Float3((float)v0->x, (float)v0->y, (float)v0->z),
+			0,
+			triangle_index++
 		);
 	}
 
 	JPH::MeshShapeSettings shape_settings(jolt_faces);
 	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
+	shape_settings.mPerTriangleUserData = JoltProjectSettings::enable_ray_cast_face_index();
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -143,6 +143,8 @@ private:
 		PhysicsServer3DExtensionMotionResult* p_result
 	) const;
 
+	int _try_get_face_index(const JPH::Body& p_body, const JPH::SubShapeID& p_sub_shape_id);
+
 	void _generate_manifold(
 		const JPH::CollideShapeResult& p_hit,
 		JPH::ContactPoints& p_contact_points1,


### PR DESCRIPTION
Fixes #702.

This adds support for the `face_index` field found in the result `Dictionary` of `intersect_ray`, also known as `get_collision_face_index()` in the `RayCast3D` node.

Note that this feature is opt-in through a new project setting called `physics/jolt_3d/queries/enable_ray_cast_face_index`, as this feature adds roughly an additional 25% extra memory to every `ConcavePolygonShape3D`.