### PR TITLE
Fixed Xcode version for macOS-based CI jobs

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -2,7 +2,7 @@ name: Setup macOS
 
 inputs:
   version:
-    default: 15.2
+    default: 16.4
 
 runs:
   using: composite


### PR DESCRIPTION
It seems I somehow entered the wrong Xcode version for the CI jobs in #1071, and put in version 15.2 instead of 16.4.

This fixes that.