### PR TITLE
Fixed issue where soft bodies would lag behind moving attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Breaking changes are denoted with ⚠️.
   tree.
 - Fixed issue where using the extension in Godot 4.5 would result in errors about required virtual
   methods needing to be overridden.
+- Fixed issue where `SoftBody3D` would lag behind any moving attachment.
 
 ## [0.15.0] - 2025-03-09
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -416,9 +416,6 @@ void JoltSoftBodyImpl3D::set_vertex_position(int32_t p_index, const Vector3& p_p
 	ERR_FAIL_INDEX(p_index, shared->mesh_to_physics.size());
 	const int32_t physics_index = shared->mesh_to_physics[p_index];
 
-	const float last_step = space->get_last_step();
-	QUIET_FAIL_COND(last_step == 0.0f);
-
 	JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
@@ -430,11 +427,7 @@ void JoltSoftBodyImpl3D::set_vertex_position(int32_t p_index, const Vector3& p_p
 	JPH::SoftBodyVertex& physics_vertex = physics_vertices[(size_t)physics_index];
 
 	const JPH::RVec3 center_of_mass = body->GetCenterOfMassPosition();
-	const JPH::Vec3 local_position = JPH::Vec3(to_jolt_r(p_position) - center_of_mass);
-	const JPH::Vec3 displacement = local_position - physics_vertex.mPosition;
-	const JPH::Vec3 velocity = displacement / last_step;
-
-	physics_vertex.mVelocity = velocity;
+	physics_vertex.mPosition = JPH::Vec3(to_jolt_r(p_position) - center_of_mass);
 
 	_vertices_changed();
 }


### PR DESCRIPTION
Backport of godotengine/godot#106366.

> This fixes a discrepancy between godot physics and Jolt physics where in Jolt a vertex pinned to a body only gets its velocity updated while in godot it gets its position updated. This causes it to lag one frame behind.