### PR TITLE
Fixed `SoftBody3D` jittering when not close to world origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Breaking changes are denoted with ⚠️.
   `HeightMapShape3D` correctly.
 - Fixed issue where adding/removing shapes from a body while it's overlapping with an `Area3D` could
   result in strange overlap reports.
+- Fixed issue where the position of `SoftBody3D` would greatly influence the accuracy of its
+  physics.
 
 ## [0.15.0] - 2025-03-09
 


### PR DESCRIPTION
Backport of godotengine/godot#112483.

> The position of a soft body was always kept at identity. This introduced computational errors when moving the soft body away from the origin. Translation is now stored in the soft body's position rather than in its vertices.