### PR TITLE
Added project version to `godot-jolt.gdextension`

### DIFF
--- a/cmake/templates/gdextension.in
+++ b/cmake/templates/gdextension.in
@@ -1,3 +1,7 @@
+[godot-jolt]
+version = "${PROJECT_VERSION_WITH_STATUS}"
+build = "${PROJECT_VERSION_BUILD}"
+
 [configuration]
 
 entry_symbol = "${GDJ_ENTRY_POINT}"


### PR DESCRIPTION
Fixes #751.
Fixes #977.

This adds a new section to the `godot-jolt.gdextension` file with the project version and build.