### PR TITLE
Fixed crash when changing mesh of soft body with pinned vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Breaking changes are denoted with ⚠️.
   `damping_coefficient`, `simulation_precision`, or when moving any of its pinned points.
 - Fixed issue where bodies with multiple shapes could end up clipping through other bodies if the
   "Use Enhanced Internal Edge Detection" setting was enabled (which it is by default).
+- Fixed crash when changing the mesh of an in-tree `SoftBody3D` that has pinned vertices.
 
 ## [0.13.0] - 2024-08-15
 

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -18,6 +18,8 @@ public:
 
 	~JoltSoftBodyImpl3D() override;
 
+	bool in_space() const;
+
 	void add_collision_exception(const RID& p_excepted_body);
 
 	void remove_collision_exception(const RID& p_excepted_body);


### PR DESCRIPTION
Probably fixes #951.

There was some problematic error-checking happening in `JoltSoftBodyImpl3D` with regards to checking for valid pin indices, and whether we're actually (properly) inside of a physics space or not, which in some cases could lead to a crash even.

This PR should address all that.

I also threw in some refactoring to clean up some code duplication (`_pin_vertices`).