### PR TITLE
Fixed `SoftBody3D` not waking up when setting its transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Breaking changes are denoted with ⚠️.
   faces.
 - Fixed issue where contacts would not be reported on the first physics frame of a collision, and
   thus missed entirely if the contact only lasted a single physics frame.
+- Fixed issue where `SoftBody3D` would not wake up when settings its transform.
 
 ## [0.15.0] - 2025-03-09
 

--- a/src/objects/jolt_soft_body_impl_3d.cpp
+++ b/src/objects/jolt_soft_body_impl_3d.cpp
@@ -297,6 +297,8 @@ void JoltSoftBodyImpl3D::set_transform(const Transform3D& p_transform) {
 		vertex.mPosition = vertex.mPreviousPosition = relative_transform * vertex.mPosition;
 		vertex.mVelocity = JPH::Vec3::sZero();
 	}
+
+	_transform_changed();
 }
 
 AABB JoltSoftBodyImpl3D::get_bounds() const {
@@ -764,6 +766,10 @@ void JoltSoftBodyImpl3D::_try_rebuild() {
 	if (space != nullptr) {
 		_reset_space();
 	}
+}
+
+void JoltSoftBodyImpl3D::_transform_changed() {
+	wake_up();
 }
 
 void JoltSoftBodyImpl3D::_mesh_changed() {

--- a/src/objects/jolt_soft_body_impl_3d.hpp
+++ b/src/objects/jolt_soft_body_impl_3d.hpp
@@ -141,6 +141,8 @@ private:
 
 	void _try_rebuild();
 
+	void _transform_changed();
+
 	void _mesh_changed();
 
 	void _simulation_precision_changed();


### PR DESCRIPTION
Backport of godotengine/godot#108094.

> This updates `JoltSoftBody3D::set_transform()` to wake up the soft body after changing the transform.
> 
> Previously, if you had a soft body that was sleeping in a steady state on a ground plane, and you then translated it upwards by 1 meter it would just hang in the air.  Now it falls to the ground correctly.