### PR TITLE
Fixed out-of-bounds crash when rendering `SoftBody3D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Breaking changes are denoted with ⚠️.
 - Fixed issue where contacts would not be reported on the first physics frame of a collision, and
   thus missed entirely if the contact only lasted a single physics frame.
 - Fixed issue where `SoftBody3D` would not wake up when settings its transform.
+- Fixed crash when rendering `SoftBody3D` meshes that have unused vertices.
 
 ## [0.15.0] - 2025-03-09
 


### PR DESCRIPTION
Backport of godotengine/godot/pull/109929.

> When a mesh is provided that has vertices that are not referenced by any face, these vertices will be discarded. In the internal 'mesh_to_physics' map, this led to uninitialized data which could result in a crash. Now we initialize the map with -1 and report an error when users try to manipulate these vertices.