### PR TITLE
Changed ray-casting to behave more like in Godot Physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Breaking changes are denoted with ⚠️.
 
 - ⚠️ Changed the `center_of_mass` property of `PhysicsDirectBodyState3D` to be a relative global
   position rather than an absolute global position, to match Godot Physics.
+- ⚠️ Changed the ray-cast parameter `hit_back_faces` to no longer hit the back/inside of convex
+  shapes, to better match Godot Physics. This means `hit_back_faces` will only have an effect on
+  `ConcavePolygonShape3D` and `HeightMapShape3D`.
+- ⚠️ Changed the ray-cast parameter `hit_back_faces` to only hit back-faces of a
+  `ConcavePolygonShape3D` if its `backface_collision` property is set to `true`, to better match
+  Godot Physics.
 
 ### Added
 
@@ -20,6 +26,8 @@ Breaking changes are denoted with ⚠️.
 - Added support for `face_index` in ray-cast results.
 - Added project setting "World Boundary Shape Size", to allow changing the effective size of
   `WorldBoundaryShape3D`.
+- Added project setting "Use Legacy Ray Casting", to allow reverting back to the (now legacy)
+  behavior of the `hit_back_faces` ray-cast parameter.
 - Added project setting "Enable Ray Cast Face Index", to allow opting in to the additional memory
   needed to support `face_index`, which is roughly an additional 25% to every
   `ConcavePolygonShape3D`.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ should not be relied upon if determinism is a hard requirement.
 - Joints only support soft limits through their substitutes (`JoltHingeJoint3D`, etc.)
 - Springs and linear motors are actually implemented in `Generic6DOFJoint3D`
 - Single-body joints will make `node_a` be the "world node" rather than `node_b`
-- Ray-casts using `hit_back_faces` will hit the back/inside of all shapes, not only concave ones
 - Ray-casts returning `face_index` is opt-in, at a potentially [heavy memory cost][jst]
-- Ray-casts are not affected by the `backface_collision` property of `ConcavePolygonShape3D`
 - Shape-casts should be more accurate, but their cost also scale with the cast distance
 - Shape margins are used, but are treated as an upper bound and scale with the shape's extents
 - Manipulating a body's shape(s) after it has entered a scene tree can be costly

--- a/src/objects/jolt_shaped_object_impl_3d.cpp
+++ b/src/objects/jolt_shaped_object_impl_3d.cpp
@@ -165,7 +165,7 @@ JPH::ShapeRefC JoltShapedObjectImpl3D::try_build_shape() {
 	}
 
 	if (is_area()) {
-		result = JoltShapeImpl3D::with_double_sided(result);
+		result = JoltShapeImpl3D::with_double_sided(result, true);
 	}
 
 	return result;

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -30,6 +30,7 @@ constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetr
 constexpr char RECOVERY_ITERATIONS[] = "physics/jolt_3d/kinematics/recovery_iterations";
 constexpr char RECOVERY_AMOUNT[] = "physics/jolt_3d/kinematics/recovery_amount";
 
+constexpr char LEGACY_RAY_CASTING[] = "physics/jolt_3d/queries/use_legacy_ray_casting";
 constexpr char RAY_FACE_INDEX[] = "physics/jolt_3d/queries/enable_ray_cast_face_index";
 
 constexpr char POSITION_ITERATIONS[] = "physics/jolt_3d/solver/position_iterations";
@@ -164,6 +165,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(RECOVERY_ITERATIONS, 4, U"1,8,or_greater");
 	register_setting_ranged(RECOVERY_AMOUNT, 40.0f, U"0,100,0.1,suffix:%");
 
+	register_setting_plain(LEGACY_RAY_CASTING, false, true);
 	register_setting_plain(RAY_FACE_INDEX, false);
 
 	register_setting_ranged(VELOCITY_ITERATIONS, 10, U"2,16,or_greater");
@@ -253,13 +255,18 @@ float JoltProjectSettings::get_kinematic_recovery_amount() {
 	return value;
 }
 
