### PR TITLE
Added update of overlapping rigid bodies damping when `Area3D::*_damp_space_override` is changed at runtime

### DIFF
--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -3,6 +3,7 @@
 #include "objects/jolt_body_impl_3d.hpp"
 #include "objects/jolt_group_filter.hpp"
 #include "objects/jolt_soft_body_impl_3d.hpp"
+#include "servers/jolt_physics_server_3d.hpp"
 #include "servers/jolt_project_settings.hpp"
 #include "spaces/jolt_broad_phase_layer.hpp"
 #include "spaces/jolt_space_3d.hpp"
@@ -276,6 +277,37 @@ void JoltAreaImpl3D::set_gravity_mode(OverrideMode p_mode) {
 	gravity_mode = p_mode;
 
 	_gravity_changed();
+}
+
+void JoltAreaImpl3D::_update_overlapping_bodies_damping() {
+	JoltPhysicsServer3D* physics_server = JoltPhysicsServer3D::get_singleton();
+	QUIET_FAIL_NULL(physics_server);
+	for (auto& [_, overlap] : bodies_by_id) {
+		JoltBodyImpl3D* body = physics_server->get_body(overlap.rid);
+		if (body != nullptr) {
+			body->_update_damp();
+		}
+	}
+}
+
+void JoltAreaImpl3D::set_linear_damp_mode(OverrideMode p_mode) {
+	if (linear_damp_mode == p_mode) {
+		return;
+	}
+
+	linear_damp_mode = p_mode;
+
+	_update_overlapping_bodies_damping();
+}
+
+void JoltAreaImpl3D::set_angular_damp_mode(OverrideMode p_mode) {
+	if (linear_damp_mode == p_mode) {
+		return;
+	}
+
+	angular_damp_mode = p_mode;
+
+	_update_overlapping_bodies_damping();
 }
 
 void JoltAreaImpl3D::set_gravity_vector(const Vector3& p_vector) {

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -135,11 +135,11 @@ public:
 
 	OverrideMode get_linear_damp_mode() const { return linear_damp_mode; }
 
-	void set_linear_damp_mode(OverrideMode p_mode) { linear_damp_mode = p_mode; }
+	void set_linear_damp_mode(OverrideMode p_mode);
 
 	OverrideMode get_angular_damp_mode() const { return angular_damp_mode; }
 
-	void set_angular_damp_mode(OverrideMode p_mode) { angular_damp_mode = p_mode; }
+	void set_angular_damp_mode(OverrideMode p_mode);
 
 	Vector3 get_gravity_vector() const { return gravity_vector; }
 
@@ -235,6 +235,8 @@ private:
 	void _update_group_filter();
 
 	void _update_default_gravity();
+
+	void _update_overlapping_bodies_damping();
 
 	void _space_changing() override;
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -11,6 +11,8 @@ class JoltBodyImpl3D final : public JoltShapedObjectImpl3D {
 public:
 	using DampMode = PhysicsServer3D::BodyDampMode;
 
+	friend JoltAreaImpl3D;
+
 	struct Contact {
 		float depth = 0.0f;
 


### PR DESCRIPTION
I already mentioned the issue shortly but I thought I'd sort it out before bothering you.

Briefly, it's the same issue but for areas. If the mode is changed at runtime then an area has to tell overlapping bodies to recompute total damping, as the space override mode might change the value applied to a body.

In fact, it could also be an issue for [gravity_space_override](https://docs.godotengine.org/en/stable/classes/class_area3d.html#class-area3d-property-gravity-space-override).
