### PR TITLE
Updated Linux CI jobs to run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   clang-format:
     name: Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -47,7 +47,7 @@ jobs:
 
   clang-tidy:
     name: Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "\
       ${{ matrix.platform }}-\
       ${{ matrix.arch }}-\

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "\
       ${{ matrix.platform }}-\
       ${{ matrix.arch }}-\

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,7 +68,7 @@ jobs:
           retention-days: 1
 
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -249,7 +249,7 @@ jobs:
           retention-days: 1
 
   android:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -303,7 +303,7 @@ jobs:
           retention-days: 1
 
   upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes are denoted with ⚠️.
 
 ### Changed
 
+- ⚠️ Raised the minimum required glibc version for the Linux binaries from 2.31 to 2.35, which for
+  Ubuntu raises the minimum required version from Ubuntu 20.04 to Ubuntu 22.04.
 - ⚠️ Changed the "Use Enhanced Internal Edge Detection" project setting under the "Collisions"
   category to only apply to the collision detection that happens for `RigidBody3D`. There are now
   instead identically named settings under the "Kinematics" and "Queries" categories for controlling

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Currently the **only** supported version is **Godot 4.3** (including 4.3.x).
 - iOS
 - Android (ARM64, ARM32, x86-64, x86)
 
-Note that Linux support is limited to glibc 2.31 or newer, which for Ubuntu means 20.04 (Focal
+Note that Linux support is limited to glibc 2.35 or newer, which for Ubuntu means 22.04 (Focal
 Fossa) or newer.
 
 ## How do I get started?


### PR DESCRIPTION
The Ubuntu 20.04 runner images for GitHub Actions have been deprecated and will undergo brownouts soon, so we must update to Ubuntu 22.04.

Note that this means that we also _package_ Linux builds using Ubuntu 22.04, which means we'll end up depending on a later version of glibc, effectively raising the minimum system requirements for the extension. The glibc minimum required version will be bumped from version 2.31 to version 2.35.