### PR TITLE
Fixed soft body vertex normal calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Changed
+
+- ⚠️ Changed vertex normal calculation for `SoftBody3D` to use smooth shading instead of hard shading,
+  to match Godot Physics.
+
 ### Added
 
 - Added support for Godot 4.5.

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -338,6 +338,7 @@ void JoltSoftBodyImpl3D::update_rendering_server(
 
 	const auto physics_vertex_count = (int32_t)physics_vertices.size();
 
+	normals.clear();
 	normals.resize(physics_vertex_count);
 
 	for (const SoftBodyFace& physics_face : physics_faces) {
@@ -353,9 +354,16 @@ void JoltSoftBodyImpl3D::update_rendering_server(
 
 		const Vector3 normal = (v2 - v0).cross(v1 - v0).normalized();
 
-		normals[(int32_t)i0] = normal;
-		normals[(int32_t)i1] = normal;
-		normals[(int32_t)i2] = normal;
+		normals[(int32_t)i0] += normal;
+		normals[(int32_t)i1] += normal;
+		normals[(int32_t)i2] += normal;
+	}
+
+	for (Vector3& normal : normals) {
+		real_t normal_length = normal.length();
+		if (normal_length > CMP_EPSILON) {
+			normal /= normal_length;
+		}
 	}
 
 	const int32_t mesh_vertex_count = shared->mesh_to_physics.size();


### PR DESCRIPTION
Backport of godotengine/godot#107832.

> The code previously iterated through each face and set all vertices to that face's normal. This resulted in each vertex getting the normal from just one face that it belonged to (whichever face was last in this array). This caused weird shading artifacts.
>
> This fixes the code so that the vertex normal is now the average normal of all faces that it belongs to. This results in "smooth shading" behavior for soft body meshes. This is still somewhat undesirable if the input mesh was using flat shading, but it looks less bad than the previous behavior of picking a normal at random from one attached face.
>
> This matches the behavior of GodotPhysicsServer3D.