### PR TITLE
Silenced CMake deprecation errors when building for Android

### DIFF
--- a/cmake/toolchains/android/Common.cmake
+++ b/cmake/toolchains/android/Common.cmake
@@ -2,3 +2,9 @@ set(CMAKE_SYSTEM_NAME Android)
 set(CMAKE_SYSTEM_VERSION 21)
 set(CMAKE_ANDROID_STL_TYPE c++_static)
 set(CMAKE_ANDROID_EXCEPTIONS FALSE)
+
+# HACK(mihe): CMake 3.31 dropped support for projects compatible with CMake versions older than
+# 3.10, which breaks the Android NDK, since it declares 3.6 as its minimum version. So we just
+# disable deprecation warnings altogether.
+set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
+set(CMAKE_ERROR_DEPRECATED OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
It seems that CMake 3.31 has dropped support for projects that declare compatibility with CMake versions older than 3.10.

This causes problems with the Android NDK, which declares compatibility with CMake 3.6 and newer.

To get around this we disable deprecation warnings/errors entirely for Android builds.