### PR TITLE
Fixed issues related to enhanced internal edge removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,31 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed the "Use Enhanced Internal Edge Detection" project setting under the "Collisions"
+  category to only apply to the collision detection that happens for `RigidBody3D`. There are now
+  instead identically named settings under the "Kinematics" and "Queries" categories for controlling
+  those contexts. See below for more information.
+
+### Added
+
+- Added a new "Use Enhanced Internal Edge Detection" project setting under the "Kinematics" category
+  for controlling the use of Jolt's enhanced internal edge detection in the context of kinematic
+  movement methods, meaning the `body_test_motion` method of `PhysicsServer3D`, which is also what
+  powers `test_move`, `move_and_collide` and `move_and_slide`.
+- Added a new "Use Enhanced Internal Edge Detection" project setting under the "Queries" category
+  for controlling the use of Jolt's enhanced internal edge detection in the context of shape
+  queries, meaning `collide_shape`, `intersect_shape`, `get_rest_info` and `cast_motion`, which is
+  also what powers the `ShapeCast3D` node.
+
 ### Fixed
 
 - ⚠️ Fixed issue where custom inertia wouldn't be applied correctly for bodies using
   `ConvexPolygonShape3D` or offset shapes.
+- ⚠️ Fixed issue where shape queries (e.g. `collide_shape`) would not function correctly when
+  overlapping with multiple bodies and the "Use Enhanced Internal Edge Detection" project setting
+  was enabled.
 
 ## [0.14.0] - 2024-11-03
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -205,17 +205,12 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
       <td>Collisions</td>
       <td>Use Enhanced Internal Edge Removal</td>
       <td>
-        Whether or not to enable the enhanced internal edge removal, which means that extra effort
-        will be made to try to remove collisions with internal edges of
-        <code>ConcavePolygonShape3D</code> and <code>HeightMapShape3D</code>. This makes physics
-        bodies move smoother over such shapes, at the cost of performance.
+        Whether or not to enable the enhanced internal edge removal for <code>RigidBody3D</code>,
+        which means that extra effort will be made to try to remove collisions with internal edges
+        of another physics body. This makes physics bodies move smoother over certain shapes, at the
+        cost of performance.
       </td>
-      <td>
-        Note that this applies to <code>RigidBody3D</code> as well as queries like
-        <code>get_rest_info</code>, <code>move_and_collide</code> and <code>move_and_slide</code>.
-        <br><br>Also note that enabling this setting will leave the "Active Edge Threshold" setting
-        unused.
-      </td>
+      <td>-</td>
     </tr>
     <tr>
       <td>Collisions</td>
@@ -317,6 +312,18 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Kinematics</td>
+      <td>Use Enhanced Internal Edge Removal</td>
+      <td>
+        Whether or not to enable the enhanced internal edge removal for the kinematic movement
+        methods (<code>move_and_slide</code>, <code>move_and_collide</code>, <code>test_move</code>
+        and <code>body_test_motion</code>) which means that extra effort will be made to try to
+        remove hits with internal edges of whatever physics body they hit, which can help alleviate
+        odd collision normals and thus ghost collisions.
+      </td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Kinematics</td>
       <td>Recovery Iterations</td>
       <td>
         The number of iterations to run when resolving penetration during things like
@@ -332,6 +339,23 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
         <code>move_and_slide</code>.
       </td>
       <td>-</td>
+    </tr>
+    <tr>
+      <td>Queries</td>
+      <td>Use Enhanced Internal Edge Removal</td>
+      <td>
+        Whether or not to enable the enhanced internal edge removal for the shape query methods
+        (<code>collide_shape</code>, <code>intersect_shape</code>, <code>get_rest_info</code>
+        and <code>cast_motion</code>) which means that extra effort will be made to try to remove
+        hits with internal edges of whatever physics body they hit, which can help alleviate odd
+        collision normals.
+      </td>
+      <td>
+        Note that enabling this can result in hits against individual shapes of bodies that have
+        multiple shapes to not be reported at all, so it's generally only advisable to enable this
+        if you're using the shape queries for things like kinematic movement and you're willing to
+        accept this compromise.
+      </td>
     </tr>
     <tr>
       <td>Queries</td>
@@ -397,8 +421,8 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
         result in things like <code>RigidBody3D</code> sinking into triangle edges or
         <code>move_and_slide</code> behaving in weird ways when going over or pressing up against
         triangle edges.
