### PR TITLE
Improved error message for invalid scaling of `ShapeCast3D`

### DIFF
--- a/src/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -266,12 +266,19 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion(
 
 	Transform3D transform = p_transform;
 
-	ENSURE_SCALE_NOT_ZERO(transform, "cast_motion was passed an invalid transform.");
+	ENSURE_SCALE_NOT_ZERO(
+		transform,
+		"cast_motion (maybe from ShapeCast3D?) was passed an invalid transform."
+	);
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
 
-	ENSURE_SCALE_VALID(jolt_shape, scale, "cast_motion was passed an invalid transform.");
+	ENSURE_SCALE_VALID(
+		jolt_shape,
+		scale,
+		"cast_motion (maybe from ShapeCast3D?) was passed an invalid transform."
+	);
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	Transform3D transform_com = transform.translated_local(com_scaled);
@@ -434,12 +441,19 @@ bool JoltPhysicsDirectSpaceState3D::_rest_info(
 
 	Transform3D transform = p_transform;
 
-	ENSURE_SCALE_NOT_ZERO(transform, "get_rest_info was passed an invalid transform.");
+	ENSURE_SCALE_NOT_ZERO(
+		transform,
+		"get_rest_info (maybe from ShapeCast3D?) was passed an invalid transform."
+	);
 
 	Vector3 scale;
 	Math::decompose(transform, scale);
 
-	ENSURE_SCALE_VALID(jolt_shape, scale, "get_rest_info was passed an invalid transform.");
+	ENSURE_SCALE_VALID(
+		jolt_shape,
+		scale,
+		"get_rest_info (maybe from ShapeCast3D?) was passed an invalid transform."
+	);
 
 	const Vector3 com_scaled = to_godot(jolt_shape->GetCenterOfMass());
 	const Transform3D transform_com = transform.translated_local(com_scaled);


### PR DESCRIPTION
Related to #954.

This adds a mention of `ShapeCast3D` to the scaling errors that are emitted from `cast_motion` and `get_rest_info`, in case someone isn't using these two methods directly but instead rely entirely on `ShapeCast3D`.