-int32_t JoltProjectSettings::get_velocity_iterations() {
-	static const auto value = get_setting<int32_t>(VELOCITY_ITERATIONS);
+bool JoltProjectSettings::use_legacy_ray_casting() {
+	static const auto value = get_setting<bool>(LEGACY_RAY_CASTING);
 	return value;
 }
 
 bool JoltProjectSettings::enable_ray_cast_face_index() {
 	static const auto value = get_setting<bool>(RAY_FACE_INDEX);
+	return value;
+}
+
+int32_t JoltProjectSettings::get_velocity_iterations() {
+	static const auto value = get_setting<int32_t>(VELOCITY_ITERATIONS);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -30,6 +30,8 @@ public:
 
 	static float get_kinematic_recovery_amount();
 
+	static bool use_legacy_ray_casting();
+
 	static bool enable_ray_cast_face_index();
 
 	static int32_t get_velocity_iterations();

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.cpp
@@ -5,7 +5,7 @@
 Variant JoltConcavePolygonShapeImpl3D::get_data() const {
 	Dictionary data;
 	data["faces"] = faces;
-	data["backface_collision"] = backface_collision;
+	data["backface_collision"] = back_face_collision;
 	return data;
 }
 
@@ -17,11 +17,11 @@ void JoltConcavePolygonShapeImpl3D::set_data(const Variant& p_data) {
 	const Variant maybe_faces = data.get("faces", {});
 	ERR_FAIL_COND(maybe_faces.get_type() != Variant::PACKED_VECTOR3_ARRAY);
 
-	const Variant maybe_backface_collision = data.get("backface_collision", {});
-	ERR_FAIL_COND(maybe_backface_collision.get_type() != Variant::BOOL);
+	const Variant maybe_back_face_collision = data.get("backface_collision", {});
+	ERR_FAIL_COND(maybe_back_face_collision.get_type() != Variant::BOOL);
 
 	faces = maybe_faces;
-	backface_collision = maybe_backface_collision;
+	back_face_collision = maybe_back_face_collision;
 
 	aabb = _calculate_aabb();
 
@@ -100,13 +100,7 @@ JPH::ShapeRefC JoltConcavePolygonShapeImpl3D::_build() const {
 		)
 	);
 
-	JPH::ShapeRefC shape = shape_result.Get();
-
-	if (backface_collision) {
-		return JoltShapeImpl3D::with_double_sided(shape);
-	}
-
-	return shape;
+	return JoltShapeImpl3D::with_double_sided(shape_result.Get(), back_face_collision);
 }
 
 AABB JoltConcavePolygonShapeImpl3D::_calculate_aabb() const {

--- a/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
+++ b/src/shapes/jolt_concave_polygon_shape_impl_3d.hpp
@@ -29,5 +29,5 @@ private:
 
 	PackedVector3Array faces;
 
-	bool backface_collision = false;
+	bool back_face_collision = false;
 };

--- a/src/shapes/jolt_custom_double_sided_shape.cpp
+++ b/src/shapes/jolt_custom_double_sided_shape.cpp
@@ -1,5 +1,7 @@
 #include "jolt_custom_double_sided_shape.hpp"
 
+#include "servers/jolt_project_settings.hpp"
+
 namespace {
 
 JPH::Shape* construct_double_sided() {
@@ -107,4 +109,26 @@ void JoltCustomDoubleSidedShape::register_type() {
 			collide_shape_vs_double_sided
 		);
 	}
+}
+
+void JoltCustomDoubleSidedShape::CastRay(
+	const JPH::RayCast& p_ray,
+	const JPH::RayCastSettings& p_ray_cast_settings,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+	JPH::CastRayCollector& p_collector,
+	const JPH::ShapeFilter& p_shape_filter
+) const {
+	JPH::RayCastSettings new_ray_cast_settings = p_ray_cast_settings;
+
+	if (!back_face_collision && !JoltProjectSettings::use_legacy_ray_casting()) {
+		new_ray_cast_settings.SetBackFaceMode(JPH::EBackFaceMode::IgnoreBackFaces);
+	}
+
+	return mInnerShape->CastRay(
+		p_ray,
+		new_ray_cast_settings,
+		p_sub_shape_id_creator,
+		p_collector,
+		p_shape_filter
+	);
 }

--- a/src/shapes/jolt_custom_double_sided_shape.hpp
+++ b/src/shapes/jolt_custom_double_sided_shape.hpp
@@ -5,9 +5,22 @@
 
 class JoltCustomDoubleSidedShapeSettings final : public JoltCustomDecoratedShapeSettings {
 public:
-	using JoltCustomDecoratedShapeSettings::JoltCustomDecoratedShapeSettings;
+	JoltCustomDoubleSidedShapeSettings() = default;
 
-	ShapeResult Create() const override;
+	JoltCustomDoubleSidedShapeSettings(
+		const ShapeSettings* p_inner_settings,
+		bool p_back_face_collision
+	)
+		: JoltCustomDecoratedShapeSettings(p_inner_settings)
+		, back_face_collision(p_back_face_collision) { }
+
+	JoltCustomDoubleSidedShapeSettings(const JPH::Shape* p_inner_shape, bool p_back_face_collision)
+		: JoltCustomDecoratedShapeSettings(p_inner_shape)
+		, back_face_collision(p_back_face_collision) { }
+
+	JPH::Shape::ShapeResult Create() const override;
+
+	bool back_face_collision = false;
 };
 
 class JoltCustomDoubleSidedShape final : public JoltCustomDecoratedShape {
@@ -19,11 +32,27 @@ public:
 
 	JoltCustomDoubleSidedShape(
 		const JoltCustomDoubleSidedShapeSettings& p_settings,
-		ShapeResult& p_result
+		JPH::Shape::ShapeResult& p_result
 	)
-		: JoltCustomDecoratedShape(JoltCustomShapeSubType::DOUBLE_SIDED, p_settings, p_result) {
+		: JoltCustomDecoratedShape(JoltCustomShapeSubType::DOUBLE_SIDED, p_settings, p_result)
+		, back_face_collision(p_settings.back_face_collision) {
 		if (!p_result.HasError()) {
 			p_result.Set(this);
 		}
 	}
+
+	JoltCustomDoubleSidedShape(const JPH::Shape* p_inner_shape, bool p_back_face_collision)
+		: JoltCustomDecoratedShape(JoltCustomShapeSubType::DOUBLE_SIDED, p_inner_shape)
+		, back_face_collision(p_back_face_collision) { }
+
+	void CastRay(
+		const JPH::RayCast& p_ray,
+		const JPH::RayCastSettings& p_ray_cast_settings,
+		const JPH::SubShapeIDCreator& p_sub_shape_id_creator,
+		JPH::CastRayCollector& p_collector,
+		const JPH::ShapeFilter& p_shape_filter = {}
+	) const override;
+
+private:
+	bool back_face_collision = false;
 };

--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -66,8 +66,12 @@ void collide_ray_vs_shape(
 	const JPH::RayCast ray_cast(ray_start2, ray_vector_padded2);
 
 	JPH::RayCastSettings ray_cast_settings;
-	ray_cast_settings.SetBackFaceMode(p_collide_shape_settings.mBackFaceMode);
 	ray_cast_settings.mTreatConvexAsSolid = false;
+	ray_cast_settings.mBackFaceModeTriangles = p_collide_shape_settings.mBackFaceMode;
+
+	if (JoltProjectSettings::use_legacy_ray_casting()) {
+		ray_cast_settings.mBackFaceModeConvex = p_collide_shape_settings.mBackFaceMode;
+	}
 
 	JoltQueryCollectorClosest<JPH::CastRayCollector> ray_collector;
 

--- a/src/shapes/jolt_height_map_shape_impl_3d.cpp
+++ b/src/shapes/jolt_height_map_shape_impl_3d.cpp
@@ -70,17 +70,17 @@ JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build() const {
 	);
 
 	if (width != depth) {
-		return JoltShapeImpl3D::with_double_sided(_build_mesh());
+		return JoltShapeImpl3D::with_double_sided(_build_mesh(), true);
 	}
 
 	const int32_t block_size = 2; // Default of JPH::HeightFieldShapeSettings::mBlockSize
 	const int32_t block_count = width / block_size;
 
 	if (block_count < 2) {
-		return JoltShapeImpl3D::with_double_sided(_build_mesh());
+		return JoltShapeImpl3D::with_double_sided(_build_mesh(), true);
 	}
 
-	return JoltShapeImpl3D::with_double_sided(_build_height_field());
+	return JoltShapeImpl3D::with_double_sided(_build_height_field(), true);
 }
 
 JPH::ShapeRefC JoltHeightMapShapeImpl3D::_build_height_field() const {

--- a/src/shapes/jolt_shape_impl_3d.cpp
+++ b/src/shapes/jolt_shape_impl_3d.cpp
@@ -167,10 +167,13 @@ JPH::ShapeRefC JoltShapeImpl3D::with_user_data(const JPH::Shape* p_shape, uint64
 	return shape_result.Get();
 }
 
-JPH::ShapeRefC JoltShapeImpl3D::with_double_sided(const JPH::Shape* p_shape) {
+JPH::ShapeRefC JoltShapeImpl3D::with_double_sided(
+	const JPH::Shape* p_shape,
+	bool p_back_face_collision
+) {
 	ERR_FAIL_NULL_D(p_shape);
 
-	const JoltCustomDoubleSidedShapeSettings shape_settings(p_shape);
+	const JoltCustomDoubleSidedShapeSettings shape_settings(p_shape, p_back_face_collision);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 
 	ERR_FAIL_COND_D_MSG(

--- a/src/shapes/jolt_shape_impl_3d.hpp
+++ b/src/shapes/jolt_shape_impl_3d.hpp
@@ -62,7 +62,7 @@ public:
 
 	static JPH::ShapeRefC with_user_data(const JPH::Shape* p_shape, uint64_t p_user_data);
 
-	static JPH::ShapeRefC with_double_sided(const JPH::Shape* p_shape);
+	static JPH::ShapeRefC with_double_sided(const JPH::Shape* p_shape, bool p_back_face_collision);
 
 	static JPH::ShapeRefC without_custom_shapes(const JPH::Shape* p_shape);
 

--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -41,12 +41,17 @@ bool JoltPhysicsDirectSpaceState3D::_intersect_ray(
 	const auto vector = JPH::Vec3(to - from);
 	const JPH::RRayCast ray(from, vector);
 
+	const JPH::EBackFaceMode back_face_mode = p_hit_back_faces
+		? JPH::EBackFaceMode::CollideWithBackFaces
+		: JPH::EBackFaceMode::IgnoreBackFaces;
+
 	JPH::RayCastSettings settings;
 	settings.mTreatConvexAsSolid = p_hit_from_inside;
-	settings.SetBackFaceMode(
-		p_hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces
-						 : JPH::EBackFaceMode::IgnoreBackFaces
-	);
+	settings.mBackFaceModeTriangles = back_face_mode;
+
+	if (JoltProjectSettings::use_legacy_ray_casting()) {
+		settings.mBackFaceModeConvex = back_face_mode;
+	}
 
 	JoltQueryCollectorClosest<JPH::CastRayCollector> collector;
 


### PR DESCRIPTION
Fixes #273.
Fixes #542.
Fixes #644.
Fixes #655.
Fixes #869.
Fixes #946.
Fixes #957.

In the interest of becoming more compatible with Godot Physics (as discussed [here](https://github.com/godotengine/godot-proposals/issues/7308#issuecomment-2307521547) and [here](https://github.com/godot-jolt/godot-jolt/issues/957)) and with Jolt now differentiating between triangle back-faces and convex back-faces, this PR addresses these two discrepancies mentioned in `README.md`:

> - Ray-casts using `hit_back_faces` will hit the back/inside of all shapes, not only concave ones
> [...]
> - Ray-casts are not affected by the `backface_collision` property of `ConcavePolygonShape3D`

Now instead these will behave as with Godot Physics, meaning:

1. `hit_back_faces` will no longer hit the back/inside of convex shapes.
2. `hit_back_faces` is only respected if `backface_collision` is enabled on the `ConcavePolygonShape3D`.

Which effectively means that with everything at its default value you will no longer hit the back-face of anything when ray-casting with this extension (same as in Godot Physics).

If anyone needs the previous behavior there is now also a new project setting called "Use Legacy Ray Casting" which reverts back to that behavior.