### PR TITLE
Fixed error when setting joint nodes out-of-tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Breaking changes are denoted with ⚠️.
 
 - Fixed issue where `ConcavePolygonShape3D` would effectively always have its `backface_collision`
   property enabled in the context of shape-versus-shape collisions.
+- Fixed issue where the joint substitute nodes (`JoltHingeJoint3D`, etc.) would cause errors to be
+  emitted when setting the `node_a` and `node_b` properties before the joint was added to the scene
+  tree.
 
 ## [0.15.0] - 2025-03-09
 

--- a/src/joints/jolt_joint_3d.cpp
+++ b/src/joints/jolt_joint_3d.cpp
@@ -77,10 +77,12 @@ void JoltJoint3D::set_node_b(const NodePath& p_path) {
 }
 
 PhysicsBody3D* JoltJoint3D::get_body_a() const {
+	QUIET_FAIL_COND_V(!is_inside_tree(), nullptr);
 	return Object::cast_to<PhysicsBody3D>(get_node_or_null(node_a));
 }
 
 PhysicsBody3D* JoltJoint3D::get_body_b() const {
+	QUIET_FAIL_COND_V(!is_inside_tree(), nullptr);
 	return Object::cast_to<PhysicsBody3D>(get_node_or_null(node_b));
 }
 


### PR DESCRIPTION
Fixes #1068.

`Node::get_node_or_null` shouldn't be called if the node isn't in a scene tree. This fixes that.