### PR TITLE
Updated Jolt to 8187798876

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT c08b9e83b90481adb04df81dcfbdf9da3852a935
+	GIT_COMMIT 8187798876e0753b25ef6c6b9a308bf2d1255b8a
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -66,7 +66,7 @@ void collide_ray_vs_shape(
 	const JPH::RayCast ray_cast(ray_start2, ray_vector_padded2);
 
 	JPH::RayCastSettings ray_cast_settings;
-	ray_cast_settings.mBackFaceMode = p_collide_shape_settings.mBackFaceMode;
+	ray_cast_settings.SetBackFaceMode(p_collide_shape_settings.mBackFaceMode);
 	ray_cast_settings.mTreatConvexAsSolid = false;
 
 	JoltQueryCollectorClosest<JPH::CastRayCollector> ray_collector;

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -43,9 +43,10 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 
 	JPH::RayCastSettings settings;
 	settings.mTreatConvexAsSolid = p_hit_from_inside;
-	settings.mBackFaceMode = p_hit_back_faces
-		? JPH::EBackFaceMode::CollideWithBackFaces
-		: JPH::EBackFaceMode::IgnoreBackFaces;
+	settings.SetBackFaceMode(
+		p_hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces
+						 : JPH::EBackFaceMode::IgnoreBackFaces
+	);
 
 	JoltQueryCollectorClosest<JPH::CastRayCollector> collector;
 


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@c08b9e83b90481adb04df81dcfbdf9da3852a935 to godot-jolt/jolt@8187798876e0753b25ef6c6b9a308bf2d1255b8a (see diff [here](https://github.com/godot-jolt/jolt/compare/c08b9e83b90481adb04df81dcfbdf9da3852a935...8187798876e0753b25ef6c6b9a308bf2d1255b8a)).

This brings in the following relevant changes:

- Splits `RayCastSettings::mBackFaceMode` into `mBackFaceModeTriangles` and `mBackFaceModeConvex`.