### PR TITLE
Fixed `Area3D` not reporting triangle collisions properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Breaking changes are denoted with ⚠️.
   thus missed entirely if the contact only lasted a single physics frame.
 - Fixed issue where `SoftBody3D` would not wake up when settings its transform.
 - Fixed crash when rendering `SoftBody3D` meshes that have unused vertices.
+- Fixed issue where `Area3D` would not report collisions with `ConcavePolygonShape3D` and
+  `HeightMapShape3D` correctly.
 
 ## [0.15.0] - 2025-03-09
 

--- a/src/objects/jolt_area_impl_3d.hpp
+++ b/src/objects/jolt_area_impl_3d.hpp
@@ -39,6 +39,12 @@ class JoltAreaImpl3D final : public JoltShapedObjectImpl3D {
 			: other(p_other)
 			, self(p_self) { }
 
+		static uint32_t hash(const ShapeIndexPair& p_pair) {
+			uint32_t hash = hash_murmur3_one_32((uint32_t)p_pair.other);
+			hash = hash_murmur3_one_32((uint32_t)p_pair.self, hash);
+			return hash_fmix32(hash);
+		}
+
 		friend bool operator==(const ShapeIndexPair& p_lhs, const ShapeIndexPair& p_rhs) {
 			return std::tie(p_lhs.other, p_lhs.self) == std::tie(p_rhs.other, p_rhs.self);
 		}
@@ -50,6 +56,8 @@ class JoltAreaImpl3D final : public JoltShapedObjectImpl3D {
 
 	struct Overlap {
 		HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair> shape_pairs;
+
+		HashMap<ShapeIndexPair, int, ShapeIndexPair> ref_counts;
 
 		InlineVector<ShapeIndexPair, 1> pending_added;
 

--- a/src/spaces/jolt_contact_listener_3d.hpp
+++ b/src/spaces/jolt_contact_listener_3d.hpp
@@ -162,8 +162,6 @@ private:
 
 	void _flush_area_enters();
 
-	void _flush_area_shifts();
-
 	void _flush_area_exits();
 
 	ManifoldsByShapePair manifolds_by_shape_pair;


### PR DESCRIPTION
Backport of godotengine/godot#106918.

> This pull request adds reference counting of the shape index pairs that are managed in `JoltArea3D`, and changes its event emitting of `PhysicsServer3D::AREA_BODY_ADDED` and `PhysicsServer3D::AREA_BODY_REMOVED` to instead only happen when this reference counter gets set to/from zero.
>
> This is necessary due to triangle-based shapes like ConcavePolygonShape3D (and presumably HeightMapShape3D) currently being able to produce multiple contacts/overlaps/manifolds for different triangles, that all have different Jolt sub-shape pairs, but that resolve down to the same shape index pair, which I failed to take into account when first implementing support for Area3D, resulting in it emitting events when it shouldn't.
>
>
> This pull request also fixes an issue where removing or adding shapes to a body that's overlapping with an Area3D would similarly result in borked signal emissions, which turned out to be part me having screwed up `JoltContactListener3D::_flush_area_shifts` when first implementing Area3D support and part regression from #101189.
>
> Note however that there is still a slight discrepancy in how these signal emissions happen when comparing with Godot Physics. For example, if you have a RigidBody3D with three shapes that's enveloped by an Area3D, and you remove the middle one, Godot Physics will emit two exit events, one for index 1 and one for index 2, and then an enter event for index 1. With Jolt, as of this pull request, you will instead only get a single event, which is the exit event for index 2.