### PR TITLE
Added updating of damping when switching damping mode

### DIFF
--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -186,9 +186,11 @@ void JoltBodyImpl3D::set_param(PhysicsServer3D::BodyParameter p_param, const Var
 		} break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE: {
 			set_linear_damp_mode((DampMode)(int32_t)p_value);
+			_update_damp();
 		} break;
 		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE: {
 			set_angular_damp_mode((DampMode)(int32_t)p_value);
+			_update_damp();
 		} break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP: {
 			set_linear_damp(p_value);

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1042,6 +1042,26 @@ void JoltBodyImpl3D::set_angular_damp(float p_damp) {
 	_update_damp();
 }
 
+void JoltBodyImpl3D::set_linear_damp_mode(DampMode p_mode) {
+	if (p_mode == linear_damp_mode) {
+		return;
+	}
+
+	linear_damp_mode = p_mode;
+
+	_update_damp();
+}
+
+void JoltBodyImpl3D::set_angular_damp_mode(DampMode p_mode) {
+	if (p_mode == angular_damp_mode) {
+		return;
+	}
+
+	angular_damp_mode = p_mode;
+
+	_update_damp();
+}
+
 bool JoltBodyImpl3D::is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const {
 	return (locked_axes & (uint32_t)p_axis) != 0;
 }

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -186,11 +186,9 @@ void JoltBodyImpl3D::set_param(PhysicsServer3D::BodyParameter p_param, const Var
 		} break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE: {
 			set_linear_damp_mode((DampMode)(int32_t)p_value);
-			_update_damp();
 		} break;
 		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE: {
 			set_angular_damp_mode((DampMode)(int32_t)p_value);
-			_update_damp();
 		} break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP: {
 			set_linear_damp(p_value);

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -233,17 +233,11 @@ public:
 
 	DampMode get_linear_damp_mode() const { return linear_damp_mode; }
 
-	void set_linear_damp_mode(DampMode p_mode) {
-		linear_damp_mode = p_mode;
-		_update_damp();
-	}
+	void set_linear_damp_mode(DampMode p_mode);
 
 	DampMode get_angular_damp_mode() const { return angular_damp_mode; }
 
-	void set_angular_damp_mode(DampMode p_mode) {
-		angular_damp_mode = p_mode;
-		_update_damp();
-	}
+	void set_angular_damp_mode(DampMode p_mode);
 
 	bool is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const;
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -233,11 +233,17 @@ public:
 
 	DampMode get_linear_damp_mode() const { return linear_damp_mode; }
 
-	void set_linear_damp_mode(DampMode p_mode) { linear_damp_mode = p_mode; }
+	void set_linear_damp_mode(DampMode p_mode) { 
+		linear_damp_mode = p_mode; 
+		_update_damp();
+	}
 
 	DampMode get_angular_damp_mode() const { return angular_damp_mode; }
 
-	void set_angular_damp_mode(DampMode p_mode) { angular_damp_mode = p_mode; }
+	void set_angular_damp_mode(DampMode p_mode) { 
+		angular_damp_mode = p_mode; 
+		_update_damp();
+	}
 
 	bool is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const;
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -233,15 +233,15 @@ public:
 
 	DampMode get_linear_damp_mode() const { return linear_damp_mode; }
 
-	void set_linear_damp_mode(DampMode p_mode) { 
-		linear_damp_mode = p_mode; 
+	void set_linear_damp_mode(DampMode p_mode) {
+		linear_damp_mode = p_mode;
 		_update_damp();
 	}
 
 	DampMode get_angular_damp_mode() const { return angular_damp_mode; }
 
-	void set_angular_damp_mode(DampMode p_mode) { 
-		angular_damp_mode = p_mode; 
+	void set_angular_damp_mode(DampMode p_mode) {
+		angular_damp_mode = p_mode;
 		_update_damp();
 	}
 


### PR DESCRIPTION
Hi there 👋

Here's a fix for an issue where [linear_damp](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#class-rigidbody3d-property-linear-damp) and [angular_damp](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#class-rigidbody3d-property-angular-damp) are not updated when either [linear_damp_mode](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#class-rigidbody3d-property-linear-damp-mode) or [angular_damp_mode](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#class-rigidbody3d-property-angular-damp-mode) is changed at runtime.

Previously, [linear_damp](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#class-rigidbody3d-property-linear-damp) and [angular_damp](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#class-rigidbody3d-property-angular-damp) were computed once using their initial [damping mode](https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html#enum-rigidbody3d-dampmode) and not updated whenever a mode was changed.

It's likely that we want to split that update operation for each damping type.

---

I've made a short demo, Cube A and B are the same but they change their linear damping mode when they collide with a floor surface, the red one changes the mode to REPLACE while the blue one changes the mode to COMBINE.
The initial mode is COMBINE for both and they have the same initial velocity in opposite directions. 
The default linear damping value is `.5`.

https://github.com/user-attachments/assets/c937b559-04fa-489d-a275-21bf57dde1bc


