### PR TITLE
Fixed various issues with `SeparationRayShape3D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Breaking changes are denoted with ⚠️.
   `HeightMapShape3D` using non-power-of-two dimensions.
 - Fixed issue where CCD would have no effect against a `ConcavePolygonShape3D` that had
   `backface_collision` enabled.
+- Fixed crash when using a `SeparationRayShape3D` in a `RigidBody3D` that had CCD enabled.
+- Fixed issue where the behavior of the `body_test_motion` method of `PhysicsServer3D` (which powers
+  `move_and_collide` and `move_and_slide`) may have differed from Godot Physics when dealing with a
+  `SeparationRayShape3D` that had `slide_on_slope` enabled.
 
 ## [0.13.0] - 2024-08-15
 

--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -90,6 +90,12 @@ void collide_ray_vs_shape(
 		return;
 	}
 
+	// Since `hit.mSubShapeID2` could represent a path not only from `p_shape2` but also any
+	// compound shape that it's contained within, we need to split this path into something that
+	// `p_shape2` can actually understand.
+	JPH::SubShapeID local_sub_shape_id2;
+	hit.mSubShapeID2.PopID(p_sub_shape_id_creator2.GetNumBitsWritten(), local_sub_shape_id2);
+
 	const JPH::Vec3 hit_point2 = ray_cast.GetPointOnRay(hit.mFraction);
 
 	const JPH::Vec3 hit_point_on_1 = ray_start + ray_vector;
@@ -98,7 +104,7 @@ void collide_ray_vs_shape(
 	JPH::Vec3 hit_normal2 = JPH::Vec3::sZero();
 
 	if (shape1->slide_on_slope) {
-		hit_normal2 = p_shape2->GetSurfaceNormal(hit.mSubShapeID2, hit_point2);
+		hit_normal2 = p_shape2->GetSurfaceNormal(local_sub_shape_id2, hit_point2);
 
 		// HACK(mihe): If we got a back-face normal we need to flip it
 		if (hit_normal2.Dot(ray_direction2) > 0) {
@@ -121,14 +127,8 @@ void collide_ray_vs_shape(
 	);
 
 	if (p_collide_shape_settings.mCollectFacesMode == JPH::ECollectFacesMode::CollectFaces) {
-		// Since `hit.mSubShapeID2` could represent a path not only from `p_shape2` but also any
-		// compound shape that it's contained within, we need to split this path into something that
-		// `p_shape2` can actually understand.
-		JPH::SubShapeID sub_shape_id2;
-		hit.mSubShapeID2.PopID(p_sub_shape_id_creator2.GetNumBitsWritten(), sub_shape_id2);
-
 		p_shape2->GetSupportingFace(
-			sub_shape_id2,
+			local_sub_shape_id2,
 			ray_direction2,
 			p_scale2,
 			p_center_of_mass_transform2,
@@ -190,7 +190,9 @@ void JoltCustomRayShape::register_type() {
 		JPH::EShapeSubType::Cylinder,
 		JPH::EShapeSubType::ConvexHull,
 		JPH::EShapeSubType::Mesh,
-		JPH::EShapeSubType::HeightField};
+		JPH::EShapeSubType::HeightField,
+		JPH::EShapeSubType::Plane,
+		JPH::EShapeSubType::TaperedCylinder};
 
 	for (const JPH::EShapeSubType concrete_sub_type : concrete_sub_types) {
 		JPH::CollisionDispatch::sRegisterCollideShape(
@@ -211,15 +213,32 @@ void JoltCustomRayShape::register_type() {
 		JoltCustomShapeSubType::RAY,
 		collide_noop
 	);
-	JPH::CollisionDispatch::sRegisterCastShape(
-		JoltCustomShapeSubType::RAY,
-		JoltCustomShapeSubType::RAY,
-		cast_noop
-	);
+
+	for (const JPH::EShapeSubType sub_type : JPH::sAllSubShapeTypes) {
+		JPH::CollisionDispatch::sRegisterCastShape(
+			JoltCustomShapeSubType::RAY,
+			sub_type,
+			cast_noop
+		);
+
+		JPH::CollisionDispatch::sRegisterCastShape(
+			sub_type,
+			JoltCustomShapeSubType::RAY,
+			cast_noop
+		);
+	}
 }
 
 JPH::AABox JoltCustomRayShape::GetLocalBounds() const {
-	return {JPH::Vec3::sZero(), JPH::Vec3(0.0f, 0.0f, length)};
+	const float radius = GetInnerRadius();
+	return {JPH::Vec3(-radius, -radius, 0.0f), JPH::Vec3(radius, radius, length)};
+}
+
+float JoltCustomRayShape::GetInnerRadius() const {
+	// HACK(mihe): There is no sensible value here, since this shape is infinitely thin, so we pick
+	// something that's hopefully small enough to effectively be zero, but big enough to not cause
+	// any numerical issues.
+	return 0.0001f;
 }
 
 JPH::MassProperties JoltCustomRayShape::GetMassProperties() const {

--- a/src/shapes/jolt_custom_ray_shape.hpp
+++ b/src/shapes/jolt_custom_ray_shape.hpp
@@ -56,7 +56,7 @@ public:
 
 	JPH::AABox GetLocalBounds() const override;
 
-	float GetInnerRadius() const override { return 0.0f; }
+	float GetInnerRadius() const override;
 
 	JPH::MassProperties GetMassProperties() const override;
 

--- a/src/spaces/jolt_motion_filter_3d.cpp
+++ b/src/spaces/jolt_motion_filter_3d.cpp
@@ -4,6 +4,7 @@
 #include "objects/jolt_object_impl_3d.hpp"
 #include "servers/jolt_physics_server_3d.hpp"
 #include "shapes/jolt_custom_motion_shape.hpp"
+#include "shapes/jolt_custom_ray_shape.hpp"
 #include "shapes/jolt_custom_shape_type.hpp"
 #include "shapes/jolt_shape_impl_3d.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
@@ -91,5 +92,10 @@ bool JoltMotionFilter3D::ShouldCollide(
 	const auto* motion_shape = static_cast<const JoltCustomMotionShape*>(p_jolt_shape_self);
 	const JPH::ConvexShape& actual_shape_self = motion_shape->get_inner_shape();
 
-	return actual_shape_self.GetSubType() != JoltCustomShapeSubType::RAY;
+	if (actual_shape_self.GetSubType() == JoltCustomShapeSubType::RAY) {
+		// When `slide_on_slope` is enabled the ray shape acts as a regular shape.
+		return static_cast<const JoltCustomRayShape&>(actual_shape_self).slide_on_slope;
+	}
+
+	return true;
 }


### PR DESCRIPTION
Fixes #992.

This primarily fixes the issue of not being able to use `SeparationRayShape3D` for a `RigidBody3D` that had CCD enabled. It achieves this by providing a no-op implementation for any shape-casting[^1] involving the shape, which achieves a similar effect to what Godot Physics is doing with CCD for `SeparationRayShape3D`. I also added a non-zero (but very small) inner radius to the shape, in order to stop Jolt's asserts from triggering.

Besides that I also found some other minor issues, which I've included here:

1. There was a discrepancy with Godot Physics with regards to the filtering that happens in `body_test_motion` for `SeparationRayShape3D` using `slide_on_slope`, which may or may not have resulted in strange collision results when `slide_on_slope` was enabled.
2. There was another Jolt assert that triggered when using `slide_on_slope` for a `SeparationRayShape3D` that collided with another compound shape, which was effectively the same problem as with #895, but when fetching the surface normal of the compound shape. This luckily only manifested as an assert, and likely worked just fine anyway.

[^1]: Only applies to Jolt's own shape-casting, which isn't utilized for things like `cast_motion`.