### PR TITLE
Removed the "Areas Detect Static Bodies" project setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes are denoted with ⚠️.
 
 ## [Unreleased]
 
+### Removed
+
+- ⚠️ Removed the "Areas Detect Static Bodies" project setting. `Area3D` will now always detect
+  overlaps with static bodies by default, and should do so much cheaper than before.
+
 ### Changed
 
 - ⚠️ Changed vertex normal calculation for `SoftBody3D` to use smooth shading instead of hard shading,
@@ -37,6 +42,8 @@ Breaking changes are denoted with ⚠️.
 - Fixed crash when rendering `SoftBody3D` meshes that have unused vertices.
 - Fixed issue where `Area3D` would not report collisions with `ConcavePolygonShape3D` and
   `HeightMapShape3D` correctly.
+- Fixed issue where adding/removing shapes from a body while it's overlapping with an `Area3D` could
+  result in strange overlap reports.
 
 ## [0.15.0] - 2025-03-09
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ should not be relied upon if determinism is a hard requirement.
 ## What else is different?
 
 - Scale is actually used for all bodies, shapes and shape queries, except for `SoftBody3D`
-- `Area3D` detecting static bodies is opt-in, at a potentially [heavy performance/memory cost][jst]
 - Joints only support soft limits through their substitutes (`JoltHingeJoint3D`, etc.)
 - Springs and linear motors are actually implemented in `Generic6DOFJoint3D`
 - Single-body joints will make `node_a` be the "world node" rather than `node_b`
@@ -121,7 +120,7 @@ Godot Jolt is distributed under the MIT license. See [`LICENSE.txt`][lic] for mo
 
 [god]: https://godotengine.org/
 [jlt]: https://github.com/jrouwe/JoltPhysics
