### PR TITLE
Updated Jolt to b385bc3d76

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 2c6b713fe09bdfb9ec440616f9db84747461470f
+	GIT_COMMIT b385bc3d7683a03edcc794c67c297bd7a3d1974f
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@2c6b713fe09bdfb9ec440616f9db84747461470f to godot-jolt/jolt@b385bc3d7683a03edcc794c67c297bd7a3d1974f (see diff [here](https://github.com/godot-jolt/jolt/compare/2c6b713fe09bdfb9ec440616f9db84747461470f...b385bc3d7683a03edcc794c67c297bd7a3d1974f)).

This brings in the following relevant changes:

- Bug fix for `JPH::SixDOFConstraint`, allowing the rotation axes to all be locked while also locking one or more of those same axes for either of the two bodies.