-        <br><br>Note that this setting has no effect when using the "Use Enhanced Internal Edge
-        Removal" setting.
+        <br><br>Note that this setting has no effect when using any of the "Use Enhanced Internal
+        Edge Removal" settings.
       </td>
     </tr>
     <tr>

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1139,7 +1139,7 @@ void JoltBodyImpl3D::_add_to_space() {
 	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
 	jolt_settings->mMaxAngularVelocity = JoltProjectSettings::get_max_angular_velocity();
 
-	if (JoltProjectSettings::use_enhanced_edge_removal()) {
+	if (JoltProjectSettings::use_edge_removal_for_bodies()) {
 		jolt_settings->mEnhancedInternalEdgeRemoval = true;
 	}
 

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -14,7 +14,7 @@ constexpr char SLEEP_VELOCITY_THRESHOLD[] = "physics/jolt_3d/sleep/velocity_thre
 constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_3d/sleep/time_threshold";
 
 constexpr char SHAPE_MARGINS[] = "physics/jolt_3d/collisions/use_shape_margins";
-constexpr char EDGE_REMOVAL[] = "physics/jolt_3d/collisions/use_enhanced_internal_edge_removal";
+constexpr char BODY_EDGE_REMOVAL[] = "physics/jolt_3d/collisions/use_enhanced_internal_edge_removal";
 constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_3d/collisions/areas_detect_static_bodies";
 constexpr char KINEMATIC_CONTACTS[] = "physics/jolt_3d/collisions/report_all_kinematic_contacts";
 constexpr char SOFT_BODY_POINT_MARGIN[] = "physics/jolt_3d/collisions/soft_body_point_margin";
@@ -27,9 +27,11 @@ constexpr char JOINT_WORLD_NODE[] = "physics/jolt_3d/joints/world_node";
 constexpr char CCD_MOVEMENT_THRESHOLD[] = "physics/jolt_3d/continuous_cd/movement_threshold";
 constexpr char CCD_MAX_PENETRATION[] = "physics/jolt_3d/continuous_cd/max_penetration";
 
+constexpr char KINEMATIC_EDGE_REMOVAL[] = "physics/jolt_3d/kinematics/use_enhanced_internal_edge_removal";
 constexpr char RECOVERY_ITERATIONS[] = "physics/jolt_3d/kinematics/recovery_iterations";
 constexpr char RECOVERY_AMOUNT[] = "physics/jolt_3d/kinematics/recovery_amount";
 
+constexpr char QUERY_EDGE_REMOVAL[] = "physics/jolt_3d/queries/use_enhanced_internal_edge_removal";
 constexpr char LEGACY_RAY_CASTING[] = "physics/jolt_3d/queries/use_legacy_ray_casting";
 constexpr char RAY_FACE_INDEX[] = "physics/jolt_3d/queries/enable_ray_cast_face_index";
 
@@ -151,7 +153,7 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(SLEEP_TIME_THRESHOLD, 0.5f, U"0,5,0.01,or_greater,suffix:s");
 
 	register_setting_plain(SHAPE_MARGINS, true);
-	register_setting_plain(EDGE_REMOVAL, true);
+	register_setting_plain(BODY_EDGE_REMOVAL, true);
 	register_setting_plain(AREAS_DETECT_STATIC, false);
 	register_setting_plain(KINEMATIC_CONTACTS, false);
 
@@ -162,9 +164,11 @@ void JoltProjectSettings::register_settings() {
 	register_setting_ranged(CCD_MOVEMENT_THRESHOLD, 75.0f, U"0,100,0.1,suffix:%");
 	register_setting_ranged(CCD_MAX_PENETRATION, 25.0f, U"0,100,0.1,suffix:%");
 
+	register_setting_plain(KINEMATIC_EDGE_REMOVAL, true);
 	register_setting_ranged(RECOVERY_ITERATIONS, 4, U"1,8,or_greater");
 	register_setting_ranged(RECOVERY_AMOUNT, 40.0f, U"0,100,0.1,suffix:%");
 
+	register_setting_plain(QUERY_EDGE_REMOVAL, false);
 	register_setting_plain(LEGACY_RAY_CASTING, false, true);
 	register_setting_plain(RAY_FACE_INDEX, false);
 
@@ -220,8 +224,8 @@ bool JoltProjectSettings::report_all_kinematic_contacts() {
 	return value;
 }
 
-bool JoltProjectSettings::use_enhanced_edge_removal() {
-	static const auto value = get_setting<bool>(EDGE_REMOVAL);
+bool JoltProjectSettings::use_edge_removal_for_bodies() {
+	static const auto value = get_setting<bool>(BODY_EDGE_REMOVAL);
 	return value;
 }
 
@@ -245,6 +249,11 @@ float JoltProjectSettings::get_ccd_max_penetration() {
 	return value;
 }
 
+bool JoltProjectSettings::use_edge_removal_for_kinematics() {
+	static const auto value = get_setting<bool>(KINEMATIC_EDGE_REMOVAL);
+	return value;
+}
+
 int32_t JoltProjectSettings::get_kinematic_recovery_iterations() {
 	static const auto value = get_setting<int32_t>(RECOVERY_ITERATIONS);
 	return value;
@@ -252,6 +261,11 @@ int32_t JoltProjectSettings::get_kinematic_recovery_iterations() {
 
 float JoltProjectSettings::get_kinematic_recovery_amount() {
 	static const auto value = get_setting<float>(RECOVERY_AMOUNT) / 100.0f;
+	return value;
+}
+
+bool JoltProjectSettings::use_edge_removal_for_queries() {
+	static const auto value = get_setting<bool>(QUERY_EDGE_REMOVAL);
 	return value;
 }
 
@@ -281,10 +295,7 @@ float JoltProjectSettings::get_position_correction() {
 }
 
 float JoltProjectSettings::get_active_edge_threshold() {
-	static const auto value = use_enhanced_edge_removal()
-		? 0.996195f // Math::cos(5 degrees)
-		: Math::cos(get_setting<float>(ACTIVE_EDGE_THRESHOLD));
-
+	static const auto value = Math::cos(get_setting<float>(ACTIVE_EDGE_THRESHOLD));
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -16,7 +16,7 @@ public:
 
 	static bool report_all_kinematic_contacts();
 
-	static bool use_enhanced_edge_removal();
+	static bool use_edge_removal_for_bodies();
 
 	static float get_soft_body_point_margin();
 
@@ -26,9 +26,13 @@ public:
 
 	static float get_ccd_max_penetration();
 
+	static bool use_edge_removal_for_kinematics();
+
 	static int32_t get_kinematic_recovery_iterations();
 
 	static float get_kinematic_recovery_amount();
+
+	static bool use_edge_removal_for_queries();
 
 	static bool use_legacy_ray_casting();
 

--- a/src/shapes/jolt_custom_ray_shape.cpp
+++ b/src/shapes/jolt_custom_ray_shape.cpp
@@ -1,5 +1,6 @@
 #include "jolt_custom_ray_shape.hpp"
 
+#include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_query_collectors.hpp"
 
 namespace {

--- a/src/spaces/jolt_physics_direct_space_state_3d.hpp
+++ b/src/spaces/jolt_physics_direct_space_state_3d.hpp
@@ -107,6 +107,7 @@ private:
 		const Transform3D& p_transform_com,
 		const Vector3& p_scale,
 		const Vector3& p_motion,
+		bool p_use_edge_removal,
 		bool p_ignore_overlaps,
 		const JPH::CollideShapeSettings& p_settings,
 		const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter,
@@ -153,6 +154,32 @@ private:
 		,
 		JPH::RVec3Arg p_center_of_mass
 #endif // JPH_DEBUG_RENDERER
+	) const;
+
+	void _collide_shape_queries(
+		const JPH::Shape* p_shape,
+		JPH::Vec3Arg p_scale,
+		JPH::RMat44Arg p_transform_com,
+		const JPH::CollideShapeSettings& p_settings,
+		JPH::RVec3Arg p_base_offset,
+		JPH::CollideShapeCollector& p_collector,
+		const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter = {},
+		const JPH::ObjectLayerFilter& p_object_layer_filter = {},
+		const JPH::BodyFilter& p_body_filter = {},
+		const JPH::ShapeFilter& p_shape_filter = {}
+	) const;
+
+	void _collide_shape_kinematics(
+		const JPH::Shape* p_shape,
+		JPH::Vec3Arg p_scale,
+		JPH::RMat44Arg p_transform_com,
+		const JPH::CollideShapeSettings& p_settings,
+		JPH::RVec3Arg p_base_offset,
+		JPH::CollideShapeCollector& p_collector,
+		const JPH::BroadPhaseLayerFilter& p_broad_phase_layer_filter = {},
+		const JPH::ObjectLayerFilter& p_object_layer_filter = {},
+		const JPH::BodyFilter& p_body_filter = {},
+		const JPH::ShapeFilter& p_shape_filter = {}
 	) const;
 
 	JoltSpace3D* space = nullptr;

--- a/src/spaces/jolt_query_collectors.hpp
+++ b/src/spaces/jolt_query_collectors.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "servers/jolt_project_settings.hpp"
+#include "spaces/jolt_space_3d.hpp"
 
 template<typename TBase, int32_t TInlineCapacity>
 class JoltQueryCollectorAll final : public TBase {
@@ -167,78 +167,16 @@ private:
 	int32_t max_hits = 0;
 };
 
-template<typename TInnerCollector>
-class JoltQueryCollectorNoEdges final : public JPH::InternalEdgeRemovingCollector {
-	using Base = JPH::InternalEdgeRemovingCollector;
-
-public:
-	using Hit = typename TInnerCollector::ResultType;
-
-	template<typename... TArgs>
-	explicit JoltQueryCollectorNoEdges(TArgs&&... p_args)
-		: Base(inner_collector)
-		, inner_collector(std::forward<TArgs>(p_args)...) { }
-
-	int32_t get_hit_count() const { return inner_collector.get_hit_count(); }
-
-	const Hit& get_hit() const { return inner_collector.get_hit(); }
-
-	const Hit& get_hit(int32_t p_index) const { return inner_collector.get_hit(p_index); }
-
-	bool finish() {
-		if (use_enhanced_edge_removal) {
-			Base::Flush();
-		}
-
-		return inner_collector.had_hit();
-	}
-
-	void reset() { Reset(); }
-
-	void OnBody(const JPH::Body& p_body) override {
-		if (use_enhanced_edge_removal) {
-			Base::OnBody(p_body);
-		} else {
-			inner_collector.OnBody(p_body);
-		}
-	}
-
-	void AddHit(const Hit& p_hit) override {
-		if (use_enhanced_edge_removal) {
-			Base::AddHit(p_hit);
-		} else {
-			inner_collector.AddHit(p_hit);
-		}
-	}
-
-	void Reset() override {
-		if (use_enhanced_edge_removal) {
-			Base::Reset();
-		} else {
-			inner_collector.Reset();
-		}
-	}
-
-private:
-	TInnerCollector inner_collector;
-
-	bool use_enhanced_edge_removal = JoltProjectSettings::use_enhanced_edge_removal();
-};
+using JoltShapeQueryCollectorAny = JoltQueryCollectorAny<JPH::CollideShapeCollector>;
 
 template<int32_t TInlineCapacity>
-using JoltQueryCollectorAllNoEdges = JoltQueryCollectorNoEdges<
-	JoltQueryCollectorAll<JPH::CollideShapeCollector, TInlineCapacity>>;
+using JoltShapeQueryCollectorAnyMulti = JoltQueryCollectorAnyMulti<
+	JPH::CollideShapeCollector,
+	TInlineCapacity>;
 
-using JoltQueryCollectorAnyNoEdges = JoltQueryCollectorNoEdges<
-	JoltQueryCollectorAny<JPH::CollideShapeCollector>>;
-
-template<int32_t TInlineCapacity>
-using JoltQueryCollectorAnyMultiNoEdges = JoltQueryCollectorNoEdges<
-	JoltQueryCollectorAnyMulti<JPH::CollideShapeCollector, TInlineCapacity>>;
-
-using JoltQueryCollectorClosestNoEdges = JoltQueryCollectorNoEdges<
-	JoltQueryCollectorClosest<JPH::CollideShapeCollector>>;
+using JoltShapeQueryCollectorClosest = JoltQueryCollectorClosest<JPH::CollideShapeCollector>;
 
 template<int32_t TInlineCapacity>
-using JoltQueryCollectorClosestMultiNoEdges = JoltQueryCollectorNoEdges<
-	JoltQueryCollectorClosestMulti<JPH::CollideShapeCollector, TInlineCapacity>>;
+using JoltShapeQueryCollectorClosestMulti = JoltQueryCollectorClosestMulti<
+	JPH::CollideShapeCollector,
+	TInlineCapacity>;


### PR DESCRIPTION
Fixes #1014.

This pull request mainly does two things:

1. It fixes the incorrect use of Jolt's enhanced internal edge removal in the context of shape queries hitting multiple bodies, where `JPH::InternalEdgeRemovingCollector` apparently has to be flushed inbetween every body. This is now done using the new `CollideShapeWithInternalEdgeRemoval` method.
2. It splits the current "Use Enhanced Internal Edge Detection" setting into three settings, in order to be able to distinctly control its use for `RigidBody3D`, kinematic queries (`move_and_slide`, etc.) and shape queries (`intersect_shape`, etc.), since its effects on shape queries can be undesirable when not using them for kinematic movement purposes.
3. It changes the default value of this setting for queries to be off, in order to always return all hits by default.