### PR TITLE
Updated Jolt to 7e59df4e8f

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT a72422a24a89698f82bec45af00a45eca232636d
+	GIT_COMMIT 7e59df4e8f676fb8ed6c68d610543ce6ba3248c8
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@a72422a24a89698f82bec45af00a45eca232636d to godot-jolt/jolt@7e59df4e8f676fb8ed6c68d610543ce6ba3248c8 (see diff [here](https://github.com/godot-jolt/jolt/compare/a72422a24a89698f82bec45af00a45eca232636d...7e59df4e8f676fb8ed6c68d610543ce6ba3248c8)).

This brings in the following relevant changes:

- Fixes issue with bodies gaining more energy than intended due to restitution
- Optimizations for creation of `ConcavePolygonShape3D`
- Adds `JPH::NarrowPhase::CollideShapeWithInternalEdgeRemoval`