### PR TITLE
Changed updating of total damping to be done every tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue with spring stiffness not having any effect for `Generic6DOFJoint3D`.
 - Fixed issue where effective total damping wouldn't be updated when changing the `linear_damp_mode`
   or `angular_damp_mode` properties of `RigidBody3D` after it had entered a scene tree.
+- Fixed issue where changing damping-related properties of `Area3D` wouldn't update damping for
+  the bodies it overlapped.
 
 ## [0.14.0] - 2024-11-03
 

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -123,13 +123,13 @@ void JoltAreaImpl3D::set_param(PhysicsServer3D::AreaParameter p_param, const Var
 			set_linear_damp_mode((OverrideMode)(int32_t)p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP: {
-			set_area_linear_damp(p_value);
+			set_linear_damp(p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE: {
 			set_angular_damp_mode((OverrideMode)(int32_t)p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP: {
-			set_area_angular_damp(p_value);
+			set_angular_damp(p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_PRIORITY: {
 			set_priority(p_value);

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -123,11 +123,11 @@ public:
 
 	float get_linear_damp() const { return linear_damp; }
 
-	void set_area_linear_damp(float p_damp) { linear_damp = p_damp; }
+	void set_linear_damp(float p_damp) { linear_damp = p_damp; }
 
 	float get_angular_damp() const { return angular_damp; }
 
-	void set_area_angular_damp(float p_damp) { angular_damp = p_damp; }
+	void set_angular_damp(float p_damp) { angular_damp = p_damp; }
 
 	OverrideMode get_gravity_mode() const { return gravity_mode; }
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1012,13 +1012,7 @@ void JoltBodyImpl3D::set_linear_damp(float p_damp) {
 		p_damp = 0;
 	}
 
-	if (p_damp == linear_damp) {
-		return;
-	}
-
 	linear_damp = p_damp;
-
-	_update_damp();
 }
 
 void JoltBodyImpl3D::set_angular_damp(float p_damp) {
@@ -1033,33 +1027,7 @@ void JoltBodyImpl3D::set_angular_damp(float p_damp) {
 		p_damp = 0;
 	}
 
-	if (p_damp == angular_damp) {
-		return;
-	}
-
 	angular_damp = p_damp;
-
-	_update_damp();
-}
-
-void JoltBodyImpl3D::set_linear_damp_mode(DampMode p_mode) {
-	if (p_mode == linear_damp_mode) {
-		return;
-	}
-
-	linear_damp_mode = p_mode;
-
-	_update_damp();
-}
-
-void JoltBodyImpl3D::set_angular_damp_mode(DampMode p_mode) {
-	if (p_mode == angular_damp_mode) {
-		return;
-	}
-
-	angular_damp_mode = p_mode;
-
-	_update_damp();
 }
 
 bool JoltBodyImpl3D::is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const {
@@ -1180,6 +1148,7 @@ void JoltBodyImpl3D::_integrate_forces(float p_step, JPH::Body& p_jolt_body) {
 	}
 
 	_update_gravity(p_jolt_body);
+	_update_damp();
 
 	if (!custom_integrator) {
 		JPH::MotionProperties& motion_properties = *p_jolt_body.GetMotionPropertiesUnchecked();
@@ -1240,6 +1209,7 @@ void JoltBodyImpl3D::_pre_step_rigid(float p_step, JPH::Body& p_jolt_body) {
 
 void JoltBodyImpl3D::_pre_step_kinematic(float p_step, JPH::Body& p_jolt_body) {
 	_update_gravity(p_jolt_body);
+	_update_damp();
 
 	_move_kinematic(p_step, p_jolt_body);
 
@@ -1438,8 +1408,6 @@ void JoltBodyImpl3D::_update_damp() {
 			total_angular_damp = angular_damp;
 		} break;
 	}
-
-	_motion_changed();
 }
 
 void JoltBodyImpl3D::_update_kinematic_transform() {
@@ -1529,7 +1497,6 @@ void JoltBodyImpl3D::_space_changed() {
 }
 
 void JoltBodyImpl3D::_areas_changed() {
-	_update_damp();
 	wake_up();
 }
 

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -233,11 +233,11 @@ public:
 
 	DampMode get_linear_damp_mode() const { return linear_damp_mode; }
 
-	void set_linear_damp_mode(DampMode p_mode);
+	void set_linear_damp_mode(DampMode p_mode) { linear_damp_mode = p_mode; }
 
 	DampMode get_angular_damp_mode() const { return angular_damp_mode; }
 
-	void set_angular_damp_mode(DampMode p_mode);
+	void set_angular_damp_mode(DampMode p_mode) { angular_damp_mode = p_mode; }
 
 	bool is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const;
 


### PR DESCRIPTION
Supersedes #1031.
Reverts #1029.
Reverts parts of #201.

This changes the calculation of total damping for dynamic and kinematic bodies to be done every physics step, as opposed to only when the set of overlapping areas changed, or when certain properties changed.

This brings things more in line with how Godot Physics behaves, and with how the calculation for gravity behaves as well.

Note that this does introduce some amount of unnecessary overhead, but it's likely to be small for bodies not overlapping with any areas.