### PR TITLE
Updated Jolt to 1e38fc6003

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT b385bc3d7683a03edcc794c67c297bd7a3d1974f
+	GIT_COMMIT 1e38fc600308ca686e030db9132758b53d9cbbfc
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -76,10 +76,6 @@
 
 #include <Jolt/Jolt.h>
 
-// clang-format off
-#include <Jolt/Physics/Collision/TransformedShape.h>
-// clang-format on
-
 #include <Jolt/Core/Factory.h>
 #include <Jolt/Core/FixedSizeFreeList.h>
 #include <Jolt/Core/IssueReporting.h>


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@b385bc3d7683a03edcc794c67c297bd7a3d1974f to godot-jolt/jolt@1e38fc600308ca686e030db9132758b53d9cbbfc (see diff [here](https://github.com/godot-jolt/jolt/compare/b385bc3d7683a03edcc794c67c297bd7a3d1974f...1e38fc600308ca686e030db9132758b53d9cbbfc)).

This brings in the following relevant changes:

- Removes the need for explicitly including Jolt's `TransformedShape.h` in `src/precompiled.hpp`.