### PR TITLE
Implemented waking up body's neighbors

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -257,9 +257,7 @@ void JoltBodyImpl3D::set_is_sleeping(bool p_enabled) {
 }
 
 void JoltBodyImpl3D::wake_up_neighbors() {
-	JoltSpace3D* space = this->get_space();
-
-	const JoltReadableBody3D body = space->read_body(this->get_jolt_id());
+	const JoltReadableBody3D body = space->read_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
 	JPH::AABox aabb = body->GetWorldSpaceBounds();
@@ -267,7 +265,7 @@ void JoltBodyImpl3D::wake_up_neighbors() {
 	JoltQueryCollectorAnyMulti<JPH::CollideShapeBodyCollector, 2048> aabb_collector;
 
 	const JoltQueryFilter3D
-		query_filter(*space->get_direct_state(), this->get_collision_mask(), true, false);
+		query_filter(*space->get_direct_state(), collision_mask, true, false);
 
 	space->get_broad_phase_query().CollideAABox(aabb, aabb_collector, query_filter, query_filter);
 
@@ -276,8 +274,8 @@ void JoltBodyImpl3D::wake_up_neighbors() {
 	for (int32_t i = 0; i < hit_count; ++i) {
 		const JPH::BodyID other_jolt_id = aabb_collector.get_hit(i);
 
-		const JoltReadableBody3D body = space->read_body(other_jolt_id);
-		body.as_body()->wake_up();
+		const JoltReadableBody3D other_jolt_body = space->read_body(other_jolt_id);
+		other_jolt_body.as_body()->wake_up();
 	}
 }
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -72,6 +72,8 @@ public:
 
 	void wake_up() { set_is_sleeping(false); }
 
+	void wake_up_neighbors();
+
 	bool can_sleep() const;
 
 	void set_can_sleep(bool p_enabled);

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -83,7 +83,7 @@ void JoltPhysicsServer3D::_bind_methods() {
 	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_applied_force, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_applied_torque, "joint");
 	
-	BIND_METHOD(JoltPhysicsServer3D, body_wakeup_neighbors, "body_rid");
+	BIND_METHOD(JoltPhysicsServer3D, body_wake_up_neighbors, "body");
 
 	// clang-format on
 
@@ -2350,7 +2350,7 @@ float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(const RID& p_jo
 	return g6dof_joint->get_applied_torque();
 }
 
-void JoltPhysicsServer3D::body_wakeup_neighbors(const RID& p_body) {
+void JoltPhysicsServer3D::body_wake_up_neighbors(const RID& p_body) {
 	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 

--- a/src/servers/jolt_physics_server_3d.cpp
+++ b/src/servers/jolt_physics_server_3d.cpp
@@ -82,6 +82,8 @@ void JoltPhysicsServer3D::_bind_methods() {
 
 	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_applied_force, "joint");
 	BIND_METHOD(JoltPhysicsServer3D, generic_6dof_joint_get_applied_torque, "joint");
+	
+	BIND_METHOD(JoltPhysicsServer3D, body_wakeup_neighbors, "body_rid");
 
 	// clang-format on
 
@@ -2346,4 +2348,11 @@ float JoltPhysicsServer3D::generic_6dof_joint_get_applied_torque(const RID& p_jo
 	auto* g6dof_joint = static_cast<JoltGeneric6DOFJointImpl3D*>(joint);
 
 	return g6dof_joint->get_applied_torque();
+}
+
+void JoltPhysicsServer3D::body_wakeup_neighbors(const RID& p_body) {
+	JoltBodyImpl3D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->wake_up_neighbors();
 }

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -733,7 +733,7 @@ public:
 
 	float generic_6dof_joint_get_applied_torque(const RID& p_joint);
 
-	void body_wakeup_neighbors(const RID& p_body);
+	void body_wake_up_neighbors(const RID& p_body);
 
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;

--- a/src/servers/jolt_physics_server_3d.hpp
+++ b/src/servers/jolt_physics_server_3d.hpp
@@ -733,6 +733,8 @@ public:
 
 	float generic_6dof_joint_get_applied_torque(const RID& p_joint);
 
+	void body_wakeup_neighbors(const RID& p_body);
+
 private:
 	mutable RID_PtrOwner<JoltSpace3D> space_owner;
 


### PR DESCRIPTION
Currently, when PhysicsBody3D is moved/freed, its neighbors remain floating in the air. This PR adds an utility method to manually wake up neighbors using broad phase query (https://github.com/jrouwe/JoltPhysics/issues/267#issuecomment-1274151892).