### PR TITLE
Replaced `radians` property hints with `radians_as_degrees`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where bodies with multiple shapes could end up clipping through other bodies if the
   "Use Enhanced Internal Edge Detection" setting was enabled (which it is by default).
 - Fixed crash when changing the mesh of an in-tree `SoftBody3D` that has pinned vertices.
+- Fixed issue where the joint substitute nodes (`JoltHingeJoint3D`, etc.) would not display their
+  angle properties in degrees when using a `DISABLE_DEPRECATED` build of Godot.
 
 ## [0.13.0] - 2024-08-15
 

--- a/src/joints/jolt_cone_twist_joint_3d.cpp
+++ b/src/joints/jolt_cone_twist_joint_3d.cpp
@@ -50,24 +50,28 @@ void JoltConeTwistJoint3D::_bind_methods() {
 	ADD_GROUP("Swing Limit", "swing_limit_");
 
 	BIND_PROPERTY("swing_limit_enabled", Variant::BOOL);
-	BIND_PROPERTY_RANGED("swing_limit_span", Variant::FLOAT, "-180,180,0.1,radians");
+	BIND_PROPERTY_RANGED("swing_limit_span", Variant::FLOAT, "-180,180,0.1,radians_as_degrees");
 
 	ADD_GROUP("Twist Limit", "twist_limit_");
 
 	BIND_PROPERTY("twist_limit_enabled", Variant::BOOL);
-	BIND_PROPERTY_RANGED("twist_limit_span", Variant::FLOAT, "-180,180,0.1,radians");
+	BIND_PROPERTY_RANGED("twist_limit_span", Variant::FLOAT, "-180,180,0.1,radians_as_degrees");
+
+	// clang-format off
 
 	ADD_GROUP("Swing Motor", "swing_motor_");
 
 	BIND_PROPERTY("swing_motor_enabled", Variant::BOOL);
-	BIND_PROPERTY("swing_motor_target_velocity_y", Variant::FLOAT, U"radians,suffix:°/s");
-	BIND_PROPERTY("swing_motor_target_velocity_z", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("swing_motor_target_velocity_y", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
+	BIND_PROPERTY("swing_motor_target_velocity_z", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
 	BIND_PROPERTY("swing_motor_max_torque", Variant::FLOAT, U"suffix:kg⋅m²/s² (Nm)");
+
+	// clang-format on
 
 	ADD_GROUP("Twist Motor", "twist_motor_");
 
 	BIND_PROPERTY("twist_motor_enabled", Variant::BOOL);
-	BIND_PROPERTY("twist_motor_target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("twist_motor_target_velocity", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
 	BIND_PROPERTY("twist_motor_max_torque", Variant::FLOAT, U"suffix:kg⋅m²/s² (Nm)");
 }
 

--- a/src/joints/jolt_generic_6dof_joint.cpp
+++ b/src/joints/jolt_generic_6dof_joint.cpp
@@ -301,47 +301,51 @@ void JoltGeneric6DOFJoint3D::_bind_methods() {
 	ADD_GROUP("Angular Limit", "angular_limit_");
 
 	BIND_SUBPROPERTY("angular_limit_x", "enabled", Variant::BOOL);
-	BIND_SUBPROPERTY("angular_limit_x", "upper", Variant::FLOAT, "radians");
-	BIND_SUBPROPERTY("angular_limit_x", "lower", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_limit_x", "upper", Variant::FLOAT, "radians_as_degrees");
+	BIND_SUBPROPERTY("angular_limit_x", "lower", Variant::FLOAT, "radians_as_degrees");
 
 	BIND_SUBPROPERTY("angular_limit_y", "enabled", Variant::BOOL);
-	BIND_SUBPROPERTY("angular_limit_y", "upper", Variant::FLOAT, "radians");
-	BIND_SUBPROPERTY("angular_limit_y", "lower", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_limit_y", "upper", Variant::FLOAT, "radians_as_degrees");
+	BIND_SUBPROPERTY("angular_limit_y", "lower", Variant::FLOAT, "radians_as_degrees");
 
 	BIND_SUBPROPERTY("angular_limit_z", "enabled", Variant::BOOL);
-	BIND_SUBPROPERTY("angular_limit_z", "upper", Variant::FLOAT, "radians");
-	BIND_SUBPROPERTY("angular_limit_z", "lower", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_limit_z", "upper", Variant::FLOAT, "radians_as_degrees");
+	BIND_SUBPROPERTY("angular_limit_z", "lower", Variant::FLOAT, "radians_as_degrees");
+
+	// clang-format off
 
 	ADD_GROUP("Angular Motor", "angular_motor_");
 
 	BIND_SUBPROPERTY("angular_motor_x", "enabled", Variant::BOOL);
-	BIND_SUBPROPERTY("angular_motor_x", "target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_SUBPROPERTY("angular_motor_x", "target_velocity", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
 	BIND_SUBPROPERTY("angular_motor_x", "max_torque", Variant::FLOAT, U"suffix:kg⋅m²/s² (Nm)");
 
 	BIND_SUBPROPERTY("angular_motor_y", "enabled", Variant::BOOL);
-	BIND_SUBPROPERTY("angular_motor_y", "target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_SUBPROPERTY("angular_motor_y", "target_velocity", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
 	BIND_SUBPROPERTY("angular_motor_y", "max_torque", Variant::FLOAT, U"suffix:kg⋅m²/s² (Nm)");
 
 	BIND_SUBPROPERTY("angular_motor_z", "enabled", Variant::BOOL);
-	BIND_SUBPROPERTY("angular_motor_z", "target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_SUBPROPERTY("angular_motor_z", "target_velocity", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
 	BIND_SUBPROPERTY("angular_motor_z", "max_torque", Variant::FLOAT, U"suffix:kg⋅m²/s² (Nm)");
+
+	// clang-format on
 
 	ADD_GROUP("Angular Spring", "angular_spring_");
 
 	BIND_SUBPROPERTY("angular_spring_x", "enabled", Variant::BOOL);
 	BIND_SUBPROPERTY("angular_spring_x", "frequency", Variant::FLOAT, "suffix:hz");
 	BIND_SUBPROPERTY("angular_spring_x", "damping", Variant::FLOAT);
-	BIND_SUBPROPERTY("angular_spring_x", "equilibrium_point", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_spring_x", "equilibrium_point", Variant::FLOAT, "radians_as_degrees");
 
 	BIND_SUBPROPERTY("angular_spring_y", "enabled", Variant::BOOL);
 	BIND_SUBPROPERTY("angular_spring_y", "frequency", Variant::FLOAT, "suffix:hz");
 	BIND_SUBPROPERTY("angular_spring_y", "damping", Variant::FLOAT);
-	BIND_SUBPROPERTY("angular_spring_y", "equilibrium_point", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_spring_y", "equilibrium_point", Variant::FLOAT, "radians_as_degrees");
 
 	BIND_SUBPROPERTY("angular_spring_z", "enabled", Variant::BOOL);
 	BIND_SUBPROPERTY("angular_spring_z", "frequency", Variant::FLOAT, "suffix:hz");
 	BIND_SUBPROPERTY("angular_spring_z", "damping", Variant::FLOAT);
-	BIND_SUBPROPERTY("angular_spring_z", "equilibrium_point", Variant::FLOAT, "radians");
+	BIND_SUBPROPERTY("angular_spring_z", "equilibrium_point", Variant::FLOAT, "radians_as_degrees");
 
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_UPPER);
 	BIND_ENUM_CONSTANT(PARAM_LINEAR_LIMIT_LOWER);

--- a/src/joints/jolt_hinge_joint_3d.cpp
+++ b/src/joints/jolt_hinge_joint_3d.cpp
@@ -45,8 +45,8 @@ void JoltHingeJoint3D::_bind_methods() {
 	ADD_GROUP("Limit", "limit_");
 
 	BIND_PROPERTY("limit_enabled", Variant::BOOL);
-	BIND_PROPERTY_RANGED("limit_upper", Variant::FLOAT, "-180,180,0.1,radians");
-	BIND_PROPERTY_RANGED("limit_lower", Variant::FLOAT, "-180,180,0.1,radians");
+	BIND_PROPERTY_RANGED("limit_upper", Variant::FLOAT, "-180,180,0.1,radians_as_degrees");
+	BIND_PROPERTY_RANGED("limit_lower", Variant::FLOAT, "-180,180,0.1,radians_as_degrees");
 
 	ADD_GROUP("Limit Spring", "limit_spring_");
 
@@ -57,7 +57,7 @@ void JoltHingeJoint3D::_bind_methods() {
 	ADD_GROUP("Motor", "motor_");
 
 	BIND_PROPERTY("motor_enabled", Variant::BOOL);
-	BIND_PROPERTY("motor_target_velocity", Variant::FLOAT, U"radians,suffix:°/s");
+	BIND_PROPERTY("motor_target_velocity", Variant::FLOAT, U"radians_as_degrees,suffix:°/s");
 	BIND_PROPERTY("motor_max_torque", Variant::FLOAT, U"suffix:kg⋅m²/s² (Nm)");
 }
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -143,6 +143,8 @@ TType get_setting(const char* p_setting) {
 } // namespace
 
 void JoltProjectSettings::register_settings() {
+	// clang-format off
+
 	register_setting_plain(SLEEP_ENABLED, true);
 	register_setting_hinted(SLEEP_VELOCITY_THRESHOLD, 0.03f, U"suffix:m/s");
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
@@ -167,13 +169,13 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
 	register_setting_ranged(POSITION_ITERATIONS, 2, U"1,16,or_greater");
 	register_setting_ranged(POSITION_CORRECTION, 20.0f, U"0,100,0.1,suffix:%");
-	register_setting_ranged(ACTIVE_EDGE_THRESHOLD, Math::deg_to_rad(50.0f), U"0,90,0.01,radians");
+	register_setting_ranged(ACTIVE_EDGE_THRESHOLD, Math::deg_to_rad(50.0f), U"0,90,0.01,radians_as_degrees");
 	register_setting_hinted(BOUNCE_VELOCITY_THRESHOLD, 1.0f, U"suffix:m/s");
 	register_setting_ranged(CONTACT_DISTANCE, 0.02f, U"0,1,0.00001,or_greater,suffix:m");
 	register_setting_ranged(CONTACT_PENETRATION, 0.02f, U"0,1,0.00001,or_greater,suffix:m");
 	register_setting_plain(PAIR_CACHE_ENABLED, true);
 	register_setting_ranged(PAIR_CACHE_DISTANCE, 0.001f, U"0,0.01,0.00001,or_greater,suffix:m");
-	register_setting_ranged(PAIR_CACHE_ANGLE, Math::deg_to_rad(2.0f), U"0,180,0.01,radians");
+	register_setting_ranged(PAIR_CACHE_ANGLE, Math::deg_to_rad(2.0f), U"0,180,0.01,radians_as_degrees");
 
 	register_setting_ranged(WORLD_BOUNDARY_SIZE, 2000.0f, U"2,2000,0.1,or_greater,suffix:m");
 	register_setting_ranged(MAX_LINEAR_VELOCITY, 500.0f, U"0,500,0.01,or_greater,suffix:m/s");
@@ -182,6 +184,8 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(MAX_PAIRS, 65536, U"8,65536,or_greater");
 	register_setting_ranged(MAX_CONTACTS, 20480, U"8,20480,or_greater");
 	register_setting_ranged(MAX_TEMP_MEMORY, 32, U"1,32,or_greater,suffix:MiB");
+
+	// clang-format on
 }
 
 bool JoltProjectSettings::is_sleep_enabled() {


### PR DESCRIPTION
Fixes #961.

This replaces all usage of the `radians` property hint with the newer `radians_as_degrees`, as the former seems to have been deprecated, causing `DISABLE_DEPRECATED` builds of Godot to display any angle property in radians as opposed to degrees.