### PR TITLE
Changed memory ordering for atomics

### DIFF
--- a/src/spaces/jolt_contact_listener_3d.cpp
+++ b/src/spaces/jolt_contact_listener_3d.cpp
@@ -386,7 +386,7 @@ bool JoltContactListener3D::_try_add_debug_contacts(
 	const auto additional_pairs = (int32_t)p_manifold.mRelativeContactPointsOn1.size();
 	const int32_t additional_contacts = additional_pairs * 2;
 
-	int32_t current_count = debug_contact_count;
+	int32_t current_count = debug_contact_count.load(std::memory_order_relaxed);
 	bool exchanged = false;
 
 	do {
@@ -396,7 +396,12 @@ bool JoltContactListener3D::_try_add_debug_contacts(
 			return false;
 		}
 
-		exchanged = debug_contact_count.compare_exchange_weak(current_count, new_count);
+		exchanged = debug_contact_count.compare_exchange_weak(
+			current_count,
+			new_count,
+			std::memory_order_release,
+			std::memory_order_relaxed
+		);
 	} while (!exchanged);
 
 	for (int32_t i = 0; i < additional_pairs; ++i) {
@@ -430,7 +435,7 @@ bool JoltContactListener3D::_try_add_debug_contacts(
 		}
 	}
 
-	int32_t current_count = debug_contact_count;
+	int32_t current_count = debug_contact_count.load(std::memory_order_relaxed);
 	bool exchanged = false;
 
 	do {
@@ -440,7 +445,12 @@ bool JoltContactListener3D::_try_add_debug_contacts(
 			return false;
 		}
 
-		exchanged = debug_contact_count.compare_exchange_weak(current_count, new_count);
+		exchanged = debug_contact_count.compare_exchange_weak(
+			current_count,
+			new_count,
+			std::memory_order_release,
+			std::memory_order_relaxed
+		);
 	} while (!exchanged);
 
 	int32_t contact_index = current_count;

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -69,7 +69,9 @@ public:
 #ifdef GDJ_CONFIG_EDITOR
 	const PackedVector3Array& get_debug_contacts() const { return debug_contacts; }
 
-	int32_t get_debug_contact_count() const { return debug_contact_count; }
+	int32_t get_debug_contact_count() const {
+		return debug_contact_count.load(std::memory_order_acquire);
+	}
 
 	int32_t get_max_debug_contacts() const { return (int32_t)debug_contacts.size(); }
 


### PR DESCRIPTION
I have until now relied on the default memory ordering (`std::memory_order_seq_cst`) for all atomic operations, which is used for the debug contacts in `JoltContactListener3D` and the completed jobs list in `JoltJobSystem`. While this is mostly fine on x86, it is apparently not the case on ARM, which supposedly uses a weaker memory model.

This PR changes the orderings to hopefully be more appropriate for ARM as well.

(Whether this manifests into any real noticeable difference I can't say. I doubt it.)