### PR TITLE
Fixed `ConcavePolygonShape3D` always using `backface_collision`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where `ConcavePolygonShape3D` would effectively always have its `backface_collision`
+  property enabled in the context of shape-versus-shape collisions.
+
 ## [0.15.0] - 2025-03-09
 
 ### Changed

--- a/src/shapes/jolt_custom_double_sided_shape.cpp
+++ b/src/shapes/jolt_custom_double_sided_shape.cpp
@@ -26,7 +26,10 @@ void collide_double_sided_vs_shape(
 	const auto* shape1 = static_cast<const JoltCustomDoubleSidedShape*>(p_shape1);
 
 	JPH::CollideShapeSettings new_collide_shape_settings = p_collide_shape_settings;
-	new_collide_shape_settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+
+	if (shape1->should_collide_with_back_faces()) {
+		new_collide_shape_settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+	}
 
 	JPH::CollisionDispatch::sCollideShapeVsShape(
 		shape1->GetInnerShape(),
@@ -61,7 +64,10 @@ void collide_shape_vs_double_sided(
 	const auto* shape2 = static_cast<const JoltCustomDoubleSidedShape*>(p_shape2);
 
 	JPH::CollideShapeSettings new_collide_shape_settings = p_collide_shape_settings;
-	new_collide_shape_settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+
+	if (shape2->should_collide_with_back_faces()) {
+		new_collide_shape_settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+	}
 
 	JPH::CollisionDispatch::sCollideShapeVsShape(
 		p_shape1,
@@ -91,10 +97,13 @@ void cast_shape_vs_double_sided(
 ) {
 	ERR_FAIL_COND(p_shape->GetSubType() != JoltCustomShapeSubType::DOUBLE_SIDED);
 
-	JPH::ShapeCastSettings new_shape_cast_settings = p_shape_cast_settings;
-	new_shape_cast_settings.mBackFaceModeTriangles = JPH::EBackFaceMode::CollideWithBackFaces;
-
 	const auto* shape = static_cast<const JoltCustomDoubleSidedShape*>(p_shape);
+
+	JPH::ShapeCastSettings new_shape_cast_settings = p_shape_cast_settings;
+
+	if (shape->should_collide_with_back_faces()) {
+		new_shape_cast_settings.mBackFaceModeTriangles = JPH::EBackFaceMode::CollideWithBackFaces;
+	}
 
 	JPH::CollisionDispatch::sCastShapeVsShapeLocalSpace(
 		p_shape_cast,

--- a/src/shapes/jolt_custom_double_sided_shape.hpp
+++ b/src/shapes/jolt_custom_double_sided_shape.hpp
@@ -53,6 +53,8 @@ public:
 		const JPH::ShapeFilter& p_shape_filter = {}
 	) const override;
 
+	bool should_collide_with_back_faces() const { return back_face_collision; }
+
 private:
 	bool back_face_collision = false;
 };


### PR DESCRIPTION
Fixes #1055.

It seems that #967 broke the `backface_collision` property for `ConcavePolygonShape3D`, as the `JoltCustomDoubleSidedShape` decorator shape is always applied, but the decorator shape itself also unconditionally overrides the `mBackFaceModeTriangles` to `CollideWithBackFaces`, which it should not.

This pull request resolves this by adding said condition to the collision dispatch functions.