-[jst]: docs/settings.md#jolt-3d
+[jst]: docs/settings.md#jolt-physics-extension-3d
 [jdc]: https://jrouwe.github.io/JoltPhysics/
 [rls]: https://github.com/godot-jolt/godot-jolt/releases/latest
 [ast]: https://godotengine.org/asset-library/asset/1918

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,7 +10,7 @@ in order to see the settings listed here.
 
 - [Common](#common)
 - [3D](#3d)
-- [Jolt Physics Extension 3D](#jolt-3d)
+- [Jolt Physics Extension 3D](#jolt-physics-extension-3d)
 
 ## Common
 
@@ -102,25 +102,25 @@ These settings are part of Godot's default project settings and can be found und
       <td>-</td>
       <td>Sleep Threshold Linear</td>
       <td>No</td>
-      <td>See extension settings <a href="#jolt-3d">below</a>.</td>
+      <td>See extension settings <a href="#jolt-physics-extension-3d">below</a>.</td>
     </tr>
     <tr>
       <td>-</td>
       <td>Sleep Threshold Angular</td>
       <td>No</td>
-      <td>See extension settings <a href="#jolt-3d">below</a>.</td>
+      <td>See extension settings <a href="#jolt-physics-extension-3d">below</a>.</td>
     </tr>
     <tr>
       <td>-</td>
       <td>Time Before Sleep</td>
       <td>No</td>
-      <td>See extension settings <a href="#jolt-3d">below</a>.</td>
+      <td>See extension settings <a href="#jolt-physics-extension-3d">below</a>.</td>
     </tr>
     <tr>
       <td>Solver</td>
       <td>Solver Iterations</td>
       <td>No</td>
-      <td>See extension settings <a href="#jolt-3d">below</a>.</td>
+      <td>See extension settings <a href="#jolt-physics-extension-3d">below</a>.</td>
     </tr>
     <tr>
       <td>Solver</td>
@@ -138,7 +138,7 @@ These settings are part of Godot's default project settings and can be found und
       <td>Solver</td>
       <td>Contact Max Allowed Penetration</td>
       <td>No</td>
-      <td>See extension settings <a href="#jolt-3d">below</a>.</td>
+      <td>See extension settings <a href="#jolt-physics-extension-3d">below</a>.</td>
     </tr>
     <tr>
       <td>Solver</td>
@@ -215,31 +215,16 @@ These settings are exposed by Godot Jolt and can be found under "Physics" - "Jol
     </tr>
     <tr>
       <td>Collisions</td>
-      <td>Areas Detect Static Bodies</td>
-      <td>
-        Whether or not <code>Area3D</code> is able to detect overlaps with <code>StaticBody3D</code>
-        and <code>RigidBody3D</code> frozen with <code>FREEZE_MODE_STATIC</code>.
-      </td>
-      <td>
-        ⚠️ This can come at a heavy performance and memory cost if you allow many/large areas to
-        overlap with complex static geometry, such as <code>ConcavePolygonShape3D</code> or
-        <code>HeightMapShape3D</code>.
-        <br><br>It is strongly recommended that you set up your collision layers and masks in such a
-        way that only a few small <code>Area3D</code> can detect static bodies.
-      </td>
-    </tr>
-    <tr>
-      <td>Collisions</td>
       <td>Report All Kinematic Contacts</td>
       <td>
         Whether or not a <code>RigidBody3D</code> frozen with <code>FREEZE_MODE_KINEMATIC</code> is
         able to collide with (and thus reports contacts for) other kinematic/static bodies.
       </td>
       <td>
-        ⚠️ Much like the "Areas Detect Static Bodies" setting, this setting can come at a heavy
-        performance and memory cost if you allow many/large frozen kinematic bodies with a non-zero
-        <code>max_contacts_reported</code> to overlap with complex static geometry, such as
-        <code>ConcavePolygonShape3D</code> or <code>HeightMapShape3D</code>.
+        ⚠️ This setting can come at a heavy performance and memory cost if you allow many/large
+        frozen kinematic bodies with a non-zero <code>max_contacts_reported</code> to overlap with
+        complex static geometry, such as <code>ConcavePolygonShape3D</code> or
+        <code>HeightMapShape3D</code>.
         <br><br>It is strongly recommended that you set up your collision layers and masks in such a
         way that only a few small such kinematic bodies can detect static bodies.
       </td>

--- a/src/objects/jolt_area_impl_3d.cpp
+++ b/src/objects/jolt_area_impl_3d.cpp
@@ -437,14 +437,11 @@ void JoltAreaImpl3D::_add_to_space() {
 	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
 	jolt_settings->mMotionType = _get_motion_type();
 	jolt_settings->mIsSensor = true;
+	jolt_settings->mCollideKinematicVsNonDynamic = true;
 	jolt_settings->mUseManifoldReduction = false;
 	jolt_settings->mOverrideMassProperties = JPH::EOverrideMassProperties::MassAndInertiaProvided;
 	jolt_settings->mMassPropertiesOverride.mMass = 1.0f;
 	jolt_settings->mMassPropertiesOverride.mInertia = JPH::Mat44::sIdentity();
-
-	if (JoltProjectSettings::areas_detect_static_bodies()) {
-		jolt_settings->mCollideKinematicVsNonDynamic = true;
-	}
 
 	jolt_settings->SetShape(jolt_shape);
 

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -76,6 +76,10 @@
 
 #include <Jolt/Jolt.h>
 
+// clang-format off
+#include <Jolt/Physics/Collision/TransformedShape.h>
+// clang-format on
+
 #include <Jolt/Core/Factory.h>
 #include <Jolt/Core/FixedSizeFreeList.h>
 #include <Jolt/Core/IssueReporting.h>
@@ -91,6 +95,8 @@
 #include <Jolt/Physics/Collision/CastResult.h>
 #include <Jolt/Physics/Collision/CollidePointResult.h>
 #include <Jolt/Physics/Collision/CollideShape.h>
+#include <Jolt/Physics/Collision/CollideShapeVsShapePerLeaf.h>
+#include <Jolt/Physics/Collision/CollisionCollectorImpl.h>
 #include <Jolt/Physics/Collision/CollisionDispatch.h>
 #include <Jolt/Physics/Collision/CollisionGroup.h>
 #include <Jolt/Physics/Collision/ContactListener.h>

--- a/src/servers/jolt_project_settings.cpp
+++ b/src/servers/jolt_project_settings.cpp
@@ -15,7 +15,6 @@ constexpr char SLEEP_TIME_THRESHOLD[] = "physics/jolt_physics_extension_3d/sleep
 
 constexpr char SHAPE_MARGINS[] = "physics/jolt_physics_extension_3d/collisions/use_shape_margins";
 constexpr char BODY_EDGE_REMOVAL[] = "physics/jolt_physics_extension_3d/collisions/use_enhanced_internal_edge_removal";
-constexpr char AREAS_DETECT_STATIC[] = "physics/jolt_physics_extension_3d/collisions/areas_detect_static_bodies";
 constexpr char KINEMATIC_CONTACTS[] = "physics/jolt_physics_extension_3d/collisions/report_all_kinematic_contacts";
 constexpr char SOFT_BODY_POINT_MARGIN[] = "physics/jolt_physics_extension_3d/collisions/soft_body_point_margin";
 constexpr char PAIR_CACHE_ENABLED[] = "physics/jolt_physics_extension_3d/collisions/body_pair_cache_enabled";
@@ -169,6 +168,21 @@ void migrate_setting(const String& p_setting) {
 	}
 }
 
+void remove_setting(const String& p_setting) {
+	ProjectSettings* project_settings = ProjectSettings::get_singleton();
+
+	const String old_name = "physics/jolt_3d/" + p_setting;
+	const String new_name = "physics/jolt_physics_extension_3d/" + p_setting;
+
+	if (project_settings->has_setting(old_name)) {
+		project_settings->clear(old_name);
+	}
+
+	if (project_settings->has_setting(new_name)) {
+		project_settings->clear(new_name);
+	}
+}
+
 void migrate_settings() {
 	migrate_physics_engine_setting();
 
@@ -177,7 +191,7 @@ void migrate_settings() {
 	migrate_setting("sleep/time_threshold");
 	migrate_setting("collisions/use_shape_margins");
 	migrate_setting("collisions/use_enhanced_internal_edge_removal");
-	migrate_setting("collisions/areas_detect_static_bodies");
+	remove_setting("collisions/areas_detect_static_bodies");
 	migrate_setting("collisions/report_all_kinematic_contacts");
 	migrate_setting("collisions/soft_body_point_margin");
 	migrate_setting("collisions/body_pair_cache_enabled");
@@ -221,7 +235,6 @@ void JoltProjectSettings::register_settings() {
 
 	register_setting_plain(SHAPE_MARGINS, true);
 	register_setting_plain(BODY_EDGE_REMOVAL, true);
-	register_setting_plain(AREAS_DETECT_STATIC, false);
 	register_setting_plain(KINEMATIC_CONTACTS, false);
 
 	register_setting_ranged(SOFT_BODY_POINT_MARGIN, 0.01f, U"0,1,0.001,or_greater,suffix:m");
@@ -278,11 +291,6 @@ float JoltProjectSettings::get_sleep_time_threshold() {
 
 bool JoltProjectSettings::use_shape_margins() {
 	static const auto value = get_setting<bool>(SHAPE_MARGINS);
-	return value;
-}
-
-bool JoltProjectSettings::areas_detect_static_bodies() {
-	static const auto value = get_setting<bool>(AREAS_DETECT_STATIC);
 	return value;
 }
 

--- a/src/servers/jolt_project_settings.hpp
+++ b/src/servers/jolt_project_settings.hpp
@@ -12,8 +12,6 @@ public:
 
 	static bool use_shape_margins();
 
-	static bool areas_detect_static_bodies();
-
 	static bool report_all_kinematic_contacts();
 
 	static bool use_edge_removal_for_bodies();

--- a/src/spaces/jolt_layer_mapper.cpp
+++ b/src/spaces/jolt_layer_mapper.cpp
@@ -15,7 +15,11 @@ public:
 		using namespace JoltBroadPhaseLayer;
 
 		allow_collision(BODY_STATIC, BODY_DYNAMIC);
+		allow_collision(BODY_STATIC, AREA_DETECTABLE);
+		allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
 		allow_collision(BODY_STATIC_BIG, BODY_DYNAMIC);
+		allow_collision(BODY_STATIC_BIG, AREA_DETECTABLE);
+		allow_collision(BODY_STATIC_BIG, AREA_UNDETECTABLE);
 		allow_collision(BODY_DYNAMIC, BODY_STATIC);
 		allow_collision(BODY_DYNAMIC, BODY_STATIC_BIG);
 		allow_collision(BODY_DYNAMIC, BODY_DYNAMIC);
@@ -24,19 +28,12 @@ public:
 		allow_collision(AREA_DETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_DETECTABLE, AREA_DETECTABLE);
 		allow_collision(AREA_DETECTABLE, AREA_UNDETECTABLE);
+		allow_collision(AREA_DETECTABLE, BODY_STATIC);
+		allow_collision(AREA_DETECTABLE, BODY_STATIC_BIG);
 		allow_collision(AREA_UNDETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_UNDETECTABLE, AREA_DETECTABLE);
-
-		if (JoltProjectSettings::areas_detect_static_bodies()) {
-			allow_collision(BODY_STATIC, AREA_DETECTABLE);
-			allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
-			allow_collision(BODY_STATIC_BIG, AREA_DETECTABLE);
-			allow_collision(BODY_STATIC_BIG, AREA_UNDETECTABLE);
-			allow_collision(AREA_DETECTABLE, BODY_STATIC);
-			allow_collision(AREA_DETECTABLE, BODY_STATIC_BIG);
-			allow_collision(AREA_UNDETECTABLE, BODY_STATIC);
-			allow_collision(AREA_UNDETECTABLE, BODY_STATIC_BIG);
-		}
+		allow_collision(AREA_UNDETECTABLE, BODY_STATIC);
+		allow_collision(AREA_UNDETECTABLE, BODY_STATIC_BIG);
 	}
 
 	void allow_collision(UnderlyingType p_layer1, UnderlyingType p_layer2) {


### PR DESCRIPTION
Backport of godotengine/godot#105746.

> This PR removes the project setting `physics/jolt_physics_3d/simulation/areas_detect_static_bodies`, effectively making it permanently `true`, in favor of leveraging the newly introduced `JPH::PhysicsSystem::SetSimCollideBodyVsBody` functionality, and the `JPH::CollideShapeVsShapePerLeaf` helper function, which lets us configure the amount of contacts that are generated (and thus cached) by Jolt as part of the collision detection that it does during simulation, thus mitigating the performance impact of enabling this project setting.
>
> This is technically a breaking change, and potentially quite pervasive, depending on the project, since areas that were maybe not meant to detect static bodies now will. [...]
>
> This project setting has become a fairly popular one to enable over the years, largely due to Godot Physics supporting this already, and despite efforts to warn people about its ill effects in Jolt Physics specifically, most seem to just go ahead and enable it anyway, since the alternatives/workarounds can be inconvenient and/or unintuitive.
>
> As such, this removes a fairly significant performance footgun, since by default Jolt would otherwise (when enabling this project setting) generate contacts for every overlapping triangle when an `Area3D` overlaps with a `ConcavePolygonShape3D`, which when dealing with complex collision meshes (or many/large `Area3D`) can end up being a lot. These contacts can add a lot of overhead both in terms of CPU and memory during the simulation step in ways that might not be easy to correlate to the source of the problem.
>
> This new way of doing it is essentially exploiting the fact that `Area3D` in Godot doesn't actually expose the exact contacts between itself and the thing it's overlapping. This means that the underlying collision detection during simulation really only needs exactly one contact per shape, and that contact can be anywhere, which means we can set Jolt's underlying collision collector to be the much cheaper `JPH::AnyHitCollisionCollector` for any collision involving sensors/areas.
>
> [...]
>
> Note however that since we're now forced to always allow interactions between the broadphase layers belonging to areas and static bodies, this will presumably add some amount of additional cost to `Area3D`'s collision detection, for anyone who wasn't previously relying on this project setting, but it is what it is. Being diligent about using collision masks and layers properly (which should be done anyway) should hopefully mitigate some of that.

Note that this needs #1088 to function properly.