### PR TITLE
Added support for performing CCD against a double-sided shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Breaking changes are denoted with ⚠️.
   angle properties in degrees when using a `DISABLE_DEPRECATED` build of Godot.
 - Fixed crash when a `SoftBody3D` collided with the border of a
   `HeightMapShape3D` using non-power-of-two dimensions.
+- Fixed issue where CCD would have no effect against a `ConcavePolygonShape3D` that had
+  `backface_collision` enabled.
 
 ## [0.13.0] - 2024-08-15
 

--- a/src/shapes/jolt_custom_double_sided_shape.cpp
+++ b/src/shapes/jolt_custom_double_sided_shape.cpp
@@ -78,6 +78,37 @@ void collide_shape_vs_double_sided(
 	);
 }
 
+void cast_shape_vs_double_sided(
+	const JPH::ShapeCast& p_shape_cast,
+	const JPH::ShapeCastSettings& p_shape_cast_settings,
+	const JPH::Shape* p_shape,
+	JPH::Vec3Arg p_scale,
+	const JPH::ShapeFilter& p_shape_filter,
+	JPH::Mat44Arg p_center_of_mass_transform2,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator1,
+	const JPH::SubShapeIDCreator& p_sub_shape_id_creator2,
+	JPH::CastShapeCollector& p_collector
+) {
+	ERR_FAIL_COND(p_shape->GetSubType() != JoltCustomShapeSubType::DOUBLE_SIDED);
+
+	JPH::ShapeCastSettings new_shape_cast_settings = p_shape_cast_settings;
+	new_shape_cast_settings.mBackFaceModeTriangles = JPH::EBackFaceMode::CollideWithBackFaces;
+
+	const auto* shape = static_cast<const JoltCustomDoubleSidedShape*>(p_shape);
+
+	JPH::CollisionDispatch::sCastShapeVsShapeLocalSpace(
+		p_shape_cast,
+		new_shape_cast_settings,
+		shape->GetInnerShape(),
+		p_scale,
+		p_shape_filter,
+		p_center_of_mass_transform2,
+		p_sub_shape_id_creator1,
+		p_sub_shape_id_creator2,
+		p_collector
+	);
+}
+
 } // namespace
 
 JPH::ShapeSettings::ShapeResult JoltCustomDoubleSidedShapeSettings::Create() const {
@@ -107,6 +138,14 @@ void JoltCustomDoubleSidedShape::register_type() {
 			sub_type,
 			JoltCustomShapeSubType::DOUBLE_SIDED,
 			collide_shape_vs_double_sided
+		);
+	}
+
+	for (const JPH::EShapeSubType sub_type : JPH::sConvexSubShapeTypes) {
+		JPH::CollisionDispatch::sRegisterCastShape(
+			sub_type,
+			JoltCustomShapeSubType::DOUBLE_SIDED,
+			cast_shape_vs_double_sided
 		);
 	}
 }


### PR DESCRIPTION
It turns out that not registering any shape-casting handler with Jolt's `JPH::CollisionDispatch` for `JoltCustomDoubleSidedShape` meant that any attempt to CCD against a `ConcavePolygonShape3D` with `backface_collision` enabled would effectively nullify any benefit of the CCD operation.

This fixes that by implementing a shape-casting handler for `JoltCustomDoubleSidedShape`