### PR TITLE
Updated Jolt to 2c6b713fe0

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT a18d475653c579c319bcf7b350f199ab437cafce
+	GIT_COMMIT 2c6b713fe09bdfb9ec440616f9db84747461470f
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@a18d475653c579c319bcf7b350f199ab437cafce to godot-jolt/jolt@2c6b713fe09bdfb9ec440616f9db84747461470f (see diff [here](https://github.com/godot-jolt/jolt/compare/a18d475653c579c319bcf7b350f199ab437cafce...2c6b713fe09bdfb9ec440616f9db84747461470f)).

This brings in the following relevant changes:

- Bug fix to the active edge calculation of `ConcavePolygonShape3D`.