### PR TITLE
Updated Jolt to 9fb2ce0f9b

### DIFF
--- a/cmake/GodotJoltExternalJolt.cmake
+++ b/cmake/GodotJoltExternalJolt.cmake
@@ -35,7 +35,7 @@ endif()
 
 gdj_add_external_library(jolt "${configurations}"
 	GIT_REPOSITORY https://github.com/godot-jolt/jolt.git
-	GIT_COMMIT 1e38fc600308ca686e030db9132758b53d9cbbfc
+	GIT_COMMIT 9fb2ce0f9b6acfc058f31d812fbaae9d74ddafc7
 	LANGUAGE CXX
 	SOURCE_SUBDIR Build
 	OUTPUT_NAME Jolt


### PR DESCRIPTION
This bumps Jolt from godot-jolt/jolt@1e38fc600308ca686e030db9132758b53d9cbbfc to godot-jolt/jolt@9fb2ce0f9b6acfc058f31d812fbaae9d74ddafc7 (see diff [here](https://github.com/godot-jolt/jolt/compare/1e38fc600308ca686e030db9132758b53d9cbbfc...9fb2ce0f9b6acfc058f31d812fbaae9d74ddafc7)).