### PR TITLE
Set better defaults for joint motor/spring limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Breaking changes are denoted with ⚠️.
 - ⚠️ Fixed issue where shape queries (e.g. `collide_shape`) would not function correctly when
   overlapping with multiple bodies and the "Use Enhanced Internal Edge Detection" project setting
   was enabled.
+- Fixed issue with spring stiffness not having any effect for `Generic6DOFJoint3D`.
 
 ## [0.14.0] - 2024-11-03
 

--- a/src/joints/jolt_cone_twist_joint_impl_3d.hpp
+++ b/src/joints/jolt_cone_twist_joint_impl_3d.hpp
@@ -83,9 +83,9 @@ private:
 
 	double twist_motor_target_speed = 0.0;
 
-	double swing_motor_max_torque = 0.0;
+	double swing_motor_max_torque = FLT_MAX;
 
-	double twist_motor_max_torque = 0.0;
+	double twist_motor_max_torque = FLT_MAX;
 
 	bool swing_limit_enabled = true;
 

--- a/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
+++ b/src/joints/jolt_generic_6dof_joint_impl_3d.hpp
@@ -111,7 +111,7 @@ private:
 
 	double motor_speed[AXIS_COUNT] = {};
 
-	double motor_limit[AXIS_COUNT] = {};
+	double motor_limit[AXIS_COUNT] = {FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX};
 
 	double spring_stiffness[AXIS_COUNT] = {};
 
@@ -121,7 +121,7 @@ private:
 
 	double spring_equilibrium[AXIS_COUNT] = {};
 
-	double spring_limit[AXIS_COUNT] = {};
+	double spring_limit[AXIS_COUNT] = {FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX};
 
 	bool limit_enabled[AXIS_COUNT] = {};
 

--- a/src/joints/jolt_hinge_joint_impl_3d.hpp
+++ b/src/joints/jolt_hinge_joint_impl_3d.hpp
@@ -93,7 +93,7 @@ private:
 
 	double motor_target_speed = 0.0f;
 
-	double motor_max_torque = 0.0;
+	double motor_max_torque = FLT_MAX;
 
 	bool limits_enabled = false;
 

--- a/src/joints/jolt_slider_joint_impl_3d.hpp
+++ b/src/joints/jolt_slider_joint_impl_3d.hpp
@@ -87,7 +87,7 @@ private:
 
 	double motor_target_speed = 0.0f;
 
-	double motor_max_force = 0.0;
+	double motor_max_force = FLT_MAX;
 
 	bool limits_enabled = true;
 


### PR DESCRIPTION
It seems that #983 actually broke springs for the normal `Generic6DOFJoint3D` entirely, as this newly introduced force/torque limit defaulted to zero, and since `Generic6DOFJoint3D` doesn't have any way of setting it to non-zero you'd end up with a completely moot spring.

This PR fixes that by defaulting these spring limits to `FLT_MAX` instead, in the underlying implementation of all joints.

I also threw in the same change for the motor force/torque limits.