### PR TITLE
Fixed contacts not being reported on first physics frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where an error would be emitted for any degenerate faces present in the mesh data
   passed to `SoftBody3D`. Now instead it behaves like Godot Physics and silently skips over such
   faces.
+- Fixed issue where contacts would not be reported on the first physics frame of a collision, and
+  thus missed entirely if the contact only lasted a single physics frame.
 
 ## [0.15.0] - 2025-03-09
 

--- a/src/objects/jolt_body_impl_3d.cpp
+++ b/src/objects/jolt_body_impl_3d.cpp
@@ -1174,7 +1174,7 @@ void JoltBodyImpl3D::_integrate_forces(float p_step, JPH::Body& p_jolt_body) {
 		p_jolt_body.AddTorque(to_jolt(constant_torque));
 	}
 
-	sync_state = true;
+	_enqueue_state_synchronization();
 }
 
 void JoltBodyImpl3D::_move_kinematic(float p_step, JPH::Body& p_jolt_body) {
@@ -1193,7 +1193,7 @@ void JoltBodyImpl3D::_move_kinematic(float p_step, JPH::Body& p_jolt_body) {
 
 	p_jolt_body.MoveKinematic(new_position, new_rotation, p_step);
 
-	sync_state = true;
+	_enqueue_state_synchronization();
 }
 
 void JoltBodyImpl3D::_pre_step_static(
@@ -1217,8 +1217,13 @@ void JoltBodyImpl3D::_pre_step_kinematic(float p_step, JPH::Body& p_jolt_body) {
 		// HACK(mihe): This seems to emulate the behavior of Godot Physics, where kinematic bodies
 		// are set as active (and thereby have their state synchronized on every step) only if its
 		// max reported contacts is non-zero.
-		sync_state = true;
+		_enqueue_state_synchronization();
 	}
+}
+
+void JoltBodyImpl3D::_enqueue_state_synchronization() {
+	// This method will be called on multiple threads during the simulation step.
+	sync_state = true;
 }
 
 JPH::EAllowedDOFs JoltBodyImpl3D::_calculate_allowed_dofs() const {

--- a/src/objects/jolt_body_impl_3d.hpp
+++ b/src/objects/jolt_body_impl_3d.hpp
@@ -252,6 +252,8 @@ public:
 	bool can_interact_with(const JoltAreaImpl3D& p_other) const override;
 
 private:
+	friend class JoltBodyActivationListener3D;
+
 	JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 
 	JPH::ObjectLayer _get_object_layer() const override;
@@ -269,6 +271,8 @@ private:
 	void _pre_step_rigid(float p_step, JPH::Body& p_jolt_body);
 
 	void _pre_step_kinematic(float p_step, JPH::Body& p_jolt_body);
+
+	void _enqueue_state_synchronization();
 
 	JPH::EAllowedDOFs _calculate_allowed_dofs() const;
 

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -83,6 +83,7 @@
 #include <Jolt/Core/TempAllocator.h>
 #include <Jolt/Geometry/ConvexSupport.h>
 #include <Jolt/Geometry/GJKClosestPoint.h>
+#include <Jolt/Physics/Body/BodyActivationListener.h>
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyID.h>
 #include <Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h>

--- a/src/spaces/jolt_body_activation_listener_3d.cpp
+++ b/src/spaces/jolt_body_activation_listener_3d.cpp
@@ -1,0 +1,14 @@
+#include "jolt_body_activation_listener_3d.hpp"
+
+#include "objects/jolt_body_impl_3d.hpp"
+
+void JoltBodyActivationListener3D::OnBodyActivated(
+	[[maybe_unused]] const JPH::BodyID& p_body_id,
+	JPH::uint64 p_body_user_data
+) {
+	// This method will be called on multiple threads during the simulation step.
+
+	if (JoltBodyImpl3D* body = reinterpret_cast<JoltObjectImpl3D*>(p_body_user_data)->as_body()) {
+		body->_enqueue_state_synchronization();
+	}
+}

--- a/src/spaces/jolt_body_activation_listener_3d.hpp
+++ b/src/spaces/jolt_body_activation_listener_3d.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class JoltBodyActivationListener3D final : public JPH::BodyActivationListener {
+	void OnBodyActivated(const JPH::BodyID& p_body_id, JPH::uint64 p_body_user_data) override;
+
+	void OnBodyDeactivated(
+		[[maybe_unused]] const JPH::BodyID& p_body_id,
+		[[maybe_unused]] JPH::uint64 p_body_user_data
+	) override { }
+};

--- a/src/spaces/jolt_space_3d.cpp
+++ b/src/spaces/jolt_space_3d.cpp
@@ -7,6 +7,7 @@
 #include "servers/jolt_project_settings.hpp"
 #include "shapes/jolt_custom_shape_type.hpp"
 #include "shapes/jolt_shape_impl_3d.hpp"
+#include "spaces/jolt_body_activation_listener_3d.hpp"
 #include "spaces/jolt_contact_listener_3d.hpp"
 #include "spaces/jolt_layer_mapper.hpp"
 #include "spaces/jolt_physics_direct_space_state_3d.hpp"
@@ -30,6 +31,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	, temp_allocator(new JoltTempAllocator())
 	, layer_mapper(new JoltLayerMapper())
 	, contact_listener(new JoltContactListener3D(this))
+	, body_activation_listener(new JoltBodyActivationListener3D())
 	, physics_system(new JPH::PhysicsSystem()) {
 	physics_system->Init(
 		(JPH::uint)JoltProjectSettings::get_max_bodies(),
@@ -61,6 +63,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 	physics_system->SetGravity(JPH::Vec3::sZero());
 	physics_system->SetContactListener(contact_listener);
 	physics_system->SetSoftBodyContactListener(contact_listener);
+	physics_system->SetBodyActivationListener(body_activation_listener);
 
 	physics_system->SetCombineFriction(
 		[](const JPH::Body& p_body1,
@@ -96,6 +99,7 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem* p_job_system)
 JoltSpace3D::~JoltSpace3D() {
 	memdelete_safely(direct_state);
 	delete_safely(physics_system);
+	delete_safely(body_activation_listener);
 	delete_safely(contact_listener);
 	delete_safely(layer_mapper);
 	delete_safely(temp_allocator);

--- a/src/spaces/jolt_space_3d.hpp
+++ b/src/spaces/jolt_space_3d.hpp
@@ -3,6 +3,7 @@
 #include "spaces/jolt_body_accessor_3d.hpp"
 
 class JoltAreaImpl3D;
+class JoltBodyActivationListener3D;
 class JoltContactListener3D;
 class JoltJointImpl3D;
 class JoltLayerMapper;
@@ -126,6 +127,8 @@ private:
 	JoltLayerMapper* layer_mapper = nullptr;
 
 	JoltContactListener3D* contact_listener = nullptr;
+
+	JoltBodyActivationListener3D* body_activation_listener = nullptr;
 
 	JPH::PhysicsSystem* physics_system = nullptr;
 


### PR DESCRIPTION
Backport of godotengine/godot#108544.

> This effectively makes it so that a physics body's state synchronization (which includes things like calling `_integrate_forces`) is called at the next physics frame not only if it was awake _before_ the simulation was stepped, but also if it was woken up _during_ the simulation step.
> 
> This is done by making use of Jolt's `JPH::BodyActivationListener`, which as the name suggests invokes callbacks if the body was put to sleep or awakened, letting us queue up a body for synchronization if it was in fact awakened.
> 
> Without this we would end up calling the state synchronization (and thus `_integrate_forces`) two physics frames after the collision happened, at which point we would already have removed the contacts, assuming it was a single-frame collision.
> 
> This likely also fixes one or more hard-to-spot desync bugs between the state of the physics server and the physics nodes.